### PR TITLE
add supported for ws in reverse proxy

### DIFF
--- a/config/setup/rewrite_test.go
+++ b/config/setup/rewrite_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"fmt"
-	"github.com/mholt/caddy/middleware/rewrite"
 	"regexp"
+
+	"github.com/mholt/caddy/middleware/rewrite"
 )
 
 func TestRewrite(t *testing.T) {

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -147,7 +147,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusSwitchingProtocols && outreq.Header.Get("Upgrade") == "websocket" {
+	if res.StatusCode == http.StatusSwitchingProtocols && res.Header.Get("Upgrade") == "websocket" {
 		hj, ok := rw.(http.Hijacker)
 		if !ok {
 			return nil

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-const HTTPSwitchProtocols = 101
+const HTTPSwitchingProtocols = 101
 
 // onExitFlushLoop is a callback set by tests to detect the state of the
 // flushLoop() goroutine.
@@ -155,7 +155,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 
 	copyHeader(rw.Header(), res.Header)
 
-	if res.StatusCode == HTTPSwitchProtocols {
+	if res.StatusCode == HTTPSwitchingProtocols && outreq.Header.Get("Upgrade") == "websocket" {
 		hj, ok := rw.(http.Hijacker)
 		if !ok {
 			return nil

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	supportedPolicies map[string]func() Policy = make(map[string]func() Policy)
-	proxyHeaders      http.Header
+	proxyHeaders      http.Header              = make(http.Header)
 )
 
 type staticUpstream struct {
@@ -100,10 +100,10 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 				if !c.Args(&header, &value) {
 					return upstreams, c.ArgErr()
 				}
-				addProxyHeader(header, value)
+				proxyHeaders.Add(header, value)
 			case "websocket":
-				addProxyHeader("Connection", "{>Connection}")
-				addProxyHeader("Upgrade", "{>Upgrade}")
+				proxyHeaders.Add("Connection", "{>Connection}")
+				proxyHeaders.Add("Upgrade", "{>Upgrade}")
 			}
 		}
 
@@ -151,14 +151,6 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 // RegisterPolicy adds a custom policy to the proxy.
 func RegisterPolicy(name string, policy func() Policy) {
 	supportedPolicies[name] = policy
-}
-
-// AddProxyHeader adds a proxy header.
-func addProxyHeader(header, value string) {
-	if proxyHeaders == nil {
-		proxyHeaders = make(map[string][]string)
-	}
-	proxyHeaders.Add(header, value)
 }
 
 func (u *staticUpstream) From() string {


### PR DESCRIPTION
This should address #81. 

Some things worth noting:

1. I dug through the nginx source and it appears they make the change for a WebSocket connection by the status code, so I opted for the same thing.

2. For testing, I went ahead and ran the autobahn fuzzing server behind the proxy and used the testeeclient to exercise it. All the test passed successfully. I can share those results and commands used in slack if that would be helpful.

3. I also setup a regular http server behind the proxy to verify that still worked. It did.

4. Also as noted in the issue, you need to make sure your proxy directives include `Connection` and `Upgrade` like so:

```
proxy / localhost:8080 {
    policy round_robin
    proxy_header Connection {>Connection}
    proxy_header Upgrade {>Upgrade}
} 
```

Let me know if I missed anything or what you would like to see changed.