### PR TITLE
Enhancements to Markdown

### DIFF
--- a/config/setup/markdown.go
+++ b/config/setup/markdown.go
@@ -34,6 +34,10 @@ func Markdown(c *Controller) (middleware.Middleware, error) {
 				continue
 			}
 
+			if err := markdown.GenerateLinks(md, &cfg); err != nil {
+				return err
+			}
+
 			// If generated site already exists, clear it out
 			_, err := os.Stat(cfg.StaticDir)
 			if err == nil {

--- a/middleware/markdown/markdown.go
+++ b/middleware/markdown/markdown.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mholt/caddy/middleware"
 	"github.com/russross/blackfriday"
+	//	"log"
 )
 
 // Markdown implements a layer of middleware that serves
@@ -64,6 +65,9 @@ type Config struct {
 	// Map of request URL to static files generated
 	StaticFiles map[string]string
 
+	// Links to all markdown pages ordered by date.
+	Links []PageLink
+
 	// Directory to store static files
 	StaticDir string
 }
@@ -112,6 +116,15 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 							return http.StatusNotFound, nil
 						}
 					}
+				}
+
+				if m.StaticDir != "" {
+					// Markdown modified or new. Update links.
+					//					go func() {
+					//						if err := GenerateLinks(md, &md.Configs[i]); err != nil {
+					//							log.Println(err)
+					//						}
+					//					}()
 				}
 
 				body, err := ioutil.ReadAll(f)

