### PR TITLE
Add "without" option to proxy middleware

### DIFF
--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -34,15 +34,15 @@ type UpstreamHostDownFunc func(*UpstreamHost) bool
 // UpstreamHost represents a single proxy upstream
 type UpstreamHost struct {
 	// The hostname of this upstream host
-	Name         string
-	ReverseProxy *ReverseProxy
-	Conns        int64
-	Fails        int32
-	FailTimeout  time.Duration
-	Unhealthy    bool
-	ExtraHeaders http.Header
-	CheckDown    UpstreamHostDownFunc
-	Without      string
+	Name              string
+	ReverseProxy      *ReverseProxy
+	Conns             int64
+	Fails             int32
+	FailTimeout       time.Duration
+	Unhealthy         bool
+	ExtraHeaders      http.Header
+	CheckDown         UpstreamHostDownFunc
+	WithoutPathPrefix string
 }
 
 // Down checks whether the upstream host is down or not.
@@ -78,7 +78,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 				if baseURL, err := url.Parse(host.Name); err == nil {
 					r.Host = baseURL.Host
 					if proxy == nil {
-						proxy = NewSingleHostReverseProxy(baseURL, host.Without)
+						proxy = NewSingleHostReverseProxy(baseURL, host.WithoutPathPrefix)
 					}
 				} else if proxy == nil {
 					return http.StatusInternalServerError, err

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -42,6 +42,7 @@ type UpstreamHost struct {
 	Unhealthy    bool
 	ExtraHeaders http.Header
 	CheckDown    UpstreamHostDownFunc
+	Without      string
 }
 
 // Down checks whether the upstream host is down or not.
@@ -77,7 +78,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 				if baseURL, err := url.Parse(host.Name); err == nil {
 					r.Host = baseURL.Host
 					if proxy == nil {
-						proxy = NewSingleHostReverseProxy(baseURL)
+						proxy = NewSingleHostReverseProxy(baseURL, host.Without)
 					}
 				} else if proxy == nil {
 					return http.StatusInternalServerError, err

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -120,7 +120,7 @@ func (u *fakeUpstream) Select() *UpstreamHost {
 	uri, _ := url.Parse(u.name)
 	return &UpstreamHost{
 		Name:         u.name,
-		ReverseProxy: NewSingleHostReverseProxy(uri),
+		ReverseProxy: NewSingleHostReverseProxy(uri, ""),
 		ExtraHeaders: proxyHeaders,
 	}
 }
@@ -149,3 +149,9 @@ func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
 func (c *fakeConn) Close() error                       { return nil }
 func (c *fakeConn) Read(b []byte) (int, error)         { return c.readBuf.Read(b) }
 func (c *fakeConn) Write(b []byte) (int, error)        { return c.writeBuf.Write(b) }
+
+func newWithoutPathPrefixTestProxy(backendAddr string) *Proxy {
+	return &Proxy{
+		Upstreams: []Upstream{&fakeUpstreamWithoutPathPrefix{from: "/api/messages", withoutPathPrefix: "/api"}},
+	}
+}

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -149,9 +149,3 @@ func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
 func (c *fakeConn) Close() error                       { return nil }
 func (c *fakeConn) Read(b []byte) (int, error)         { return c.readBuf.Read(b) }
 func (c *fakeConn) Write(b []byte) (int, error)        { return c.writeBuf.Write(b) }
-
-func newWithoutPathPrefixTestProxy(backendAddr string) *Proxy {
-	return &Proxy{
-		Upstreams: []Upstream{&fakeUpstreamWithoutPathPrefix{from: "/api/messages", withoutPathPrefix: "/api"}},
-	}
-}

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -62,7 +62,9 @@ func singleJoiningSlash(a, b string) string {
 // URLs to the scheme, host, and base path provided in target. If the
 // target's path is "/base" and the incoming request was for "/dir",
 // the target request will be for /base/dir.
-func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
+// Without logic: target's path is "/", incoming is "/api/messages",
+// without is "/api", then the target request will be for /messages.
+func NewSingleHostReverseProxy(target *url.URL, without string) *ReverseProxy {
 	targetQuery := target.RawQuery
 	director := func(req *http.Request) {
 		req.URL.Scheme = target.Scheme
@@ -72,6 +74,9 @@ func NewSingleHostReverseProxy(target *url.URL) *ReverseProxy {
 			req.URL.RawQuery = targetQuery + req.URL.RawQuery
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if without != "" {
+			req.URL.Path = strings.Replace(req.URL.Path, without, "", 1)
 		}
 	}
 	return &ReverseProxy{Director: director}

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -76,7 +76,7 @@ func NewSingleHostReverseProxy(target *url.URL, without string) *ReverseProxy {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
 		if without != "" {
-			req.URL.Path = strings.Replace(req.URL.Path, without, "", 1)
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, without)
 		}
 	}
 	return &ReverseProxy{Director: director}

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -28,7 +28,7 @@ type staticUpstream struct {
 		Path     string
 		Interval time.Duration
 	}
-	Without string
+	WithoutPathPrefix string
 }
 
 // NewStaticUpstreams parses the configuration input and sets up
@@ -108,7 +108,7 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 				if !c.NextArg() {
 					return upstreams, c.ArgErr()
 				}
-				upstream.Without = c.Val()
+				upstream.WithoutPathPrefix = c.Val()
 			}
 		}
 
@@ -136,10 +136,10 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 						return false
 					}
 				}(upstream),
-				Without: upstream.Without,
+				WithoutPathPrefix: upstream.WithoutPathPrefix,
 			}
 			if baseURL, err := url.Parse(uh.Name); err == nil {
-				uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.Without)
+				uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
 			} else {
 				return upstreams, err
 			}

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -28,13 +28,13 @@ type staticUpstream struct {
 		Path     string
 		Interval time.Duration
 	}
+	Without string
 }
 
 // NewStaticUpstreams parses the configuration input and sets up
 // static upstreams for the proxy middleware.
 func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 	var upstreams []Upstream
-
 	for c.Next() {
 		upstream := &staticUpstream{
 			from:        "",
@@ -104,6 +104,11 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 			case "websocket":
 				proxyHeaders.Add("Connection", "{>Connection}")
 				proxyHeaders.Add("Upgrade", "{>Upgrade}")
+			case "without":
+				if !c.NextArg() {
+					return upstreams, c.ArgErr()
+				}
+				upstream.Without = c.Val()
 			}
 		}
 
@@ -131,9 +136,10 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 						return false
 					}
 				}(upstream),
+				Without: upstream.Without,
 			}
 			if baseURL, err := url.Parse(uh.Name); err == nil {
-				uh.ReverseProxy = NewSingleHostReverseProxy(baseURL)
+				uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.Without)
 			} else {
 				return upstreams, err
 			}


### PR DESCRIPTION
For https://github.com/mholt/caddy/issues/95

Caddyfile:
```
proxy /api localhost:9999 {
    without /api
}
```

Request ```/api/messages``` transformed to ```/messages``` and send to  localhost:9999.
