### PR TITLE
basicauth: Should write an unauthorized code to response. (Actually only returns it)

### DIFF
--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -31,7 +31,6 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 			// Check credentials
 			if !ok || username != rule.Username || password != rule.Password {
 				w.Header().Set("WWW-Authenticate", "Basic")
-				w.WriteHeader(http.StatusUnauthorized)
 				return http.StatusUnauthorized, nil
 			}
 

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -31,6 +31,7 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 			// Check credentials
 			if !ok || username != rule.Username || password != rule.Password {
 				w.Header().Set("WWW-Authenticate", "Basic")
+				w.WriteHeader(http.StatusUnauthorized)
 				return http.StatusUnauthorized, nil
 			}
 

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -24,12 +24,14 @@ func TestBasicAuth(t *testing.T) {
 		result int
 		cred   string
 	}{
+		{"/testing", http.StatusUnauthorized, "ttest:test"},
 		{"/testing", http.StatusOK, "test:ttest"},
+		
 		{"/testing", http.StatusUnauthorized, ""},
 
 	}
 
-	//auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))
+	
 	for i, test := range tests {
 
 		
@@ -41,7 +43,14 @@ func TestBasicAuth(t *testing.T) {
 		req.Header.Set("Authorization", auth)
 
 		rec := httptest.NewRecorder()
-		rw.ServeHTTP(rec, req)
+		result, err := rw.ServeHTTP(rec, req)
+		if err != nil {
+			t.Fatalf("Test %d: Could not ServeHTTP %v", i, err)
+		}
+		if result != test.result {
+			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
+				i, test.result, result)
+		}
 
 		if rec.Code != test.result {
 			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
@@ -54,5 +63,5 @@ func TestBasicAuth(t *testing.T) {
 
 func contentHandler(w http.ResponseWriter, r *http.Request) (int, error) {
 	fmt.Fprintf(w, r.URL.String())
-	return 0, nil
+	return http.StatusOK, nil
 }

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -1,0 +1,58 @@
+package basicauth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mholt/caddy/middleware"
+)
+
+func TestBasicAuth(t *testing.T) {
+
+	rw := BasicAuth{
+		Next: middleware.HandlerFunc(contentHandler),
+		Rules: []Rule{
+			{Username: "test", Password: "ttest", Resources: []string{"/testing"}},
+		},
+	}
+
+	tests := []struct {
+		from   string
+		result int
+		cred   string
+	}{
+		{"/testing", http.StatusOK, "test:ttest"},
+		{"/testing", http.StatusUnauthorized, ""},
+
+	}
+
+	//auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))
+	for i, test := range tests {
+
+		
+		req, err := http.NewRequest("GET", test.from, nil)
+		if err != nil {
+			t.Fatalf("Test %d: Could not create HTTP request %v", i, err)
+		}
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(test.cred))
+		req.Header.Set("Authorization", auth)
+
+		rec := httptest.NewRecorder()
+		rw.ServeHTTP(rec, req)
+
+		if rec.Code != test.result {
+			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
+				i, test.result, rec.Code)
+		}
+
+	}
+
+}
+
+func contentHandler(w http.ResponseWriter, r *http.Request) (int, error) {
+	fmt.Fprintf(w, r.URL.String())
+	return 0, nil
+}

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -26,7 +26,6 @@ func TestBasicAuth(t *testing.T) {
 	}{
 		{"/testing", http.StatusUnauthorized, "ttest:test"},
 		{"/testing", http.StatusOK, "test:ttest"},
-		
 		{"/testing", http.StatusUnauthorized, ""},
 
 	}
@@ -51,15 +50,70 @@ func TestBasicAuth(t *testing.T) {
 			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
 				i, test.result, result)
 		}
-
-		if rec.Code != test.result {
-			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
-				i, test.result, rec.Code)
+		if result == http.StatusUnauthorized {
+			headers := rec.Header()
+			if val, ok := headers["Www-Authenticate"]; ok {
+				if val[0] != "Basic" {
+					t.Errorf("Test %d, Www-Authenticate should be %s provided %s", i, "Basic", val[0]) 
+				}
+			} else {
+				t.Errorf("Test %d, should provide a header Www-Authenticate", i)
+			}
 		}
 
+	
 	}
 
 }
+
+
+func TestMultipleOverlappingRules(t *testing.T) {
+	rw := BasicAuth{
+		Next: middleware.HandlerFunc(contentHandler),
+		Rules: []Rule{
+			{Username: "t", Password: "p1", Resources: []string{"/t"}},
+			{Username: "t1", Password: "p2", Resources: []string{"/t/t"}},
+		},
+	}
+	
+	tests := []struct {
+		from   string
+		result int
+		cred   string
+	}{
+		{"/t", http.StatusOK, "t:p1"},
+		{"/t/t", http.StatusOK, "t:p1"},
+		{"/t/t", http.StatusOK, "t1:p2"},
+
+	}
+
+	
+	for i, test := range tests {
+
+		
+		req, err := http.NewRequest("GET", test.from, nil)
+		if err != nil {
+			t.Fatalf("Test %d: Could not create HTTP request %v", i, err)
+		}
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(test.cred))
+		req.Header.Set("Authorization", auth)
+
+		rec := httptest.NewRecorder()
+		result, err := rw.ServeHTTP(rec, req)
+		if err != nil {
+			t.Fatalf("Test %d: Could not ServeHTTP %v", i, err)
+		}
+		if result != test.result {
+			t.Errorf("Test %d: Expected Header '%d' but was '%d'",
+				i, test.result, result)
+		}
+		
+	
+	}
+
+}
+
+
 
 func contentHandler(w http.ResponseWriter, r *http.Request) (int, error) {
 	fmt.Fprintf(w, r.URL.String())

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -84,12 +84,13 @@ func TestMultipleOverlappingRules(t *testing.T) {
 		{"/t", http.StatusOK, "t:p1"},
 		{"/t/t", http.StatusOK, "t:p1"},
 		{"/t/t", http.StatusOK, "t1:p2"},
-
+		{"/a", http.StatusOK, "t1:p2"},
+		{"/t/t", http.StatusUnauthorized, "t1:p3"},
+		{"/t", http.StatusUnauthorized, "t1:p2"},
 	}
 
 	
 	for i, test := range tests {
-
 		
 		req, err := http.NewRequest("GET", test.from, nil)
 		if err != nil {
@@ -108,7 +109,6 @@ func TestMultipleOverlappingRules(t *testing.T) {
 				i, test.result, result)
 		}
 		
-	
 	}
 
 }


### PR DESCRIPTION
Test + Patch
But if this is not the desired behaviour for middlewares, I can just change test case.