### PR TITLE
Proxy Middleware: Add support for multiple backends, load balancing & healthchecks

### DIFF
--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func testPool() HostPool {
+	pool := []*UpstreamHost{
+		&UpstreamHost{
+			Name: "http://google.com", // this should resolve (healthcheck test)
+		},
+		&UpstreamHost{
+			Name: "http://shouldnot.resolve", // this shouldn't
+		},
+		&UpstreamHost{
+			Name: "http://C",
+		},
+	}
+	return HostPool(pool)
+}
+
+func TestRoundRobinPolicy(t *testing.T) {
+	pool := testPool()
+	rrPolicy := &RoundRobin{}
+	h := rrPolicy.Select(pool)
+	// First selected host is 1, because counter starts at 0
+	// and increments before host is selected
+	if h != pool[1] {
+		t.Error("Expected first round robin host to be second host in the pool.")
+	}
+	h = rrPolicy.Select(pool)
+	if h != pool[2] {
+		t.Error("Expected second round robin host to be third host in the pool.")
+	}
+	// mark host as down
+	pool[0].Unhealthy = true
+	h = rrPolicy.Select(pool)
+	if h != pool[1] {
+		t.Error("Expected third round robin host to be first host in the pool.")
+	}
+}
+
+func TestLeastConnPolicy(t *testing.T) {
+	pool := testPool()
+	lcPolicy := &LeastConn{}
+	pool[0].Conns = 10
+	pool[1].Conns = 10
+	h := lcPolicy.Select(pool)
+	if h != pool[2] {
+		t.Error("Expected least connection host to be third host.")
+	}
+	pool[2].Conns = 100
+	h = lcPolicy.Select(pool)
+	if h != pool[0] && h != pool[1] {
+		t.Error("Expected least connection host to be first or second host.")
+	}
+}

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -1,0 +1,215 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP reverse proxy handler
+
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// onExitFlushLoop is a callback set by tests to detect the state of the
+// flushLoop() goroutine.
+var onExitFlushLoop func()
+
+// ReverseProxy is an HTTP Handler that takes an incoming request and
+// sends it to another server, proxying the response back to the
+// client.
+type ReverseProxy struct {
+	// Director must be a function which modifies
+	// the request into a new request to be sent
+	// using Transport. Its response is then copied
+	// back to the original client unmodified.
+	Director func(*http.Request)
+
+	// The transport used to perform proxy requests.
+	// If nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+
+	// FlushInterval specifies the flush interval
+	// to flush to the client while copying the
+	// response body.
+	// If zero, no periodic flushing is done.
+	FlushInterval time.Duration
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+// NewSingleHostReverseProxy returns a new ReverseProxy that rewrites
+// URLs to the scheme, host, and base path provided in target. If the
+// target's path is "/base" and the incoming request was for "/dir",
+// the target request will be for /base/dir.
+func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
+	targetQuery := target.RawQuery
+	director := func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+	}
+	return &ReverseProxy{Director: director}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te", // canonicalized version of "TE"
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extraHeaders http.Header) error {
+	transport := p.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	outreq := new(http.Request)
+	*outreq = *req // includes shallow copies of maps, but okay
+
+	p.Director(outreq)
+	outreq.Proto = "HTTP/1.1"
+	outreq.ProtoMajor = 1
+	outreq.ProtoMinor = 1
+	outreq.Close = false
+
+	// Remove hop-by-hop headers to the backend.  Especially
+	// important is "Connection" because we want a persistent
+	// connection, regardless of what the client sent to us.  This
+	// is modifying the same underlying map from req (shallow
+	// copied above) so we only copy it if necessary.
+	copiedHeaders := false
+	for _, h := range hopHeaders {
+		if outreq.Header.Get(h) != "" {
+			if !copiedHeaders {
+				outreq.Header = make(http.Header)
+				copyHeader(outreq.Header, req.Header)
+				copiedHeaders = true
+			}
+			outreq.Header.Del(h)
+		}
+	}
+
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		// If we aren't the first proxy retain prior
+		// X-Forwarded-For information as a comma+space
+		// separated list and fold multiple headers into one.
+		if prior, ok := outreq.Header["X-Forwarded-For"]; ok {
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
+		}
+		outreq.Header.Set("X-Forwarded-For", clientIP)
+	}
+
+	if extraHeaders != nil {
+		for k, v := range extraHeaders {
+			outreq.Header[k] = v
+		}
+	}
+
+	res, err := transport.RoundTrip(outreq)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	for _, h := range hopHeaders {
+		res.Header.Del(h)
+	}
+
+	copyHeader(rw.Header(), res.Header)
+
+	rw.WriteHeader(res.StatusCode)
+	p.copyResponse(rw, res.Body)
+	return nil
+}
+
+func (p *ReverseProxy) copyResponse(dst io.Writer, src io.Reader) {
+	if p.FlushInterval != 0 {
+		if wf, ok := dst.(writeFlusher); ok {
+			mlw := &maxLatencyWriter{
+				dst:     wf,
+				latency: p.FlushInterval,
+				done:    make(chan bool),
+			}
+			go mlw.flushLoop()
+			defer mlw.stop()
+			dst = mlw
+		}
+	}
+
+	io.Copy(dst, src)
+}
+
+type writeFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+type maxLatencyWriter struct {
+	dst     writeFlusher
+	latency time.Duration
+
+	lk   sync.Mutex // protects Write + Flush
+	done chan bool
+}
+
+func (m *maxLatencyWriter) Write(p []byte) (int, error) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+	return m.dst.Write(p)
+}
+
+func (m *maxLatencyWriter) flushLoop() {
+	t := time.NewTicker(m.latency)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.done:
+			if onExitFlushLoop != nil {
+				onExitFlushLoop()
+			}
+			return
+		case <-t.C:
+			m.lk.Lock()
+			m.dst.Flush()
+			m.lk.Unlock()
+		}
+	}
+}
+
+func (m *maxLatencyWriter) stop() { m.done <- true }

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -1,0 +1,203 @@
+package proxy
+
+import (
+	"github.com/mholt/caddy/middleware"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type staticUpstream struct {
+	from   string
+	Hosts  HostPool
+	Policy Policy
+
+	FailTimeout time.Duration
+	MaxFails    int32
+	HealthCheck struct {
+		Path     string
+		Interval time.Duration
+	}
+}
+
+func newStaticUpstreams(c middleware.Controller) ([]Upstream, error) {
+	var upstreams []Upstream
+
+	for c.Next() {
+		upstream := &staticUpstream{
+			from:        "",
+			Hosts:       nil,
+			Policy:      &Random{},
+			FailTimeout: 10 * time.Second,
+			MaxFails:    1,
+		}
+		var proxyHeaders http.Header
+		if !c.Args(&upstream.from) {
+			return upstreams, c.ArgErr()
+		}
+		to := c.RemainingArgs()
+		if len(to) == 0 {
+			return upstreams, c.ArgErr()
+		}
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "policy":
+				if !c.NextArg() {
+					return upstreams, c.ArgErr()
+				}
+				switch c.Val() {
+				case "random":
+					upstream.Policy = &Random{}
+				case "round_robin":
+					upstream.Policy = &RoundRobin{}
+				case "least_conn":
+					upstream.Policy = &LeastConn{}
+				default:
+					return upstreams, c.ArgErr()
+				}
+			case "fail_timeout":
+				if !c.NextArg() {
+					return upstreams, c.ArgErr()
+				}
+				if dur, err := time.ParseDuration(c.Val()); err == nil {
+					upstream.FailTimeout = dur
+				} else {
+					return upstreams, err
+				}
+			case "max_fails":
+				if !c.NextArg() {
+					return upstreams, c.ArgErr()
+				}
+				if n, err := strconv.Atoi(c.Val()); err == nil {
+					upstream.MaxFails = int32(n)
+				} else {
+					return upstreams, err
+				}
+			case "health_check":
+				if !c.NextArg() {
+					return upstreams, c.ArgErr()
+				}
+				upstream.HealthCheck.Path = c.Val()
+				upstream.HealthCheck.Interval = 30 * time.Second
+				if c.NextArg() {
+					if dur, err := time.ParseDuration(c.Val()); err == nil {
+						upstream.HealthCheck.Interval = dur
+					} else {
+						return upstreams, err
+					}
+				}
+			case "proxy_header":
+				var header, value string
+				if !c.Args(&header, &value) {
+					return upstreams, c.ArgErr()
+				}
+				if proxyHeaders == nil {
+					proxyHeaders = make(map[string][]string)
+				}
+				proxyHeaders.Add(header, value)
+			}
+		}
+
+		upstream.Hosts = make([]*UpstreamHost, len(to))
+		for i, host := range to {
+			if !strings.HasPrefix(host, "http") {
+				host = "http://" + host
+			}
+			uh := &UpstreamHost{
+				Name:         host,
+				Conns:        0,
+				Fails:        0,
+				FailTimeout:  upstream.FailTimeout,
+				Unhealthy:    false,
+				ExtraHeaders: proxyHeaders,
+				CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
+					return func(uh *UpstreamHost) bool {
+						if uh.Unhealthy {
+							return true
+						}
+						if uh.Fails >= upstream.MaxFails &&
+							upstream.MaxFails != 0 {
+							return true
+						}
+						return false
+					}
+				}(upstream),
+			}
+			if baseUrl, err := url.Parse(uh.Name); err == nil {
+				uh.ReverseProxy = NewSingleHostReverseProxy(baseUrl)
+			} else {
+				return upstreams, err
+			}
+			upstream.Hosts[i] = uh
+		}
+
+		if upstream.HealthCheck.Path != "" {
+			go upstream.healthCheckWorker(nil)
+		}
+		upstreams = append(upstreams, upstream)
+	}
+	return upstreams, nil
+}
+
+func (u *staticUpstream) healthCheck() {
+	for _, host := range u.Hosts {
+		hostUrl := host.Name + u.HealthCheck.Path
+		if r, err := http.Get(hostUrl); err == nil {
+			io.Copy(ioutil.Discard, r.Body)
+			r.Body.Close()
+			host.Unhealthy = r.StatusCode < 200 || r.StatusCode >= 400
+		} else {
+			host.Unhealthy = true
+		}
+	}
+}
+
+func (u *staticUpstream) healthCheckWorker(stop chan struct{}) {
+	ticker := time.NewTicker(u.HealthCheck.Interval)
+	u.healthCheck()
+	for {
+		select {
+		case <-ticker.C:
+			u.healthCheck()
+		case <-stop:
+			// TODO: the library should provide a stop channel and global
+			// waitgroup to allow goroutines started by plugins a chance
+			// to clean themselves up.
+		}
+	}
+}
+
+func (u *staticUpstream) From() string {
+	return u.from
+}
+
+func (u *staticUpstream) Select() *UpstreamHost {
+	pool := u.Hosts
+	if len(pool) == 1 {
+		if pool[0].Down() {
+			return nil
+		}
+		return pool[0]
+	}
+	allDown := true
+	for _, host := range pool {
+		if !host.Down() {
+			allDown = false
+			break
+		}
+	}
+	if allDown {
+		return nil
+	}
+
+	if u.Policy == nil {
+		return (&Random{}).Select(pool)
+	} else {
+		return u.Policy.Select(pool)
+	}
+}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHealthCheck(t *testing.T) {
+	upstream := &staticUpstream{
+		from:        "",
+		Hosts:       testPool(),
+		Policy:      &Random{},
+		FailTimeout: 10 * time.Second,
+		MaxFails:    1,
+	}
+	upstream.healthCheck()
+	if upstream.Hosts[0].Down() {
+		t.Error("Expected first host in testpool to not fail healthcheck.")
+	}
+	if !upstream.Hosts[1].Down() {
+		t.Error("Expected second host in testpool to fail healthcheck.")
+	}
+}
+
+func TestSelect(t *testing.T) {
+	upstream := &staticUpstream{
+		from:        "",
+		Hosts:       testPool()[:3],
+		Policy:      &Random{},
+		FailTimeout: 10 * time.Second,
+		MaxFails:    1,
+	}
+	upstream.Hosts[0].Unhealthy = true
+	upstream.Hosts[1].Unhealthy = true
+	upstream.Hosts[2].Unhealthy = true
+	if h := upstream.Select(); h != nil {
+		t.Error("Expected select to return nil as all host are down")
+	}
+	upstream.Hosts[2].Unhealthy = false
+	if h := upstream.Select(); h == nil {
+		t.Error("Expected select to not return nil")
+	}
+}

