### PR TITLE
proxy: Refactor so that other upstream backends can be implemented

### DIFF
--- a/config/setup/proxy.go
+++ b/config/setup/proxy.go
@@ -1,145 +1,17 @@
 package setup
 
 import (
-	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
-	"time"
-
 	"github.com/mholt/caddy/middleware"
 	"github.com/mholt/caddy/middleware/proxy"
 )
 
 // Proxy configures a new Proxy middleware instance.
 func Proxy(c *Controller) (middleware.Middleware, error) {
-	if upstreams, err := newStaticUpstreams(c); err == nil {
+	if upstreams, err := proxy.NewStaticUpstreams(c.Dispenser); err == nil {
 		return func(next middleware.Handler) middleware.Handler {
 			return proxy.Proxy{Next: next, Upstreams: upstreams}
 		}, nil
 	} else {
 		return nil, err
 	}
-}
-
-// newStaticUpstreams parses the configuration input and sets up
-// static upstreams for the proxy middleware.
-func newStaticUpstreams(c *Controller) ([]proxy.Upstream, error) {
-	var upstreams []proxy.Upstream
-
-	for c.Next() {
-		upstream := &proxy.StaticUpstream{
-			From:        "",
-			Hosts:       nil,
-			Policy:      &proxy.Random{},
-			FailTimeout: 10 * time.Second,
-			MaxFails:    1,
-		}
-		var proxyHeaders http.Header
-		if !c.Args(&upstream.From) {
-			return upstreams, c.ArgErr()
-		}
-		to := c.RemainingArgs()
-		if len(to) == 0 {
-			return upstreams, c.ArgErr()
-		}
-
-		for c.NextBlock() {
-			switch c.Val() {
-			case "policy":
-				if !c.NextArg() {
-					return upstreams, c.ArgErr()
-				}
-				switch c.Val() {
-				case "random":
-					upstream.Policy = &proxy.Random{}
-				case "round_robin":
-					upstream.Policy = &proxy.RoundRobin{}
-				case "least_conn":
-					upstream.Policy = &proxy.LeastConn{}
-				default:
-					return upstreams, c.ArgErr()
-				}
-			case "fail_timeout":
-				if !c.NextArg() {
-					return upstreams, c.ArgErr()
-				}
-				if dur, err := time.ParseDuration(c.Val()); err == nil {
-					upstream.FailTimeout = dur
-				} else {
-					return upstreams, err
-				}
-			case "max_fails":
-				if !c.NextArg() {
-					return upstreams, c.ArgErr()
-				}
-				if n, err := strconv.Atoi(c.Val()); err == nil {
-					upstream.MaxFails = int32(n)
-				} else {
-					return upstreams, err
-				}
-			case "health_check":
-				if !c.NextArg() {
-					return upstreams, c.ArgErr()
-				}
-				upstream.HealthCheck.Path = c.Val()
-				upstream.HealthCheck.Interval = 30 * time.Second
-				if c.NextArg() {
-					if dur, err := time.ParseDuration(c.Val()); err == nil {
-						upstream.HealthCheck.Interval = dur
-					} else {
-						return upstreams, err
-					}
-				}
-			case "proxy_header":
-				var header, value string
-				if !c.Args(&header, &value) {
-					return upstreams, c.ArgErr()
-				}
-				if proxyHeaders == nil {
-					proxyHeaders = make(map[string][]string)
-				}
-				proxyHeaders.Add(header, value)
-			}
-		}
-
-		upstream.Hosts = make([]*proxy.UpstreamHost, len(to))
-		for i, host := range to {
-			if !strings.HasPrefix(host, "http") {
-				host = "http://" + host
-			}
-			uh := &proxy.UpstreamHost{
-				Name:         host,
-				Conns:        0,
-				Fails:        0,
-				FailTimeout:  upstream.FailTimeout,
-				Unhealthy:    false,
-				ExtraHeaders: proxyHeaders,
-				CheckDown: func(upstream *proxy.StaticUpstream) proxy.UpstreamHostDownFunc {
-					return func(uh *proxy.UpstreamHost) bool {
-						if uh.Unhealthy {
-							return true
-						}
-						if uh.Fails >= upstream.MaxFails &&
-							upstream.MaxFails != 0 {
-							return true
-						}
-						return false
-					}
-				}(upstream),
-			}
-			if baseUrl, err := url.Parse(uh.Name); err == nil {
-				uh.ReverseProxy = proxy.NewSingleHostReverseProxy(baseUrl)
-			} else {
-				return upstreams, err
-			}
-			upstream.Hosts[i] = uh
-		}
-
-		if upstream.HealthCheck.Path != "" {
-			go upstream.HealthCheckWorker(nil)
-		}
-		upstreams = append(upstreams, upstream)
-	}
-	return upstreams, nil
 }

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 // suitable upstream host, or nil if no such hosts are available.
 type Upstream interface {
 	//The path this upstream host should be routed on
-	from() string
+	From() string
 	// Selects an upstream host to be routed to.
 	Select() *UpstreamHost
 }
@@ -55,7 +55,7 @@ func (uh *UpstreamHost) Down() bool {
 func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 
 	for _, upstream := range p.Upstreams {
-		if middleware.Path(r.URL.Path).Matches(upstream.from()) {
+		if middleware.Path(r.URL.Path).Matches(upstream.From()) {
 			var replacer middleware.Replacer
 			start := time.Now()
 			requestHost := r.Host


### PR DESCRIPTION
Sorry for fiddling around with this middleware so much - I had noticed that a recent refactor caused the way we were doing things to break and unable to write our own proxy backends in Caddy. 

This PR simply moves things around so that interfaces are properly exposed so its easier to write your own proxy backends. Our original intent with the proxy backend was to provide a standard one (@ `upstream.go`), and have that easily copyable to another package in case you wanted to extend that upstream backend. (For example are working on a `mesosupstream` proxy backend that allows you specify mesos tasks rather than domain names - we would still like to take advantage of the proxy middleware however).

This way if someone wants to write backend that uses a different method of service discovery (like consul or gossip) they can simply copy `upstream.go` and implement that such that `Upstream.Select` returns a host using their own given method of service discovery.

This PR doesn't make any functional changes, just changes visibility on some interface methods.