### PR TITLE
rename middleware's name from `internal` to `inner`

### DIFF
--- a/config/setup/internal.go
+++ b/config/setup/internal.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"github.com/mholt/caddy/middleware"
-	"github.com/mholt/caddy/middleware/internal"
+	"github.com/mholt/caddy/middleware/inner"
 )
 
 // Internal configures a new Internal middleware instance.
@@ -13,7 +13,7 @@ func Internal(c *Controller) (middleware.Middleware, error) {
 	}
 
 	return func(next middleware.Handler) middleware.Handler {
-		return internal.Internal{Next: next, Paths: paths}
+		return inner.Internal{Next: next, Paths: paths}
 	}, nil
 }
 

--- a/middleware/inner/internal.go
+++ b/middleware/inner/internal.go
@@ -1,7 +1,7 @@
-// Package internal provides a simple middleware that (a) prevents access
+// Package inner provides a simple middleware that (a) prevents access
 // to internal locations and (b) allows to return files from internal location
 // by setting a special header, e.g. in a proxy response.
-package internal
+package inner
 
 import (
 	"net/http"

--- a/middleware/inner/internal_test.go
+++ b/middleware/inner/internal_test.go
@@ -1,4 +1,4 @@
-package internal
+package inner
 
 import (
 	"fmt"


### PR DESCRIPTION
The internal package has the special meaning in go
(see https://golang.org/s/go14internal).
So rename it to `inner`.

Signed-off-by: Tw <tw19881113@gmail.com>