--- a/middleware/replacer.go
+++ b/middleware/replacer.go
@@ -33,6 +33,9 @@ func NewReplacer(r *http.Request, rr *responseRecorder) replacer {
 		"{fragment}": r.URL.Fragment,
 		"{proto}":    r.Proto,
 		"{remote}": func() string {
+			if fwdFor := r.Header.Get("X-Forwarded-For"); fwdFor != "" {
+				return fwdFor
+			}
 			host, _, err := net.SplitHostPort(r.RemoteAddr)
 			if err != nil {
 				return r.RemoteAddr

--- a/middleware/replacer.go
+++ b/middleware/replacer.go
@@ -53,9 +53,11 @@ func NewReplacer(r *http.Request, rr *responseRecorder) replacer {
 		"{when}": func() string {
 			return time.Now().Format(timeFormat)
 		}(),
-		"{status}":  strconv.Itoa(rr.status),
-		"{size}":    strconv.Itoa(rr.size),
-		"{latency}": time.Since(rr.start).String(),
+	}
+	if rr != nil {
+		rep["{status}"] = strconv.Itoa(rr.status)
+		rep["{size}"] = strconv.Itoa(rr.size)
+		rep["{latency}"] = time.Since(rr.start).String()
 	}
 
 	// Header placeholders

--- a/middleware/replacer.go
+++ b/middleware/replacer.go
@@ -8,17 +8,21 @@ import (
 	"time"
 )
 
-// replacer is a type which can replace placeholder
+// Replacer is a type which can replace placeholder
 // substrings in a string with actual values from a
 // http.Request and responseRecorder. Always use
 // NewReplacer to get one of these.
+type Replacer interface {
+	Replace(string) string
+}
+
 type replacer map[string]string
 
 // NewReplacer makes a new replacer based on r and rr.
 // Do not create a new replacer until r and rr have all
 // the needed values, because this function copies those
 // values into the replacer.
-func NewReplacer(r *http.Request, rr *responseRecorder) replacer {
+func NewReplacer(r *http.Request, rr *responseRecorder) Replacer {
 	rep := replacer{
 		"{method}": r.Method,
 		"{scheme}": func() string {


### PR DESCRIPTION
First off - thanks for creating caddy. We were looking for a solution that would allow us to write custom service discovery backends for our mesos cluster in nginx (like creating a custom upstream) as DNS-based service discovery wasn't working too well for us (failover & dns caching didn't work too well). It looked like we would have to write our module in C. With this we can write something simpler with Go.

As I have done work creating the reverse proxy backend (for our service discovery), I thought it would have made the most sense to provide more general features to the upstream backend (as we would use those too), that had most of the base features included, but still retained the ability to be easily extensible (any developer can simply copy the `staticUpstream` implementation and get load balancing & fail over, and be able to write & extend backends - for example doing manual DNS round robin.)

**Summary**
This PR builds off the `proxy` middleware to add the ability to have multiple backends, load balancing, (with `random`, `round_robin`, and `least_conn` directives), fail over, and health checks. I've attempted to emulate nginx features, but I haven't decided to completely emulate nginx outright.

**Backwards Compatibility**
These changes should still be backwards compatible, except for 1 thing. Whereas before if the config did not specify a scheme, caddy would match the backend scheme to the incoming request's scheme. Now, the scheme simply defaults to `http` if its not given.

**Config**
```
proxy from to [to [to...]] [{
    policy random | least_conn | round_robin
    fail_timeout duration
    max_fails integer
    health_check path duration
    proxy_header name value
}]
```

Multiple backends are specified with multiple `to` fields, and the block is entirely optional. The options in the block are as follows:

* `policy` - Load balancing policy. The default is `random`, which random selects a backend. `least_conn` selects a backend with the least amount of active connections, falling back to randomly selecting a backend if there are multiple such backends, and `round_robin` selects backends in a round robin fashion.
* `fail_timeout` - When a backend has failed, this timeout specifies how long to consider that backend as down. While it is down, requests will not be routed to that backend. A backend is "down" is caddy fails to communicate with it. The default value is `10s`. 
* `max_fails` - How many failures within `fail_timout` are needed to consider a backend as down. If `max_fails` is `0`, the failures will not cause the backend to be marked as down. The default value is `1`
* `health_check` - `path` and optional `duration`. Health check will check `path` on each backend, and if that backend returns a status code of 200-399, then that backend is healthy, if it doesn't the backend is marked as unhealthy for `duration` and no requests are routed to it. If this option is not provided then health checks are disabled. The default duration is `10s`
* `proxy_header`  - `name` and `value`. Sets headers to passed to backend. This option can be specified multiple times for multiple headers. You can also interpolate certain values as part of the headers with values provided to `Replacer` (also used by the `log` middleware)
  
**Examples**
Multiple backends
```
proxy / web1.local:80 web2.local:90 web3.local:100
```

Round Robin
```
proxy / web1.local:80 web2.local:90 web3.local:100 {
  policy round_robin
}
```

Health Checks & Proxy Headers
```
proxy / web1.local:80 web2.local:90 web3.local:100 {
  policy round_robin
  health_check /health
  proxy_header Host {host}
  proxy_header X-Caddy-When server-{when}
}
```