### PR TITLE
Gzip: Accept MIME types.

### DIFF
--- a/config/setup/gzip_test.go
+++ b/config/setup/gzip_test.go
@@ -59,14 +59,35 @@ func TestGzip(t *testing.T) {
 		 level 3
 		}
 		`, false},
+		{`gzip { mimes text/html
+		}`, false},
+		{`gzip { mimes text/html application/json
+		}`, false},
+		{`gzip { mimes text/html application/
+		}`, true},
+		{`gzip { mimes text/html /json
+		}`, true},
+		{`gzip { mimes /json text/html
+		}`, true},
+		{`gzip { not /file
+		 ext .html
+		 level 1
+		 mimes text/html text/plain
+		}
+		gzip { not /file1
+		 ext .htm
+		 level 3
+		 mimes text/html text/css
+		}
+		`, false},
 	}
 	for i, test := range tests {
 		c := newTestController(test.input)
 		_, err := gzipParse(c)
 		if test.shouldErr && err == nil {
-			t.Errorf("Text %v: Expected error but found nil", i)
+			t.Errorf("Test %v: Expected error but found nil", i)
 		} else if !test.shouldErr && err != nil {
-			t.Errorf("Text %v: Expected no error but found error: ", i, err)
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
 		}
 	}
 }

--- a/middleware/gzip/filter_test.go
+++ b/middleware/gzip/filter_test.go
@@ -47,13 +47,13 @@ func TestSet(t *testing.T) {
 }
 
 func TestExtFilter(t *testing.T) {
-	var filter Filter = DefaultExtFilter()
-	_ = filter.(ExtFilter)
-	for i, e := range textExts {
-		r := urlRequest("file" + e)
-		if !filter.ShouldCompress(r) {
-			t.Errorf("Test %v: Should be valid filter", i)
-		}
+	var filter Filter = ExtFilter{make(Set)}
+	for _, e := range []string{".txt", ".html", ".css", ".md"} {
+		filter.(ExtFilter).Exts.Add(e)
+	}
+	r := urlRequest("file.txt")
+	if !filter.ShouldCompress(r) {
+		t.Errorf("Should be valid filter")
 	}
 	var exts = []string{
 		".html", ".css", ".md",
@@ -96,6 +96,32 @@ func TestPathFilter(t *testing.T) {
 		r := urlRequest(p)
 		if !filter.ShouldCompress(r) {
 			t.Errorf("Test %v: Should be valid filter", i)
+		}
+	}
+}
+
+func TestMIMEFilter(t *testing.T) {
+	var filter Filter = DefaultMIMEFilter()
+	_ = filter.(MIMEFilter)
+	var mimes = []string{
+		"text/html", "text/css", "application/json",
+	}
+	for i, m := range mimes {
+		r := urlRequest("file" + m)
+		r.Header.Set("Content-Type", m)
+		if !filter.ShouldCompress(r) {
+			t.Errorf("Test %v: Should be valid filter", i)
+		}
+	}
+	mimes = []string{
+		"image/jpeg", "image/png",
+	}
+	filter = DefaultMIMEFilter()
+	for i, m := range mimes {
+		r := urlRequest("file" + m)
+		r.Header.Set("Content-Type", m)
+		if filter.ShouldCompress(r) {
+			t.Errorf("Test %v: Should not be valid filter", i)
 		}
 	}
 }


### PR DESCRIPTION
Gzip now accepts MIME types.
```
gzip {
    mimes mime_types
}
```
mime_types - space separated list of MIME types. e.g. `text/html text/css`. If specified overrides default.
Default: `text/plain text/html text/css application/json application/javascript text/x-markdown text/xml application/xml`

Other filters `not` and `ext` are still supported.

Only either of MIME types `mimes` or File extension `ext` should be specified. If both are specified, `mimes` is preferred to `ext`. The hierarchy is `mimes` > `ext` > `Default mimes`.