### PR TITLE
core: Add the option to specify what address to bind on in Caddyfile

### DIFF
--- a/config/directives.go
+++ b/config/directives.go
@@ -43,7 +43,7 @@ var directiveOrder = []directive{
 	// Essential directives that initialize vital configuration settings
 	{"root", setup.Root},
 	{"tls", setup.TLS},
-	{"bindaddr", setup.BindAddr},
+	{"bind", setup.BindHost},
 
 	// Other directives that don't create HTTP handlers
 	{"startup", setup.Startup},

--- a/config/directives.go
+++ b/config/directives.go
@@ -43,6 +43,7 @@ var directiveOrder = []directive{
 	// Essential directives that initialize vital configuration settings
 	{"root", setup.Root},
 	{"tls", setup.TLS},
+	{"bindaddr", setup.BindAddr},
 
 	// Other directives that don't create HTTP handlers
 	{"startup", setup.Startup},

--- a/config/setup/bindaddr.go
+++ b/config/setup/bindaddr.go
@@ -1,0 +1,12 @@
+package setup
+
+import "github.com/mholt/caddy/middleware"
+
+func BindAddr(c *Controller) (middleware.Middleware, error) {
+	for c.Next() {
+		if !c.Args(&c.BindAddress) {
+			return nil, c.ArgErr()
+		}
+	}
+	return nil, nil
+}

--- a/config/setup/bindhost.go
+++ b/config/setup/bindhost.go
@@ -2,9 +2,9 @@ package setup
 
 import "github.com/mholt/caddy/middleware"
 
-func BindAddr(c *Controller) (middleware.Middleware, error) {
+func BindHost(c *Controller) (middleware.Middleware, error) {
 	for c.Next() {
-		if !c.Args(&c.BindAddress) {
+		if !c.Args(&c.BindHost) {
 			return nil, c.ArgErr()
 		}
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -11,6 +11,9 @@ type Config struct {
 	// The hostname or IP on which to serve
 	Host string
 
+	// The address to bind on - defaults to Host if empty
+	BindAddress string
+
 	// The port to listen on
 	Port string
 
@@ -44,6 +47,9 @@ type Config struct {
 
 // Address returns the host:port of c as a string.
 func (c Config) Address() string {
+	if c.BindAddress != "" {
+		return net.JoinHostPort(c.BindAddress, c.Port)
+	}
 	return net.JoinHostPort(c.Host, c.Port)
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -11,8 +11,8 @@ type Config struct {
 	// The hostname or IP on which to serve
 	Host string
 
-	// The address to bind on - defaults to Host if empty
-	BindAddress string
+	// The host address to bind on - defaults to (virtual) Host if empty
+	BindHost string
 
 	// The port to listen on
 	Port string
@@ -47,8 +47,8 @@ type Config struct {
 
 // Address returns the host:port of c as a string.
 func (c Config) Address() string {
-	if c.BindAddress != "" {
-		return net.JoinHostPort(c.BindAddress, c.Port)
+	if c.BindHost != "" {
+		return net.JoinHostPort(c.BindHost, c.Port)
 	}
 	return net.JoinHostPort(c.Host, c.Port)
 }


### PR DESCRIPTION
**Problem**
When using virtual hosts behind docker or with a host that doesn't resolve that may not resolve - Caddy won't start. Alternatively there is no way to tell Caddy to bind on a different host rather than trying to resolve the host name.

Ex.
```
http://channelmeter.com {
  proxy / http://node:3000
}
http://api.channelmeter.com {
  proxy / http://api:3000
}
```

Inside a docker container, this will cause Caddy to try and bind on `67.207.200.30`. This isn't allowed (by Docker) and so you get permission denied. An option would be to include another directive that allows you to bind on another address such as `0.0.0.0`  - such as

```
http://channelmeter.com {
  bindaddr 0.0.0.0
  proxy / http://node:3000
}
http://api.channelmeter.com {
  bindaddr 0.0.0.0
  proxy / http://api:3000
}
```

This PR provides that functionality.