### PR TITLE
tls: Client authentication

### DIFF
--- a/config/setup/tls.go
+++ b/config/setup/tls.go
@@ -53,6 +53,11 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 					}
 					c.TLS.Ciphers = append(c.TLS.Ciphers, value)
 				}
+			case "clients":
+				c.TLS.ClientCerts = c.RemainingArgs()
+				if len(c.TLS.ClientCerts) == 0 {
+					return nil, c.ArgErr()
+				}
 			default:
 				return nil, c.Errf("Unknown keyword '%s'")
 			}

--- a/config/setup/tls.go
+++ b/config/setup/tls.go
@@ -59,7 +59,7 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 					return nil, c.ArgErr()
 				}
 			default:
-				return nil, c.Errf("Unknown keyword '%s'")
+				return nil, c.Errf("Unknown keyword '%s'", c.Val())
 			}
 		}
 	}

--- a/config/setup/tls_test.go
+++ b/config/setup/tls_test.go
@@ -127,3 +127,34 @@ func TestTLSParseWithWrongOptionalParams(t *testing.T) {
 		t.Errorf("Expected errors, but no error returned")
 	}
 }
+
+func TestTLSParseWithClientAuth(t *testing.T) {
+	params := `tls cert.crt cert.key {
+			clients client_ca.crt client2_ca.crt
+		}`
+	c := newTestController(params)
+	_, err := TLS(c)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
+
+	if count := len(c.TLS.ClientCerts); count != 2 {
+		t.Fatalf("Expected two client certs, had %d", count)
+	}
+	if actual := c.TLS.ClientCerts[0]; actual != "client_ca.crt" {
+		t.Errorf("Expected first client cert file to be '%s', but was '%s'", "client_ca.crt", actual)
+	}
+	if actual := c.TLS.ClientCerts[1]; actual != "client2_ca.crt" {
+		t.Errorf("Expected second client cert file to be '%s', but was '%s'", "client2_ca.crt", actual)
+	}
+
+	// Test missing client cert file
+	params = `tls cert.crt cert.key {
+			clients
+		}`
+	c = newTestController(params)
+	_, err = TLS(c)
+	if err == nil {
+		t.Errorf("Expected an error, but no error returned")
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -64,4 +64,5 @@ type TLSConfig struct {
 	ProtocolMinVersion       uint16
 	ProtocolMaxVersion       uint16
 	PreferServerCipherSuites bool
+	ClientCerts              []string
 }


### PR DESCRIPTION
@okket Would you please take a look and see if this does what you need?

Usage:

```
tls cert.crt key.pem {
	clients clientcert.crt
}
```

Cert files must be x509 encoded (not raw DER).