### PR TITLE
Specify Go Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Caddy binaries have no dependencies and are available for nearly every platform.
 
 ## Running from Source
 
+NOTE: You will need Go **version 1.4** or greater
+
 1. `$ go get github.com/mholt/caddy`
 2. `cd` into your website's directory
 3. Run `caddy` (assumes `$GOPATH/bin` is in your `$PATH`)


### PR DESCRIPTION
Go version 1.4 or greater is required to run caddy locally due to a need update in how the BasicAuth method was implemented. I believe that in previous Go versions, it was a private method thus throwing this error:

```
$GOPATH/src/github.com/mholt/caddy/middleware/basicauth/basicauth.go:36: r.BasicAuth undefined (type *http.Request has no field or method BasicAuth)
```