### PR TITLE
tls: suggestion - disable tls if port is http?

### DIFF
--- a/config/setup/tls.go
+++ b/config/setup/tls.go
@@ -3,7 +3,7 @@ package setup
 import "github.com/mholt/caddy/middleware"
 
 func TLS(c *Controller) (middleware.Middleware, error) {
-	c.TLS.Enabled = true
+	c.TLS.Enabled = c.Port != "http"
 
 	for c.Next() {
 		if !c.NextArg() {

--- a/config/setup/tls.go
+++ b/config/setup/tls.go
@@ -1,9 +1,19 @@
 package setup
 
-import "github.com/mholt/caddy/middleware"
+import (
+	"github.com/mholt/caddy/middleware"
+	"log"
+)
 
 func TLS(c *Controller) (middleware.Middleware, error) {
-	c.TLS.Enabled = c.Port != "http"
+	c.TLS.Enabled = true
+	if c.Port == "http" {
+		c.TLS.Enabled = false
+		log.Printf("Warning: TLS was disabled on host http://%s."+
+			" Make sure you are specifying https://%s in your config (if you haven't already)."+
+			" If you meant to serve tls on port 80,"+
+			" specify port 80 in your config (http://%s:80).", c.Host, c.Host, c.Host)
+	}
 
 	for c.Next() {
 		if !c.NextArg() {


### PR DESCRIPTION
This is more of a cosmetic thing, but when setting servers, we usually have times when we want to have a server listen on both on http and https without automatically upgrading to https. (Ex, our API service which if request over http, via XHR, doing a redirect to https would cause a CORS violation).

However, we also don't want to repeat options in our Caddy file. A configuration like this:

```
http://api.example.com, https://api.example.com {
	tls example.crt example.key
	bindaddr 0.0.0.0
	gzip
	log /dev/fd/1
}
```

Would cause a Caddy to error out with 
`Configuration error: Cannot multiplex 0.0.0.0:http (HTTP) and 0.0.0.0:http (HTTPS) on same address`

With the following change, tls won't be enabled for servers with port http (either `http://example.com` or `0.0.0.0:http`.

I think its a sane default (you don't usually want https on port 80), OTOH, I could understand if some people want to be paranoid about tls.  Lastly, you would be able override the tls check by doing something like `http://example.com:80` or `0.0.0.0:80`.