### PR TITLE
Rewrite: Support for Regular Expressions.

### DIFF
--- a/config/setup/rewrite.go
+++ b/config/setup/rewrite.go
@@ -60,6 +60,7 @@ func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 					return nil, c.ArgErr()
 				}
 			}
+			// ensure pattern and to are specified
 			if pattern == "" || to == "" {
 				return nil, c.ArgErr()
 			}

--- a/config/setup/rewrite_test.go
+++ b/config/setup/rewrite_test.go
@@ -3,7 +3,9 @@ package setup
 import (
 	"testing"
 
+	"fmt"
 	"github.com/mholt/caddy/middleware/rewrite"
+	"regexp"
 )
 
 func TestRewrite(t *testing.T) {
@@ -33,27 +35,27 @@ func TestRewrite(t *testing.T) {
 }
 
 func TestRewriteParse(t *testing.T) {
-	tests := []struct {
+	simpleTests := []struct {
 		input     string
 		shouldErr bool
 		expected  []rewrite.Rule
 	}{
 		{`rewrite /from /to`, false, []rewrite.Rule{
-			{From: "/from", To: "/to"},
+			rewrite.SimpleRule{"/from", "/to"},
 		}},
 		{`rewrite /from /to
 		  rewrite a b`, false, []rewrite.Rule{
-			{From: "/from", To: "/to"},
-			{From: "a", To: "b"},
+			rewrite.SimpleRule{"/from", "/to"},
+			rewrite.SimpleRule{"a", "b"},
 		}},
 		{`rewrite a`, true, []rewrite.Rule{}},
 		{`rewrite`, true, []rewrite.Rule{}},
 		{`rewrite a b c`, true, []rewrite.Rule{
-			{From: "a", To: "b"},
+			rewrite.SimpleRule{"a", "b"},
 		}},
 	}
 
-	for i, test := range tests {
+	for i, test := range simpleTests {
 		c := newTestController(test.input)
 		actual, err := rewriteParse(c)
 
@@ -61,6 +63,8 @@ func TestRewriteParse(t *testing.T) {
 			t.Errorf("Test %d didn't error, but it should have", i)
 		} else if err != nil && !test.shouldErr {
 			t.Errorf("Test %d errored, but it shouldn't have; got '%v'", i, err)
+		} else if err != nil && test.shouldErr {
+			continue
 		}
 
 		if len(actual) != len(test.expected) {
@@ -68,8 +72,9 @@ func TestRewriteParse(t *testing.T) {
 				i, len(test.expected), len(actual))
 		}
 
-		for j, expectedRule := range test.expected {
-			actualRule := actual[j]
+		for j, e := range test.expected {
+			actualRule := actual[j].(rewrite.SimpleRule)
+			expectedRule := e.(rewrite.SimpleRule)
 
 			if actualRule.From != expectedRule.From {
 				t.Errorf("Test %d, rule %d: Expected From=%s, got %s",
@@ -82,4 +87,98 @@ func TestRewriteParse(t *testing.T) {
 			}
 		}
 	}
+
+	regexpTests := []struct {
+		input     string
+		shouldErr bool
+		expected  []rewrite.Rule
+	}{
+		{`rewrite {
+			r	.*
+			to	/to
+		 }`, false, []rewrite.Rule{
+			&rewrite.RegexpRule{"/", "/to", nil, regexp.MustCompile(".*")},
+		}},
+		{`rewrite {
+			regexp	.*
+			to		/to
+			ext		/ html txt
+		 }`, false, []rewrite.Rule{
+			&rewrite.RegexpRule{"/", "/to", []string{"/", "html", "txt"}, regexp.MustCompile(".*")},
+		}},
+		{`rewrite /path {
+			r	rr
+			to	/dest
+		 }
+		 rewrite / {
+		 	regexp	[a-z]+
+		 	to 		/to
+		 }
+		 `, false, []rewrite.Rule{
+			&rewrite.RegexpRule{"/path", "/dest", nil, regexp.MustCompile("rr")},
+			&rewrite.RegexpRule{"/", "/to", nil, regexp.MustCompile("[a-z]+")},
+		}},
+		{`rewrite {
+			to	/to
+		 }`, true, []rewrite.Rule{
+			&rewrite.RegexpRule{},
+		}},
+		{`rewrite {
+			r	.*
+		 }`, true, []rewrite.Rule{
+			&rewrite.RegexpRule{},
+		}},
+		{`rewrite {
+
+		 }`, true, []rewrite.Rule{
+			&rewrite.RegexpRule{},
+		}},
+		{`rewrite /`, true, []rewrite.Rule{
+			&rewrite.RegexpRule{},
+		}},
+	}
+
+	for i, test := range regexpTests {
+		c := newTestController(test.input)
+		actual, err := rewriteParse(c)
+
+		if err == nil && test.shouldErr {
+			t.Errorf("Test %d didn't error, but it should have", i)
+		} else if err != nil && !test.shouldErr {
+			t.Errorf("Test %d errored, but it shouldn't have; got '%v'", i, err)
+		} else if err != nil && test.shouldErr {
+			continue
+		}
+
+		if len(actual) != len(test.expected) {
+			t.Fatalf("Test %d expected %d rules, but got %d",
+				i, len(test.expected), len(actual))
+		}
+
+		for j, e := range test.expected {
+			actualRule := actual[j].(*rewrite.RegexpRule)
+			expectedRule := e.(*rewrite.RegexpRule)
+
+			if actualRule.Base != expectedRule.Base {
+				t.Errorf("Test %d, rule %d: Expected Base=%s, got %s",
+					i, j, expectedRule.Base, actualRule.Base)
+			}
+
+			if actualRule.To != expectedRule.To {
+				t.Errorf("Test %d, rule %d: Expected To=%s, got %s",
+					i, j, expectedRule.To, actualRule.To)
+			}
+
+			if fmt.Sprint(actualRule.Exts) != fmt.Sprint(expectedRule.Exts) {
+				t.Errorf("Test %d, rule %d: Expected Ext=%v, got %v",
+					i, j, expectedRule.To, actualRule.To)
+			}
+
+			if actualRule.String() != expectedRule.String() {
+				t.Errorf("Test %d, rule %d: Expected Pattern=%s, got %s",
+					i, j, expectedRule.String(), actualRule.String())
+			}
+		}
+	}
+
 }

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -109,7 +109,7 @@ func (r *RegexpRule) Rewrite(req *http.Request) bool {
 	rPath := req.URL.Path
 
 	// validate base
-	if !strings.HasPrefix(rPath, r.Base) {
+	if !middleware.Path(rPath).Matches(r.Base) {
 		return false
 	}
 

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -79,9 +79,9 @@ func NewRegexpRule(base, pattern, to string, ext []string) (*RegexpRule, error) 
 	}, nil
 }
 
-var regexpVars [2]string = [2]string{
-	"$path",
-	"$query",
+var regexpVars []string = []string{
+	"{path}",
+	"{query}",
 }
 
 func (r *RegexpRule) Rewrite(req *http.Request) bool {
@@ -92,7 +92,7 @@ func (r *RegexpRule) Rewrite(req *http.Request) bool {
 	if !r.matchExt(rPath) {
 		return false
 	}
-	if !r.MatchString(req.URL.Path) {
+	if !r.MatchString(rPath[len(r.base):]) {
 		return false
 	}
 
@@ -127,6 +127,7 @@ func (r *RegexpRule) matchExt(rPath string) bool {
 	if ext == "" {
 		ext = "/"
 	}
+
 	mustUse := false
 	for _, v := range r.ext {
 		use := true
@@ -143,9 +144,9 @@ func (r *RegexpRule) matchExt(rPath string) bool {
 			return use
 		}
 	}
+
 	if mustUse {
 		return false
 	}
-
 	return true
 }

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -99,6 +99,9 @@ func NewRegexpRule(base, pattern, to string, ext []string) (*RegexpRule, error) 
 var regexpVars []string = []string{
 	"{path}",
 	"{query}",
+	"{file}",
+	"{dir}",
+	"{frag}",
 }
 
 // Rewrite rewrites the internal location of the current request.
@@ -130,6 +133,14 @@ func (r *RegexpRule) Rewrite(req *http.Request) bool {
 				to = strings.Replace(to, v, req.URL.Path[1:], -1)
 			case "{query}":
 				to = strings.Replace(to, v, req.URL.RawQuery, -1)
+			case "{frag}":
+				to = strings.Replace(to, v, req.URL.Fragment, -1)
+			case "{file}":
+				_, file := path.Split(req.URL.Path)
+				to = strings.Replace(to, v, file, -1)
+			case "{dir}":
+				dir, _ := path.Split(req.URL.Path)
+				to = path.Clean(strings.Replace(to, v, dir, -1))
 			}
 		}
 	}

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -5,7 +5,13 @@ package rewrite
 import (
 	"net/http"
 
+	"fmt"
 	"github.com/mholt/caddy/middleware"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Rewrite is middleware to rewrite request locations internally before being handled.
@@ -17,8 +23,7 @@ type Rewrite struct {
 // ServeHTTP implements the middleware.Handler interface.
 func (rw Rewrite) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, rule := range rw.Rules {
-		if r.URL.Path == rule.From {
-			r.URL.Path = rule.To
+		if ok := rule.Rewrite(r); ok {
 			break
 		}
 	}
@@ -26,6 +31,121 @@ func (rw Rewrite) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error)
 }
 
 // A Rule describes an internal location rewrite rule.
-type Rule struct {
-	From, To string
+type Rule interface {
+	Rewrite(*http.Request) bool
+}
+
+type SimpleRule [2]string
+
+func NewSimpleRule(from, to string) SimpleRule {
+	return SimpleRule{from, to}
+}
+
+func (s SimpleRule) Rewrite(r *http.Request) bool {
+	if s[0] == r.URL.Path {
+		r.URL.Path = s[1]
+		return true
+	}
+	return false
+}
+
+type RegexpRule struct {
+	base, to string
+	ext      []string
+	*regexp.Regexp
+}
+
+func NewRegexpRule(base, pattern, to string, ext []string) (*RegexpRule, error) {
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate extensions
+	for _, v := range ext {
+		if len(v) < 2 || (len(v) < 3 && v[0] == '!') {
+			// check if it is no extension
+			if v != "/" && v != "!/" {
+				return nil, fmt.Errorf("Invalid extension %v", v)
+			}
+		}
+	}
+
+	return &RegexpRule{
+		base,
+		to,
+		ext,
+		r,
+	}, nil
+}
+
+var regexpVars [2]string = [2]string{
+	"$path",
+	"$query",
+}
+
+func (r *RegexpRule) Rewrite(req *http.Request) bool {
+	rPath := req.URL.Path
+	if strings.Index(rPath, r.base) != 0 {
+		return false
+	}
+	if !r.matchExt(rPath) {
+		return false
+	}
+	if !r.MatchString(req.URL.Path) {
+		return false
+	}
+
+	to := r.to
+
+	// check variables
+	for _, v := range regexpVars {
+		if strings.Contains(r.to, v) {
+			switch v {
+			case regexpVars[0]:
+				to = strings.Replace(to, v, req.URL.Path[1:], -1)
+			case regexpVars[1]:
+				to = strings.Replace(to, v, req.URL.RawQuery, -1)
+			}
+		}
+	}
+
+	url, err := url.Parse(to)
+	if err != nil {
+		return false
+	}
+
+	req.URL.Path = url.Path
+	req.URL.RawQuery = url.RawQuery
+
+	return true
+}
+
+func (r *RegexpRule) matchExt(rPath string) bool {
+	f := filepath.Base(rPath)
+	ext := path.Ext(f)
+	if ext == "" {
+		ext = "/"
+	}
+	mustUse := false
+	for _, v := range r.ext {
+		use := true
+		if v[0] == '!' {
+			use = false
+			v = v[1:]
+		}
+
+		if use {
+			mustUse = true
+		}
+
+		if ext == v {
+			return use
+		}
+	}
+	if mustUse {
+		return false
+	}
+
+	return true
 }

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -7,16 +7,38 @@ import (
 	"testing"
 
 	"github.com/mholt/caddy/middleware"
+	"strings"
 )
 
 func TestRewrite(t *testing.T) {
 	rw := Rewrite{
 		Next: middleware.HandlerFunc(urlPrinter),
 		Rules: []Rule{
-			{From: "/from", To: "/to"},
-			{From: "/a", To: "/b"},
+			NewSimpleRule("/from", "/to"),
+			NewSimpleRule("/a", "/b"),
 		},
 	}
+
+	regexpRules := [][]string{
+		[]string{"/reg/", ".*", "/to", ""},
+		[]string{"/r/", "[a-z]+", "/toaz", "!.html|"},
+		[]string{"/url/", "a([a-z0-9]*)s([A-Z]{2})", "/to/{path}", ""},
+		[]string{"/ab/", "ab", "/ab?{query}", ".txt|"},
+		[]string{"/ab/", "ab", "/ab?type=html&{query}", ".html|"},
+	}
+
+	for _, regexpRule := range regexpRules {
+		var ext []string
+		if s := strings.Split(regexpRule[3], "|"); len(s) > 1 {
+			ext = s[:len(s)-1]
+		}
+		rule, err := NewRegexpRule(regexpRule[0], regexpRule[1], regexpRule[2], ext)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rw.Rules = append(rw.Rules, rule)
+	}
+
 	tests := []struct {
 		from       string
 		expectedTo string
@@ -29,6 +51,25 @@ func TestRewrite(t *testing.T) {
 		{"/asdf?foo=bar", "/asdf?foo=bar"},
 		{"/foo#bar", "/foo#bar"},
 		{"/a#foo", "/b#foo"},
+		{"/reg/foo", "/to"},
+		{"/re", "/re"},
+		{"/r/", "/r/"},
+		{"/r/123", "/r/123"},
+		{"/r/a123", "/toaz"},
+		{"/r/abcz", "/toaz"},
+		{"/r/z", "/toaz"},
+		{"/r/z.html", "/r/z.html"},
+		{"/r/z.js", "/toaz"},
+		{"/url/asAB", "/to/url/asAB"},
+		{"/url/aBsAB", "/url/aBsAB"},
+		{"/url/a00sAB", "/to/url/a00sAB"},
+		{"/url/a0z0sAB", "/to/url/a0z0sAB"},
+		{"/ab/aa", "/ab/aa"},
+		{"/ab/ab", "/ab/ab"},
+		{"/ab/ab.txt", "/ab"},
+		{"/ab/ab.txt?name=name", "/ab?name=name"},
+		{"/ab/ab.html?name=name", "/ab?type=html&name=name"},
+		{"/ab/ab.html", "/ab?type=html&"},
 	}
 
 	for i, test := range tests {

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -25,6 +25,9 @@ func TestRewrite(t *testing.T) {
 		[]string{"/url/", "a([a-z0-9]*)s([A-Z]{2})", "/to/{path}", ""},
 		[]string{"/ab/", "ab", "/ab?{query}", ".txt|"},
 		[]string{"/ab/", "ab", "/ab?type=html&{query}", ".html|"},
+		[]string{"/abc/", "ab", "/abc/{file}", ".html|"},
+		[]string{"/abcd/", "ab", "/a/{dir}/{file}", ".html|"},
+		[]string{"/abcde/", "ab", "/a#{frag}", ".html|"},
 	}
 
 	for _, regexpRule := range regexpRules {
@@ -69,7 +72,10 @@ func TestRewrite(t *testing.T) {
 		{"/ab/ab.txt", "/ab"},
 		{"/ab/ab.txt?name=name", "/ab?name=name"},
 		{"/ab/ab.html?name=name", "/ab?type=html&name=name"},
-		{"/ab/ab.html", "/ab?type=html&"},
+		{"/abc/ab.html", "/abc/ab.html"},
+		{"/abcd/abcd.html", "/a/abcd/abcd.html"},
+		{"/abcde/abcde.html", "/a"},
+		{"/abcde/abcde.html#1234", "/a#1234"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Regexp support for **rewrite** middleware. Not as robust as Apache and Nginx but a leap from current functionality.

Two types are now supported.
* Simple rewrite
* Regexp rewrite

#### Simple Rewrite
This is the current functionality. Same syntax
```
rewrite from to
```

#### Regexp Rewrite
Syntax:
```
rewrite [basePath] {
    r[egexp]    pattern
    [ext]       ext
    to          to
}
```
**basePath** - optional. Defaults to `/` e.g. /home/blog/ will only rewrite for subpaths of /home/blog/

**pattern** - regular expression pattern

**ext**     - optional. File extensions to include or ignore. Prefix with `!` to ignore. 
        `.ext` for ext extension (e.g. /home.ext) or `/` for no extension (e.g. /home)
        `.html` - only rewrite for .html
        `!.html` - rewrite for everything else except .html
        `!.txt .html` - rewrite for only .html, ignore everything else including .txt. Same as `.html` above.
        `/` - only rewrite when there's no extension
        `/ .html` - only rewrite for .html and when there's no extension

**to**      - path to rewrite to. Supports variables `{path}`, `{query}`, `{file}`, `{dir}` and `{frag}`
        {path} - request path without preceding `/` e.g. blog/about
        {query} - query string without preceding `?` e.g. name=Matt
        {file} - the last part of the request path. e.g. index.html
        {dir} - the request path without {file}
        {frag} - the part of the url after `#`

##### Examples 
Prevent access to all hidden files (files prefixed with `.`)
```
rewrite {
	r	^\.(.*)
	to  /403.html
}
```

(Personal use case)
Forward request path to index.php when no file extension is specified. Applicable for PHP frameworks like [Phalcon](http://phalconphp.com).
```
rewrite {
 	r    .*
 	ext  /
 	to   /index.php?_url=/{path}&{query}
}
```

With Simple Rewrite, basePath and extensions, the regexp matching that will be done has been reduced.