--- a/middleware/markdown/metadata_test.go
+++ b/middleware/markdown/metadata_test.go
@@ -11,13 +11,11 @@ import (
 var TOML = [4]string{`
 title = "A title"
 template = "default"
-[variables]
 name = "value"
 `,
 	`+++
 title = "A title"
 template = "default"
-[variables]
 name = "value"
 +++
 Page content
@@ -25,7 +23,6 @@ Page content
 	`+++
 title = "A title"
 template = "default"
-[variables]
 name = "value"
 	`,
 	`title = "A title" template = "default" [variables] name = "value"`,
@@ -34,38 +31,31 @@ name = "value"
 var YAML = [4]string{`
 title : A title
 template : default
-variables :
-  name : value
+name : value
 `,
 	`---
 title : A title
 template : default
-variables :
-  name : value
+name : value
 ---
 Page content
 `,
 	`---
 title : A title
 template : default
-variables :
-  name : value
+name : value
 `,
 	`title : A title template : default variables : name : value`,
 }
 var JSON = [4]string{`
 	"title" : "A title",
 	"template" : "default",
-	"variables" : {
-		"name" : "value"
-	}
+	"name" : "value"
 `,
 	`{
 	"title" : "A title",
 	"template" : "default",
-	"variables" : {
-		"name" : "value"
-	}
+	"name" : "value"
 }
 Page content
 `,
@@ -73,17 +63,13 @@ Page content
 {
 	"title" : "A title",
 	"template" : "default",
-	"variables" : {
-		"name" : "value"
-	}
+	"name" : "value"
 `,
 	`
 {{
 	"title" : "A title",
 	"template" : "default",
-	"variables" : {
-		"name" : "value"
-	}
+	"name" : "value"
 }
 	`,
 }
@@ -96,9 +82,13 @@ func check(t *testing.T, err error) {
 
 func TestParsers(t *testing.T) {
 	expected := Metadata{
-		Title:     "A title",
-		Template:  "default",
-		Variables: map[string]string{"name": "value"},
+		Title:    "A title",
+		Template: "default",
+		Variables: map[string]string{
+			"name":     "value",
+			"title":    "A title",
+			"template": "default",
+		},
 	}
 	compare := func(m Metadata) bool {
 		if m.Title != expected.Title {
@@ -112,7 +102,7 @@ func TestParsers(t *testing.T) {
 				return false
 			}
 		}
-		return len(m.Variables) == 1
+		return len(m.Variables) == len(expected.Variables)
 	}
 
 	data := []struct {
@@ -120,9 +110,9 @@ func TestParsers(t *testing.T) {
 		testData [4]string
 		name     string
 	}{
-		{&JSONMetadataParser{}, JSON, "json"},
-		{&YAMLMetadataParser{}, YAML, "yaml"},
-		{&TOMLMetadataParser{}, TOML, "toml"},
+		{&JSONMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, JSON, "json"},
+		{&YAMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, YAML, "yaml"},
+		{&TOMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, TOML, "toml"},
 	}
 
 	for _, v := range data {

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -28,12 +28,12 @@ type PageLink struct {
 	Url     string
 }
 
-// pageLinkSorter sorts PageLink by newest date to oldest.
-type pageLinkSorter []PageLink
+// byDate sorts PageLink by newest date to oldest.
+type byDate []PageLink
 
-func (p pageLinkSorter) Len() int           { return len(p) }
-func (p pageLinkSorter) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p pageLinkSorter) Less(i, j int) bool { return p[i].Date.After(p[j].Date) }
+func (p byDate) Len() int           { return len(p) }
+func (p byDate) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p byDate) Less(i, j int) bool { return p[i].Date.After(p[j].Date) }
 
 type linkGen struct {
 	generating bool
@@ -120,7 +120,7 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) {
 	})
 
 	// sort by newest date
-	sort.Sort(pageLinkSorter(cfg.Links))
+	sort.Sort(byDate(cfg.Links))
 	cfg.Unlock()
 
 	l.Lock()

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -1,0 +1,103 @@
+package markdown
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/russross/blackfriday"
+)
+
+var (
+	pagesMutex      sync.RWMutex
+	linksGenerating bool
+)
+
+const (
+	timeLayout = `2006-01-02 15:04:05`
+	summaryLen = 150
+)
+
+// Page represents a statically generated markdown page.
+type PageLink struct {
+	Title   string
+	Summary string
+	Date    time.Time
+	Url     string
+}
+
+// pageLinkSorter sort PageLink by newest date to oldest.
+type pageLinkSorter []PageLink
+
+func (p pageLinkSorter) Len() int           { return len(p) }
+func (p pageLinkSorter) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p pageLinkSorter) Less(i, j int) bool { return p[i].Date.After(p[j].Date) }
+
+func GenerateLinks(md Markdown, cfg *Config) error {
+	if linksGenerating {
+		return nil
+	}
+
+	pagesMutex.Lock()
+	linksGenerating = true
+
+	fp := filepath.Join(md.Root, cfg.PathScope)
+
+	cfg.Links = []PageLink{}
+	err := filepath.Walk(fp, func(path string, info os.FileInfo, err error) error {
+		for _, ext := range cfg.Extensions {
+			if !info.IsDir() && strings.HasSuffix(info.Name(), ext) {
+				// Load the file
+				body, err := ioutil.ReadFile(path)
+				if err != nil {
+					return err
+				}
+
+				// Get the relative path as if it were a HTTP request,
+				// then prepend with "/" (like a real HTTP request)
+				reqPath, err := filepath.Rel(md.Root, path)
+				if err != nil {
+					return err
+				}
+				reqPath = "/" + reqPath
+
+				parser := findParser(body)
+				if parser == nil {
+					// no metadata, ignore.
+					continue
+				}
+				summary, err := parser.Parse(body)
+				if err != nil {
+					return err
+				}
+
+				if len(summary) > summaryLen {
+					summary = summary[:summaryLen]
+				}
+
+				metadata := parser.Metadata()
+
+				cfg.Links = append(cfg.Links, PageLink{
+					Title:   metadata.Title,
+					Url:     reqPath,
+					Date:    metadata.Date,
+					Summary: string(blackfriday.Markdown(summary, PlaintextRenderer{}, 0)),
+				})
+
+				break // don't try other file extensions
+			}
+		}
+
+		// sort by newest date
+		sort.Sort(pageLinkSorter(cfg.Links))
+		return nil
+	})
+
+	linksGenerating = false
+	pagesMutex.Unlock()
+	return err
+}

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -20,7 +20,8 @@ const (
 
 type MarkdownData struct {
 	middleware.Context
-	Doc map[string]string
+	Doc   map[string]string
+	Links []PageLink
 }
 
 // Process processes the contents of a page in b. It parses the metadata
@@ -97,9 +98,14 @@ func (md Markdown) processTemplate(c Config, requestPath string, tmpl []byte, me
 	mdData := MarkdownData{
 		Context: ctx,
 		Doc:     metadata.Variables,
+		Links:   c.Links,
 	}
 
-	if err = t.Execute(b, mdData); err != nil {
+	pagesMutex.RLock()
+	err = t.Execute(b, mdData)
+	pagesMutex.RUnlock()
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -101,9 +101,9 @@ func (md Markdown) processTemplate(c Config, requestPath string, tmpl []byte, me
 		Links:   c.Links,
 	}
 
-	pagesMutex.RLock()
+	c.RLock()
 	err = t.Execute(b, mdData)
-	pagesMutex.RUnlock()
+	c.RUnlock()
 
 	if err != nil {
 		return nil, err

--- a/middleware/markdown/renderer.go
+++ b/middleware/markdown/renderer.go
@@ -1,0 +1,93 @@
+package markdown
+
+import (
+	"bytes"
+)
+
+type PlaintextRenderer struct{}
+
+// Block-level callbacks
+
+func (r PlaintextRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {}
+
+func (r PlaintextRenderer) BlockQuote(out *bytes.Buffer, text []byte) {}
+
+func (r PlaintextRenderer) BlockHtml(out *bytes.Buffer, text []byte) {}
+
+func (r PlaintextRenderer) Header(out *bytes.Buffer, text func() bool, level int, id string) {}
+
+func (r PlaintextRenderer) HRule(out *bytes.Buffer) {}
+
+func (r PlaintextRenderer) List(out *bytes.Buffer, text func() bool, flags int) {}
+
+func (r PlaintextRenderer) ListItem(out *bytes.Buffer, text []byte, flags int) {}
+
+func (r PlaintextRenderer) Paragraph(out *bytes.Buffer, text func() bool) {
+	marker := out.Len()
+	if !text() {
+		out.Truncate(marker)
+	}
+	out.Write([]byte{' '})
+}
+
+func (r PlaintextRenderer) Table(out *bytes.Buffer, header []byte, body []byte, columnData []int) {}
+
+func (r PlaintextRenderer) TableRow(out *bytes.Buffer, text []byte) {}
+
+func (r PlaintextRenderer) TableHeaderCell(out *bytes.Buffer, text []byte, flags int) {}
+
+func (r PlaintextRenderer) TableCell(out *bytes.Buffer, text []byte, flags int) {}
+
+func (r PlaintextRenderer) Footnotes(out *bytes.Buffer, text func() bool) {}
+
+func (r PlaintextRenderer) FootnoteItem(out *bytes.Buffer, name, text []byte, flags int) {}
+
+func (r PlaintextRenderer) TitleBlock(out *bytes.Buffer, text []byte) {}
+
+// Span-level callbacks
+
+func (r PlaintextRenderer) AutoLink(out *bytes.Buffer, link []byte, kind int) {}
+
+func (r PlaintextRenderer) CodeSpan(out *bytes.Buffer, text []byte) {}
+
+func (r PlaintextRenderer) DoubleEmphasis(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (r PlaintextRenderer) Emphasis(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (r PlaintextRenderer) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {}
+
+func (r PlaintextRenderer) LineBreak(out *bytes.Buffer) {}
+
+func (r PlaintextRenderer) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+	out.Write(content)
+}
+func (r PlaintextRenderer) RawHtmlTag(out *bytes.Buffer, tag []byte) {}
+
+func (r PlaintextRenderer) TripleEmphasis(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+func (r PlaintextRenderer) StrikeThrough(out *bytes.Buffer, text []byte) {}
+
+func (r PlaintextRenderer) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {}
+
+// Low-level callbacks
+
+func (r PlaintextRenderer) Entity(out *bytes.Buffer, entity []byte) {
+	out.Write(entity)
+}
+
+func (r PlaintextRenderer) NormalText(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+// Header and footer
+
+func (r PlaintextRenderer) DocumentHeader(out *bytes.Buffer) {}
+
+func (r PlaintextRenderer) DocumentFooter(out *bytes.Buffer) {}
+
+func (r PlaintextRenderer) GetFlags() int { return 0 }

--- a/middleware/markdown/testdata/blog/test.md
+++ b/middleware/markdown/testdata/blog/test.md
@@ -1,7 +1,6 @@
 ---
 title: Markdown test
-variables:
-    sitename: A Caddy website
+sitename: A Caddy website
 ---
 
 ## Welcome on the blog

--- a/middleware/markdown/testdata/log/test.md
+++ b/middleware/markdown/testdata/log/test.md
@@ -1,7 +1,6 @@
 ---
 title: Markdown test
-variables:
-    sitename: A Caddy website
+sitename: A Caddy website
 ---
 
 ## Welcome on the blog


### PR DESCRIPTION
This includes bug fixes and mainly an enhancement to Markdown to provide blogging capability.

* Metadata variables are now flattened. No need for the `variables` block/object.
* Links to all available markdown files are now available and can be used in templates ordered by newest to oldest. Accessible via `{{.Links}}`.
 Example below. 
```html
{{ range .Links }}
	<h3>
		<a href="{{ .Url }}"> {{ .Title }} </a>
	</h3>
	<p>
		{{ .Summary }}
		<br />
		{{ .Date.Format "Jan 02, 2006 15:04:05 UTC" }}
	<p>
{{ end }}
```
a Link contains 
```go 
Title   string
Summary string
Date    time.Time
Url     string
```
* `date` can now be specified in metadata. This is used for ordering links and can be referenced in templates. Dates are only valid if specified in the format `YYYY-MM-DD HH:MM:SS`. Hopefully, this can be loosen.

##### Still to come
* Pagination
* Grouping (by tags).