### PR TITLE
-port flag to allow overriding default port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,13 +11,16 @@ import (
 )
 
 const (
-	defaultHost = "localhost"
-	defaultPort = "2015"
-	defaultRoot = "."
+	DefaultHost = "localhost"
+	DefaultPort = "2015"
+	DefaultRoot = "."
 
 	// The default configuration file to load if none is specified
 	DefaultConfigFile = "Caddyfile"
 )
+
+// Port is configurable via command line flag
+var Port = DefaultPort
 
 // config represents a server configuration. It
 // is populated by parsing a config file (via the
@@ -113,9 +116,9 @@ func IsNotFound(err error) bool {
 func Default() []Config {
 	cfg := []Config{
 		Config{
-			Root: defaultRoot,
-			Host: defaultHost,
-			Port: defaultPort,
+			Root: DefaultRoot,
+			Host: DefaultHost,
+			Port: Port,
 		},
 	}
 	return cfg

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -170,8 +170,8 @@ func TestParserBasicWithMultipleHostsPerBlock(t *testing.T) {
 		if confs[0].Host != "host1.com" {
 			t.Errorf("Expected host of first conf to be 'host1.com', got '%s'", confs[0].Host)
 		}
-		if confs[0].Port != defaultPort {
-			t.Errorf("Expected port of first conf to be '%s', got '%s'", defaultPort, confs[0].Port)
+		if confs[0].Port != DefaultPort {
+			t.Errorf("Expected port of first conf to be '%s', got '%s'", DefaultPort, confs[0].Port)
 		}
 		if confs[0].Root != "/public_html" {
 			t.Errorf("Expected root of first conf to be '/public_html', got '%s'", confs[0].Root)
@@ -255,8 +255,8 @@ func TestParserBasicWithAlternateAddressStyles(t *testing.T) {
 	if confs[4].Host != "host" {
 		t.Errorf("Expected conf[4] Host='host', got '%#v'", confs[4])
 	}
-	if confs[4].Port != defaultPort {
-		t.Errorf("Expected conf[4] Port='%s', got '%#v'", defaultPort, confs[4].Port)
+	if confs[4].Port != DefaultPort {
+		t.Errorf("Expected conf[4] Port='%s', got '%#v'", DefaultPort, confs[4].Port)
 	}
 }
 

--- a/config/parsing.go
+++ b/config/parsing.go
@@ -47,7 +47,7 @@ func (p *parser) addresses() error {
 			schemePort = "http"
 			str = str[7:]
 		} else if !strings.Contains(str, ":") {
-			str += ":" + defaultPort
+			str += ":" + Port
 		}
 
 		host, port, err = net.SplitHostPort(str)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func init() {
 	flag.BoolVar(&http2, "http2", true, "enable HTTP/2 support") // TODO: temporary flag until http2 merged into std lib
 	flag.BoolVar(&quiet, "quiet", false, "quiet mode (no initialization output)")
 	flag.StringVar(&cpu, "cpu", "100%", "CPU cap")
+	flag.StringVar(&config.Port, "port", config.DefaultPort, "Default port")
 	flag.Parse()
 }
 


### PR DESCRIPTION
Default port used if none is specified in config

This could resolve #16. @j-mcnally Would this suffice you think?