### PR TITLE
fix #127

### DIFF
--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -380,7 +380,7 @@ func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 		if err != nil {
 			return
 		}
-		if len(statusParts) > 0 {
+		if len(statusParts) > 1 {
 			resp.Status = statusParts[1]	
 		}
 		

--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -375,21 +375,15 @@ func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 	resp.Header = http.Header(mimeHeader)
 
 	if resp.Header.Get("Status") != "" {
-		
-		// check if Status is long enought to split
-		if strings.Count(resp.Header.Get("Status"), " ") > 0 {
-			statusParts := strings.SplitN(resp.Header.Get("Status"), " ", 2)
-			resp.StatusCode, err = strconv.Atoi(statusParts[0])
-			resp.Status = statusParts[1]
-			resp.Status = statusParts[1]
-		} else {
-			resp.StatusCode, err = strconv.Atoi(resp.Header.Get("Status"))
-		}
-	
+		statusParts := strings.SplitN(resp.Header.Get("Status"), " ", 2)
+		resp.StatusCode, err = strconv.Atoi(statusParts[0])
 		if err != nil {
 			return
 		}
-	
+		if (len(statusParts) > 0) {
+			resp.Status = statusParts[1]	
+		}
+		
 	} else {
 		resp.StatusCode = http.StatusOK
 	}

--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -375,12 +375,21 @@ func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 	resp.Header = http.Header(mimeHeader)
 
 	if resp.Header.Get("Status") != "" {
-		statusParts := strings.SplitN(resp.Header.Get("Status"), " ", 2)
-		resp.StatusCode, err = strconv.Atoi(statusParts[0])
+		
+		// check if Status is long enought to split
+		if strings.Count(resp.Header.Get("Status"), " ") > 0 {
+			statusParts := strings.SplitN(resp.Header.Get("Status"), " ", 2)
+			resp.StatusCode, err = strconv.Atoi(statusParts[0])
+			resp.Status = statusParts[1]
+			resp.Status = statusParts[1]
+		} else {
+			resp.StatusCode, err = strconv.Atoi(resp.Header.Get("Status"))
+		}
+	
 		if err != nil {
 			return
 		}
-		resp.Status = statusParts[1]
+	
 	} else {
 		resp.StatusCode = http.StatusOK
 	}

--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -380,7 +380,7 @@ func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 		if err != nil {
 			return
 		}
-		if (len(statusParts) > 0) {
+		if len(statusParts) > 0 {
 			resp.Status = statusParts[1]	
 		}
 		


### PR DESCRIPTION
fixes issue with Status header coming from php-fpm 5.5 different then regular "HTTP/1.1 200 OK".
If server returns  status code - "200" will be handled properly instead "throwing runtime error: index out of range"