### PR TITLE
Markdown: Watch for file changes for links. Removed sitegen dependency for links.

### DIFF
--- a/config/setup/markdown.go
+++ b/config/setup/markdown.go
@@ -36,10 +36,8 @@ func Markdown(c *Controller) (middleware.Middleware, error) {
 			if err := markdown.GenerateLinks(md, cfg); err != nil {
 				return err
 			}
-			// Watch file changes for links generation.
-			if cfg.Development {
-				markdown.Watch(md, cfg, 0)
-			} else {
+			// Watch file changes for links generation if not in development mode.
+			if !cfg.Development {
 				markdown.Watch(md, cfg, markdown.DefaultInterval)
 			}
 

--- a/config/setup/markdown.go
+++ b/config/setup/markdown.go
@@ -162,7 +162,7 @@ func markdownParse(c *Controller) ([]markdown.Config, error) {
 					// only 1 argument allowed
 					return mdconfigs, c.ArgErr()
 				}
-			case "development":
+			case "dev":
 				if c.NextArg() {
 					md.Development = strings.ToLower(c.Val()) == "true"
 				} else {

--- a/middleware/markdown/markdown.go
+++ b/middleware/markdown/markdown.go
@@ -4,6 +4,7 @@ package markdown
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -117,6 +118,13 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 				fs, err := f.Stat()
 				if err != nil {
 					return http.StatusNotFound, nil
+				}
+
+				// if development is set, scan directory for file changes for links.
+				if m.Development {
+					if err := GenerateLinks(md, m); err != nil {
+						log.Println(err)
+					}
 				}
 
 				// if static site is generated, attempt to use it

--- a/middleware/markdown/markdown.go
+++ b/middleware/markdown/markdown.go
@@ -4,7 +4,6 @@ package markdown
 
 import (
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -69,10 +68,27 @@ type Config struct {
 	// Links to all markdown pages ordered by date.
 	Links []PageLink
 
+	// Stores a directory hash to check for changes.
+	linksHash string
+
 	// Directory to store static files
 	StaticDir string
 
+	// If in development mode. i.e. Actively editing markdown files.
+	Development bool
+
 	sync.RWMutex
+}
+
+// IsValidExt checks to see if an extension is a valid markdown extension
+// for config.
+func (c Config) IsValidExt(ext string) bool {
+	for _, e := range c.Extensions {
+		if e == ext {
+			return true
+		}
+	}
+	return false
 }
 
 // ServeHTTP implements the http.Handler interface.
@@ -119,13 +135,6 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 							}
 							return http.StatusNotFound, nil
 						}
-					}
-				}
-
-				if m.StaticDir != "" {
-					// Markdown modified or new. Update links.
-					if err := GenerateLinks(md, m); err != nil {
-						log.Println(err)
 					}
 				}
 

--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -199,7 +199,7 @@ func getTrue() bool {
 		}
 	}
 
