### PR TITLE
change from error to a warning in errors setup

### DIFF
--- a/config/setup/errors.go
+++ b/config/setup/errors.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -68,7 +69,7 @@ func errorsParse(c *Controller) (*errors.ErrorHandler, error) {
 				where = path.Join(c.Root, where)
 				f, err := os.Open(where)
 				if err != nil {
-					return hadBlock, c.Err("Unable to open error page '" + where + "': " + err.Error())
+					fmt.Println("Warning: Unable to open error page '" + where + "': " + err.Error())
 				}
 				f.Close()
 


### PR DESCRIPTION
When checking if a file exist in errors config parse, print a warning instead of terminate