### PR TITLE
Update error strings (start with lowercase letters)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -54,7 +54,7 @@ func SetCPU(cpu string) error {
 		pctStr := cpu[:len(cpu)-1]
 		pctInt, err := strconv.Atoi(pctStr)
 		if err != nil || pctInt < 1 || pctInt > 100 {
-			return errors.New("Invalid CPU value: percentage must be between 1-100")
+			return errors.New("invalid CPU value: percentage must be between 1-100")
 		}
 		percent = float32(pctInt) / 100
 		numCPU = int(float32(availCPU) * percent)
@@ -62,7 +62,7 @@ func SetCPU(cpu string) error {
 		// Number
 		num, err := strconv.Atoi(cpu)
 		if err != nil || num < 1 {
-			return errors.New("Invalid CPU value: provide a number or percent greater than 0")
+			return errors.New("invalid CPU value: provide a number or percent greater than 0")
 		}
 		numCPU = num
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ func ArrangeBindings(allConfigs []server.Config) (map[*net.TCPAddr][]server.Conf
 	for _, conf := range allConfigs {
 		newAddr, err := net.ResolveTCPAddr("tcp", conf.Address())
 		if err != nil {
-			return addresses, errors.New("Could not serve " + conf.Address() + " - " + err.Error())
+			return addresses, errors.New("could not serve " + conf.Address() + " - " + err.Error())
 		}
 
 		// Make sure to compare the string representation of the address,
@@ -130,7 +130,7 @@ func ArrangeBindings(allConfigs []server.Config) (map[*net.TCPAddr][]server.Conf
 				if configs[0].TLS.Enabled {
 					otherConfigProto = "HTTPS"
 				}
-				return addresses, fmt.Errorf("Configuration error: Cannot multiplex %s (%s) and %s (%s) on same address",
+				return addresses, fmt.Errorf("configuration error: Cannot multiplex %s (%s) and %s (%s) on same address",
 					configs[0].Address(), otherConfigProto, config.Address(), thisConfigProto)
 			}
 		}

--- a/config/setup/browse.go
+++ b/config/setup/browse.go
@@ -33,7 +33,7 @@ func browseParse(c *Controller) ([]browse.Config, error) {
 	appendCfg := func(bc browse.Config) error {
 		for _, c := range configs {
 			if c.PathScope == bc.PathScope {
-				return fmt.Errorf("Duplicate browsing config for %s", c.PathScope)
+				return fmt.Errorf("duplicate browsing config for %s", c.PathScope)
 			}
 		}
 		configs = append(configs, bc)

--- a/config/setup/git.go
+++ b/config/setup/git.go
@@ -132,7 +132,7 @@ func gitParse(c *Controller) (*git.Repo, error) {
 		repo.URL, repo.Host, err = sanitizeGit(repo.URL)
 		// TODO add Windows support for private repos
 		if runtime.GOOS == "windows" {
-			return nil, fmt.Errorf("Private repository not yet supported on Windows")
+			return nil, fmt.Errorf("private repository not yet supported on Windows")
 		}
 	}
 
@@ -162,7 +162,7 @@ func sanitizeHTTP(repoURL string) (string, string, error) {
 		url.Path = url.Path[len("git@"):]
 		i := strings.Index(url.Path, ":")
 		if i < 0 {
-			return "", "", fmt.Errorf("Invalid git url %s", repoURL)
+			return "", "", fmt.Errorf("invalid git url %s", repoURL)
 		}
 		url.Host = url.Path[:i]
 		url.Path = "/" + url.Path[i+1:]
@@ -191,7 +191,7 @@ func sanitizeGit(repoURL string) (string, string, error) {
 		if url, err := url.Parse(repoURL); err == nil && strings.HasPrefix(url.Scheme, "http") {
 			repoURL = fmt.Sprintf("git@%v:%v", url.Host, url.Path[1:])
 		} else {
-			return "", "", fmt.Errorf("Invalid git url %s", repoURL)
+			return "", "", fmt.Errorf("invalid git url %s", repoURL)
 		}
 	}
 	hostURL := repoURL[len("git@"):]

--- a/middleware/commands.go
+++ b/middleware/commands.go
@@ -11,10 +11,10 @@ import (
 func SplitCommandAndArgs(command string) (cmd string, args []string, err error) {
 	parts, err := shlex.Split(command)
 	if err != nil {
-		err = errors.New("Error parsing command: " + err.Error())
+		err = errors.New("error parsing command: " + err.Error())
 		return
 	} else if len(parts) == 0 {
-		err = errors.New("No command contained in '" + command + "'")
+		err = errors.New("no command contained in '" + command + "'")
 		return
 	}
 

--- a/middleware/git/git.go
+++ b/middleware/git/git.go
@@ -189,11 +189,11 @@ func (r *Repo) Prepare() error {
 			}
 		}
 		if err != nil {
-			return fmt.Errorf("Cannot retrieve repo url for %v Error: %v", r.Path, err)
+			return fmt.Errorf("cannot retrieve repo url for %v Error: %v", r.Path, err)
 		}
-		return fmt.Errorf("Another git repo '%v' exists at %v", repoURL, r.Path)
+		return fmt.Errorf("another git repo '%v' exists at %v", repoURL, r.Path)
 	}
-	return fmt.Errorf("Cannot git clone into %v, directory not empty.", r.Path)
+	return fmt.Errorf("cannot git clone into %v, directory not empty.", r.Path)
 }
 
 // getMostRecentCommit gets the hash of the most recent commit to the
@@ -250,7 +250,7 @@ func Init() error {
 	// locate git binary in path
 	var err error
 	if gitBinary, err = gos.LookPath("git"); err != nil {
-		return fmt.Errorf("Git middleware requires git installed. Cannot find git binary in PATH")
+		return fmt.Errorf("git middleware requires git installed. Cannot find git binary in PATH")
 	}
 
 	// locate bash in PATH. If not found, fallback to sh.
@@ -259,7 +259,7 @@ func Init() error {
 	if _, err = gos.LookPath("bash"); err != nil {
 		shell = "sh"
 		if _, err = gos.LookPath("sh"); err != nil {
-			return fmt.Errorf("Git middleware requires either bash or sh.")
+			return fmt.Errorf("git middleware requires either bash or sh.")
 		}
 	}
 	return nil

--- a/middleware/git/git_test.go
+++ b/middleware/git/git_test.go
@@ -133,7 +133,7 @@ Command echo Hello successful.
 			continue
 		}
 
-		expected := "Another git repo 'git@github.com:u1/repo.git' exists at gitdir"
+		expected := "another git repo 'git@github.com:u1/repo.git' exists at gitdir"
 		if expected != err.Error() {
 			t.Errorf("Pull with Error %v: Expected %v found %v", i, expected, err.Error())
 		}

--- a/middleware/git/webhook/github_hook.go
+++ b/middleware/git/webhook/github_hook.go
@@ -45,7 +45,7 @@ func (g GithubHook) DoesHandle(h http.Header) bool {
 
 func (g GithubHook) Handle(w http.ResponseWriter, r *http.Request, repo *git.Repo) (int, error) {
 	if r.Method != "POST" {
-		return http.StatusMethodNotAllowed, errors.New("The request had an invalid method.")
+		return http.StatusMethodNotAllowed, errors.New("the request had an invalid method.")
 	}
 
 	// read full body - required for signature
@@ -58,7 +58,7 @@ func (g GithubHook) Handle(w http.ResponseWriter, r *http.Request, repo *git.Rep
 
 	event := r.Header.Get("X-Github-Event")
 	if event == "" {
-		return http.StatusBadRequest, errors.New("The 'X-Github-Event' header is required but was missing.")
+		return http.StatusBadRequest, errors.New("the 'X-Github-Event' header is required but was missing.")
 	}
 
 	switch event {
@@ -98,7 +98,7 @@ func (g GithubHook) handleSignature(r *http.Request, body []byte, secret string)
 			expectedMac := hex.EncodeToString(mac.Sum(nil))
 
 			if signature[5:] != expectedMac {
-				return errors.New("Could not verify request signature. The signature is invalid!")
+				return errors.New("could not verify request signature. The signature is invalid!")
 			}
 		}
 	}
@@ -118,7 +118,7 @@ func (g GithubHook) handlePush(body []byte, repo *git.Repo) error {
 	// and if it matches with our locally tracked one, pull.
 	refSlice := strings.Split(push.Ref, "/")
 	if len(refSlice) != 3 {
-		return errors.New("The push request contained an invalid reference string.")
+		return errors.New("the push request contained an invalid reference string.")
 	}
 
 	branch := refSlice[2]
@@ -139,7 +139,7 @@ func (g GithubHook) handleRelease(body []byte, repo *git.Repo) error {
 	}
 
 	if release.Release.TagName == "" {
-		return errors.New("The release request contained an invalid TagName.")
+		return errors.New("the release request contained an invalid TagName.")
 	}
 
 	logger().Printf("Received new release '%s'. -> Updating local repository to this release.\n", release.Release.Name)

--- a/middleware/gzip/gzip_test.go
+++ b/middleware/gzip/gzip_test.go
@@ -76,24 +76,24 @@ func nextFunc(shouldGzip bool) middleware.Handler {
 	return middleware.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
 		if shouldGzip {
 			if r.Header.Get("Accept-Encoding") != "" {
-				return 0, fmt.Errorf("Accept-Encoding header not expected")
+				return 0, fmt.Errorf("accept-Encoding header not expected")
 			}
 			if w.Header().Get("Content-Encoding") != "gzip" {
-				return 0, fmt.Errorf("Content-Encoding must be gzip, found %v", r.Header.Get("Content-Encoding"))
+				return 0, fmt.Errorf("content-Encoding must be gzip, found %v", r.Header.Get("Content-Encoding"))
 			}
 			if _, ok := w.(gzipResponseWriter); !ok {
-				return 0, fmt.Errorf("ResponseWriter should be gzipResponseWriter, found %T", w)
+				return 0, fmt.Errorf("responseWriter should be gzipResponseWriter, found %T", w)
 			}
 			return 0, nil
 		}
 		if r.Header.Get("Accept-Encoding") == "" {
-			return 0, fmt.Errorf("Accept-Encoding header expected")
+			return 0, fmt.Errorf("accept-Encoding header expected")
 		}
 		if w.Header().Get("Content-Encoding") == "gzip" {
-			return 0, fmt.Errorf("Content-Encoding must not be gzip, found gzip")
+			return 0, fmt.Errorf("content-Encoding must not be gzip, found gzip")
 		}
 		if _, ok := w.(gzipResponseWriter); ok {
-			return 0, fmt.Errorf("ResponseWriter should not be gzipResponseWriter")
+			return 0, fmt.Errorf("responseWriter should not be gzipResponseWriter")
 		}
 		return 0, nil
 	})

--- a/middleware/gzip/gzip_test.go
+++ b/middleware/gzip/gzip_test.go
@@ -76,24 +76,24 @@ func nextFunc(shouldGzip bool) middleware.Handler {
 	return middleware.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
 		if shouldGzip {
 			if r.Header.Get("Accept-Encoding") != "" {
-				return 0, fmt.Errorf("accept-Encoding header not expected")
+				return 0, fmt.Errorf("Accept-Encoding header not expected")
 			}
 			if w.Header().Get("Content-Encoding") != "gzip" {
-				return 0, fmt.Errorf("content-Encoding must be gzip, found %v", r.Header.Get("Content-Encoding"))
+				return 0, fmt.Errorf("Content-Encoding must be gzip, found %v", r.Header.Get("Content-Encoding"))
 			}
 			if _, ok := w.(gzipResponseWriter); !ok {
-				return 0, fmt.Errorf("responseWriter should be gzipResponseWriter, found %T", w)
+				return 0, fmt.Errorf("ResponseWriter should be gzipResponseWriter, found %T", w)
 			}
 			return 0, nil
 		}
 		if r.Header.Get("Accept-Encoding") == "" {
-			return 0, fmt.Errorf("accept-Encoding header expected")
+			return 0, fmt.Errorf("Accept-Encoding header expected")
 		}
 		if w.Header().Get("Content-Encoding") == "gzip" {
-			return 0, fmt.Errorf("content-Encoding must not be gzip, found gzip")
+			return 0, fmt.Errorf("Content-Encoding must not be gzip, found gzip")
 		}
 		if _, ok := w.(gzipResponseWriter); ok {
-			return 0, fmt.Errorf("responseWriter should not be gzipResponseWriter")
+			return 0, fmt.Errorf("ResponseWriter should not be gzipResponseWriter")
 		}
 		return 0, nil
 	})

--- a/middleware/markdown/metadata.go
+++ b/middleware/markdown/metadata.go
@@ -205,7 +205,7 @@ func extractMetadata(parser MetadataParser, b []byte) (metadata []byte, markdown
 
 	line := bytes.TrimSpace(scanner.Bytes())
 	if !bytes.Equal(line, parser.Opening()) {
-		return nil, b, fmt.Errorf("Wrong identifier")
+		return nil, b, fmt.Errorf("wrong identifier")
 	}
 
 	// buffer for metadata contents
@@ -232,7 +232,7 @@ func extractMetadata(parser MetadataParser, b []byte) (metadata []byte, markdown
 	}
 
 	// closing identifier not found
-	return buf.Bytes(), nil, fmt.Errorf("Metadata not closed. '%v' not found", string(parser.Closing()))
+	return buf.Bytes(), nil, fmt.Errorf("metadata not closed. '%v' not found", string(parser.Closing()))
 }
 
 // findParser finds the parser using line that contains opening identifier

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mholt/caddy/middleware"
 )
 
-var errUnreachable = errors.New("Unreachable backend")
+var errUnreachable = errors.New("unreachable backend")
 
 // Proxy represents a middleware instance that can proxy requests.
 type Proxy struct {

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -83,7 +83,7 @@ func NewRegexpRule(base, pattern, to string, ext []string) (*RegexpRule, error) 
 		if len(v) < 2 || (len(v) < 3 && v[0] == '!') {
 			// check if no extension is specified
 			if v != "/" && v != "!/" {
-				return nil, fmt.Errorf("Invalid extension %v", v)
+				return nil, fmt.Errorf("invalid extension %v", v)
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ func New(addr string, configs []Config, tls bool) (*Server, error) {
 
 	for _, conf := range configs {
 		if _, exists := s.vhosts[conf.Host]; exists {
-			return nil, fmt.Errorf("Cannot serve %s - host already defined for address %s", conf.Address(), s.address)
+			return nil, fmt.Errorf("cannot serve %s - host already defined for address %s", conf.Address(), s.address)
 		}
 
 		vh := virtualHost{config: conf}
@@ -175,7 +175,7 @@ func setupClientAuth(tlsConfigs []TLSConfig, config *tls.Config) error {
 					return err
 				}
 				if !pool.AppendCertsFromPEM(caCrt) {
-					return fmt.Errorf("Error loading client certificate '%s': no certificates were successfully parsed", caFile)
+					return fmt.Errorf("error loading client certificate '%s': no certificates were successfully parsed", caFile)
 				}
 			}
 		}


### PR DESCRIPTION
Error strings should not start with a capital letter because they are often prefixed with other strings.  See https://github.com/golang/go/wiki/Errors

This pull request updates all occurrences of `errors.New()` and `fmt.Errorf()` that started with uppercase letters.  The output is nicer.  For example, here's an error from a test failure before and after the change.

Before:
````
git_test.go:172: Test 5 should not error but found Private repository not yet supported on Windows
````

After:
````
git_test.go:172: Test 5 should not error but found private repository not yet supported on Windows
````