### PR TITLE
removed tls cache option

### DIFF
--- a/config/setup/tls.go
+++ b/config/setup/tls.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"crypto/tls"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/mholt/caddy/middleware"
@@ -54,15 +53,6 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 					}
 					c.TLS.Ciphers = append(c.TLS.Ciphers, value)
 				}
-			case "cache":
-				if !c.NextArg() {
-					return nil, c.ArgErr()
-				}
-				size, err := strconv.Atoi(c.Val())
-				if err != nil {
-					return nil, c.Errf("Cache parameter must be a number '%s': %v", c.Val(), err)
-				}
-				c.TLS.CacheSize = size
 			default:
 				return nil, c.Errf("Unknown keyword '%s'")
 			}
@@ -83,11 +73,6 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 	}
 	if c.TLS.ProtocolMaxVersion == 0 {
 		c.TLS.ProtocolMaxVersion = tls.VersionTLS12
-	}
-
-	//If no cachesize provided, set default to 64
-	if c.TLS.CacheSize <= 0 {
-		c.TLS.CacheSize = 64
 	}
 
 	// Prefer server cipher suites

--- a/config/setup/tls_test.go
+++ b/config/setup/tls_test.go
@@ -31,9 +31,6 @@ func TestTLSParseBasic(t *testing.T) {
 	if c.TLS.ProtocolMaxVersion != tls.VersionTLS12 {
 		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMaxVersion, got %v", c.TLS.ProtocolMaxVersion)
 	}
-	if c.TLS.CacheSize != 64 {
-		t.Errorf("Expected CacheSize 64, got %v", c.TLS.CacheSize)
-	}
 
 	// Cipher checks
 	expectedCiphers := []uint16{
@@ -88,7 +85,6 @@ func TestTLSParseWithOptionalParams(t *testing.T) {
 	params := `tls cert.crt cert.key {
             protocols ssl3.0 tls1.2
             ciphers RSA-3DES-EDE-CBC-SHA RSA-AES256-CBC-SHA ECDHE-RSA-AES128-GCM-SHA256
-            cache 128
         }`
 	c := newTestController(params)
 
@@ -108,28 +104,15 @@ func TestTLSParseWithOptionalParams(t *testing.T) {
 	if len(c.TLS.Ciphers)-1 != 3 {
 		t.Errorf("Expected 3 Ciphers (not including TLS_FALLBACK_SCSV), got %v", len(c.TLS.Ciphers))
 	}
-
-	if c.TLS.CacheSize != 128 {
-		t.Errorf("Expected CacheSize 128, got %v", c.TLS.CacheSize)
-	}
 }
 
 func TestTLSParseWithWrongOptionalParams(t *testing.T) {
-	params := `tls cert.crt cert.key {
-            cache a
-        }`
-	c := newTestController(params)
-	_, err := TLS(c)
-	if err == nil {
-		t.Errorf("Expected errors, but no error returned")
-	}
-
 	// Test protocols wrong params
-	params = `tls cert.crt cert.key {
+	params := `tls cert.crt cert.key {
 			protocols ssl tls
 		}`
-	c = newTestController(params)
-	_, err = TLS(c)
+	c := newTestController(params)
+	_, err := TLS(c)
 	if err == nil {
 		t.Errorf("Expected errors, but no error returned")
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -63,6 +63,5 @@ type TLSConfig struct {
 	Ciphers                  []uint16
 	ProtocolMinVersion       uint16
 	ProtocolMaxVersion       uint16
-	CacheSize                int
 	PreferServerCipherSuites bool
 }

--- a/server/server.go
+++ b/server/server.go
@@ -132,7 +132,6 @@ func ListenAndServeTLSWithSNI(srv *http.Server, tlsConfigs []TLSConfig) error {
 	config.BuildNameToCertificate()
 
 	// Customize our TLS configuration
-	config.ClientSessionCache = tls.NewLRUClientSessionCache(tlsConfigs[0].CacheSize)
 	config.MinVersion = tlsConfigs[0].ProtocolMinVersion
 	config.MaxVersion = tlsConfigs[0].ProtocolMaxVersion
 	config.CipherSuites = tlsConfigs[0].Ciphers


### PR DESCRIPTION
crypto/tls ClientSessionCache is used only for tls client.

reference: https://groups.google.com/forum/#!topic/golang-dev/ClGuwk-n_L4