### PR TITLE
Fix for Issue 13: Trouble running in Docker containers (or binding to 0.0.0.0)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		host = r.Host // oh well
 	}
 
+	// Try the host as given, or try falling back to 0.0.0.0 (wildcard)
+	if _, ok := s.vhosts[host]; !ok {
+		if _, ok2 := s.vhosts["0.0.0.0"]; ok2 {
+			host = "0.0.0.0"
+		}
+	}
+
 	if vh, ok := s.vhosts[host]; ok {
 		w.Header().Set("Server", "Caddy")
 


### PR DESCRIPTION
Fix for [Issue 13](https://github.com/mholt/caddy/issues/13):

Sites configured with ip `0.0.0.0` are now wildcards and no longer filter by request host.

e.g.
```
0.0.0.0:2015
root /html
```