### PR TITLE
fastcgi: allow more request types.

### DIFF
--- a/middleware/fastcgi/fastcgi.go
+++ b/middleware/fastcgi/fastcgi.go
@@ -85,14 +85,21 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 				return http.StatusBadGateway, err
 			}
 
-			// TODO: Allow more methods (requires refactoring fcgiclient first...)
 			var resp *http.Response
+			contentLength, _ := strconv.Atoi(r.Header.Get("Content-Length"))
 			switch r.Method {
+			case "HEAD":
+				resp, err = fcgi.Head(env)
 			case "GET":
 				resp, err = fcgi.Get(env)
 			case "POST":
-				l, _ := strconv.Atoi(r.Header.Get("Content-Length"))
-				resp, err = fcgi.Post(env, r.Header.Get("Content-Type"), r.Body, l)
+				resp, err = fcgi.Post(env, r.Header.Get("Content-Type"), r.Body, contentLength)
+			case "PUT":
+				resp, err = fcgi.Put(env, r.Header.Get("Content-Type"), r.Body, contentLength)
+			case "PATCH":
+				resp, err = fcgi.Patch(env, r.Header.Get("Content-Type"), r.Body, contentLength)
+			case "DELETE":
+				resp, err = fcgi.Delete(env, r.Header.Get("Content-Type"), r.Body, contentLength)
 			default:
 				return http.StatusMethodNotAllowed, nil
 			}

--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -407,6 +407,15 @@ func (this *FCGIClient) Get(p map[string]string) (resp *http.Response, err error
 	return this.Request(p, nil)
 }
 
+// Head issues a HEAD request to the fcgi responder.
+func (this *FCGIClient) Head(p map[string]string) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "HEAD"
+	p["CONTENT_LENGTH"] = "0"
+
+	return this.Request(p, nil)
+}
+
 // Get issues a Post request to the fcgi responder. with request body
 // in the format that bodyType specified
 func (this *FCGIClient) Post(p map[string]string, bodyType string, body io.Reader, l int) (resp *http.Response, err error) {
@@ -422,6 +431,30 @@ func (this *FCGIClient) Post(p map[string]string, bodyType string, body io.Reade
 	}
 
 	return this.Request(p, body)
+}
+
+// Put issues a PUT request to the fcgi responder.
+func (this *FCGIClient) Put(p map[string]string, bodyType string, body io.Reader, l int) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "PUT"
+
+	return this.Post(p, bodyType, body, l)
+}
+
+// Patch issues a PATCH request to the fcgi responder.
+func (this *FCGIClient) Patch(p map[string]string, bodyType string, body io.Reader, l int) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "PATCH"
+
+	return this.Post(p, bodyType, body, l)
+}
+
+// Delete issues a DELETE request to the fcgi responder.
+func (this *FCGIClient) Delete(p map[string]string, bodyType string, body io.Reader, l int) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "DELETE"
+
+	return this.Post(p, bodyType, body, l)
 }
 
 // PostForm issues a POST to the fcgi responder, with form


### PR DESCRIPTION
FastCGI middleware currently allows only `GET` and `POST` requests and returns a `405 (Method not Allowed)` for others.

This will allow the following additional request types.
* HEAD
* PUT
* PATCH
* DELETE

`HEAD` is essential and the others are useful for REST endpoints.
