### PR TITLE
core: Handle address lookup and bind errors more gracefully (fixes #136 and #164)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,9 @@ func TestReolveAddr(t *testing.T) {
 	// If that happens, maybe we should use actualAddr.IP.IsLoopback()
 	// for the assertion, rather than a direct string comparison.
 
+	// NOTE: Tests with {Host: "", Port: ""} and {Host: "localhost", Port: ""}
+	// will not behave the same cross-platform, so they have bene omitted.
+
 	for i, test := range []struct {
 		config         server.Config
 		shouldWarnErr  bool
@@ -24,8 +27,6 @@ func TestReolveAddr(t *testing.T) {
 		{server.Config{Host: "should-not-resolve", Port: "1234"}, true, false, "0.0.0.0", 1234},
 		{server.Config{Host: "localhost", Port: "http"}, false, false, "127.0.0.1", 80},
 		{server.Config{Host: "localhost", Port: "https"}, false, false, "127.0.0.1", 443},
-		{server.Config{Host: "", Port: ""}, false, true, "", 0},
-		{server.Config{Host: "localhost", Port: ""}, false, true, "127.0.0.1", 0},
 		{server.Config{Host: "", Port: "1234"}, false, false, "<nil>", 1234},
 		{server.Config{Host: "localhost", Port: "abcd"}, false, true, "", 0},
 		{server.Config{BindHost: "127.0.0.1", Host: "should-not-be-used", Port: "1234"}, false, false, "127.0.0.1", 1234},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy/server"
+)
+
+func TestReolveAddr(t *testing.T) {
+	// NOTE: If tests fail due to comparing to string "127.0.0.1",
+	// it's possible that system env resolves with IPv6, or ::1.
+	// If that happens, maybe we should use actualAddr.IP.IsLoopback()
+	// for the assertion, rather than a direct string comparison.
+
+	for i, test := range []struct {
+		config         server.Config
+		shouldWarnErr  bool
+		shouldFatalErr bool
+		expectedIP     string
+		expectedPort   int
+	}{
+		{server.Config{Host: "localhost", Port: "1234"}, false, false, "127.0.0.1", 1234},
+		{server.Config{Host: "127.0.0.1", Port: "1234"}, false, false, "127.0.0.1", 1234},
+		{server.Config{Host: "should-not-resolve", Port: "1234"}, true, false, "0.0.0.0", 1234},
+		{server.Config{Host: "localhost", Port: "http"}, false, false, "127.0.0.1", 80},
+		{server.Config{Host: "localhost", Port: "https"}, false, false, "127.0.0.1", 443},
+		{server.Config{Host: "", Port: ""}, false, true, "", 0},
+		{server.Config{Host: "localhost", Port: ""}, false, true, "127.0.0.1", 0},
+		{server.Config{Host: "", Port: "1234"}, false, false, "<nil>", 1234},
+		{server.Config{Host: "localhost", Port: "abcd"}, false, true, "", 0},
+		{server.Config{BindHost: "127.0.0.1", Host: "should-not-be-used", Port: "1234"}, false, false, "127.0.0.1", 1234},
+		{server.Config{BindHost: "localhost", Host: "should-not-be-used", Port: "1234"}, false, false, "127.0.0.1", 1234},
+		{server.Config{BindHost: "should-not-resolve", Host: "localhost", Port: "1234"}, true, false, "0.0.0.0", 1234},
+	} {
+		actualAddr, warnErr, fatalErr := resolveAddr(test.config)
+
+		if test.shouldFatalErr && fatalErr == nil {
+			t.Errorf("Test %d: Expected error, but there wasn't any", i)
+		}
+		if !test.shouldFatalErr && fatalErr != nil {
+			t.Errorf("Test %d: Expected no error, but there was one: %v", i, fatalErr)
+		}
+		if fatalErr != nil {
+			continue
+		}
+
+		if test.shouldWarnErr && warnErr == nil {
+			t.Errorf("Test %d: Expected warning, but there wasn't any", i)
+		}
+		if !test.shouldWarnErr && warnErr != nil {
+			t.Errorf("Test %d: Expected no warning, but there was one: %v", i, warnErr)
+		}
+
+		if actual, expected := actualAddr.IP.String(), test.expectedIP; actual != expected {
+			t.Errorf("Test %d: IP was %s but expected %s", i, actual, expected)
+		}
+		if actual, expected := actualAddr.Port, test.expectedPort; actual != expected {
+			t.Errorf("Test %d: Port was %d but expected %d", i, actual, expected)
+		}
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -47,9 +47,6 @@ type Config struct {
 
 // Address returns the host:port of c as a string.
 func (c Config) Address() string {
-	if c.BindHost != "" {
-		return net.JoinHostPort(c.BindHost, c.Port)
-	}
 	return net.JoinHostPort(c.Host, c.Port)
 }
 


### PR DESCRIPTION
Addresses which fail to resolve are handled more gracefully in the two most common cases: the hostname doesn't resolve or the port is unknown (like "http" or "https" on a system that doesn't support those port names). If the hostname doesn't resolve, the host is served on the listener at host 0.0.0.0. If the port is unknown, we attempt to rewrite it as a number manually and try again.

/cc @wmark and @coolaj86 - would you please take a look at this and see if this will do?