-	// attempt to trigger race condition
+	// attempt to trigger race conditions
 	var w sync.WaitGroup
 	f := func() {
 		req, err := http.NewRequest("GET", "/log/test.md", nil)
@@ -209,6 +209,16 @@ func getTrue() bool {
 		rec := httptest.NewRecorder()
 
 		md.ServeHTTP(rec, req)
+		w.Done()
+	}
+	for i := 0; i < 5; i++ {
+		w.Add(1)
+		go f()
+	}
+	w.Wait()
+
+	f = func() {
+		GenerateLinks(md, &md.Configs[0])
 		w.Done()
 	}
 	for i := 0; i < 5; i++ {

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -79,6 +79,7 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) {
 	if _, err := os.Stat(fp); os.IsNotExist(err) {
 		l.Lock()
 		l.lastErr = err
+		l.generating = false
 		l.Unlock()
 		return
 	}
@@ -87,6 +88,9 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) {
 
 	// same hash, return.
 	if err == nil && hash == cfg.linksHash {
+		l.Lock()
+		l.generating = false
+		l.Unlock()
 		return
 	} else if err != nil {
 		log.Println("Error:", err)

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -2,7 +2,11 @@ package markdown
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -79,6 +83,15 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) {
 		return
 	}
 
+	hash, err := computeDirHash(md, *cfg)
+
+	// same hash, return.
+	if err == nil && hash == cfg.linksHash {
+		return
+	} else if err != nil {
+		log.Println("Error:", err)
+	}
+
 	cfg.Links = []PageLink{}
 
 	cfg.Lock()
@@ -138,6 +151,8 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) {
 
 	// sort by newest date
 	sort.Sort(byDate(cfg.Links))
+
+	cfg.linksHash = hash
 	cfg.Unlock()
 
 	l.Lock()
@@ -175,4 +190,26 @@ func GenerateLinks(md Markdown, cfg *Config) error {
 	g.generateLinks(md, cfg)
 	g.discardWaiters()
 	return g.lastErr
+}
+
+// computeDirHash computes an hash on static directory of c.
+func computeDirHash(md Markdown, c Config) (string, error) {
+	dir := filepath.Join(md.Root, c.PathScope)
+	if _, err := os.Stat(dir); err != nil {
+		return "", err
+	}
+
+	hashString := ""
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && c.IsValidExt(filepath.Ext(path)) {
+			hashString += fmt.Sprintf("%v%v%v%v", info.ModTime(), info.Name(), info.Size(), path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha1.Sum([]byte(hashString))
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/middleware/markdown/testdata/og/first.md
+++ b/middleware/markdown/testdata/og/first.md
@@ -1,1 +1,5 @@
+---
+title: first_post
+sitename: title
+---
 # Test h1

--- a/middleware/markdown/testdata/og_static/og/first.md/index.html
+++ b/middleware/markdown/testdata/og_static/og/first.md/index.html
@@ -1,7 +1,8 @@
+
 <!DOCTYPE html>
 <html>
 <head>
-<title>first_post</title>
+    <title>first_post</title>
 </head>
 <body>
 <h1>Header title</h1>

--- a/middleware/markdown/watcher.go
+++ b/middleware/markdown/watcher.go
@@ -2,10 +2,7 @@ package markdown
 
 import "time"
 
-const (
-	DefaultInterval = time.Second * 60
-	DevInterval     = time.Second * 1
-)
+const DefaultInterval = time.Second * 60
 
 // Watch monitors the configured markdown directory for changes. It calls GenerateLinks
 // when there are changes.

--- a/middleware/markdown/watcher.go
+++ b/middleware/markdown/watcher.go
@@ -20,39 +20,19 @@ func Watch(md Markdown, c *Config, interval time.Duration) (stopChan chan struct
 func TickerFunc(interval time.Duration, f func()) chan struct{} {
 	stopChan := make(chan struct{})
 
-	if interval > 0 {
-		ticker := time.NewTicker(interval)
-		go func() {
-		loop:
-			for {
-				select {
-				case <-ticker.C:
-					f()
-				case <-stopChan:
-					ticker.Stop()
-					break loop
-				}
+	ticker := time.NewTicker(interval)
+	go func() {
+	loop:
+		for {
+			select {
+			case <-ticker.C:
+				f()
+			case <-stopChan:
+				ticker.Stop()
+				break loop
 			}
-		}()
-	} else {
-		go func() {
-		loop:
-			for {
-				m := make(chan struct{})
-				go func() {
-					f()
-					m <- struct{}{}
-				}()
-				select {
-				case <-m:
-					continue loop
-				case <-stopChan:
-					break loop
-				}
-				time.Sleep(DevInterval)
+		}
+	}()
 
-			}
-		}()
-	}
 	return stopChan
 }

--- a/middleware/markdown/watcher_test.go
+++ b/middleware/markdown/watcher_test.go
@@ -1,0 +1,34 @@
+package markdown
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWatcher(t *testing.T) {
+	expected := "12345678"
+	interval := time.Millisecond * 100
+	i := 0
+	out := ""
+	stopChan := TickerFunc(interval, func() {
+		i++
+		out += fmt.Sprint(i)
+	})
+	time.Sleep(interval * 8)
+	stopChan <- struct{}{}
+	if expected != out {
+		t.Fatalf("Expected %v, found %v", expected, out)
+	}
+	out = ""
+	i = 0
+	stopChan = TickerFunc(interval, func() {
+		i++
+		out += fmt.Sprint(i)
+	})
+	time.Sleep(interval * 10)
+	if !strings.HasPrefix(out, expected) || out == expected {
+		t.Fatalf("expected (%v) must be a proper prefix of out(%v).", expected, out)
+	}
+}


### PR DESCRIPTION
* Markdown now watches for site changes for link generation. 
* `sitegen` config no longer required for links generation.
* `dev` config option added to change link generation to page loads rather than having to wait 60s for updated index (useful when actively editing Markdown files)