### PR TITLE
Add JSON option for the browse middleware

### DIFF
--- a/middleware/browse/browse.go
+++ b/middleware/browse/browse.go
@@ -4,12 +4,14 @@ package browse
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -185,7 +187,6 @@ func directoryListing(files []os.FileInfo, r *http.Request, canGoUp bool, root s
 // ServeHTTP implements the middleware.Handler interface.
 func (b Browse) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	filename := b.Root + r.URL.Path
-
 	info, err := os.Stat(filename)
 	if err != nil {
 		return b.Next.ServeHTTP(w, r)
@@ -264,12 +265,47 @@ func (b Browse) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		listing.applySort()
 
 		var buf bytes.Buffer
-		err = bc.Template.Execute(&buf, listing)
-		if err != nil {
-			return http.StatusInternalServerError, err
+		// check if we should provide json
+		acceptHeader := strings.Join(r.Header["Accept"], ",")
+		if strings.Contains(strings.ToLower(acceptHeader), "application/json") {
+			var marsh []byte
+			// check if we are limited
+			if limitQuery := r.URL.Query().Get("limit"); limitQuery != "" {
+				limit, err := strconv.Atoi(limitQuery)
+				if err != nil { // if the 'limit' query can't be interpreted as a number, return err
+					return http.StatusBadRequest, err
+				}
+				// if `limit` is equal or less than len(listing.Items) and bigger than 0, list them
+				if limit <= len(listing.Items) && limit > 0 {
+					marsh, err = json.Marshal(listing.Items[:limit])
+				} else { // if the 'limit' query is empty, or has the wrong value, list everything
+					marsh, err = json.Marshal(listing.Items)
+				}
+				if err != nil {
+					return http.StatusInternalServerError, err
+				}
+			} else { // there's no 'limit' query, list them all
+				marsh, err = json.Marshal(listing.Items)
+				if err != nil {
+					return http.StatusInternalServerError, err
+				}
+			}
+
+			// write the marshaled json to buf
+			if _, err = buf.Write(marsh); err != nil {
+				return http.StatusInternalServerError, err
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		} else { // there's no json query, browse normally
+			err = bc.Template.Execute(&buf, listing)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
 		}
 
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		buf.WriteTo(w)
 
 		return http.StatusOK, nil


### PR DESCRIPTION
we already have the option to sort the browse listing via queries, now we can pass `json=true` to get back a JSON representation of the files.

`127.0.0.1:2015/?json=true`
```JSON
[
	{
		"IsDir": true,
		"Name": "server",
		"Size": 204,
		"URL": "server/",
		"ModTime": "2015-08-17T21:28:46+03:00",
		"Mode": 2147484141
	},
	{
		"IsDir": false,
		"Name": "README.md",
		"Size": 4960,
		"URL": "README.md",
		"ModTime": "2015-08-17T21:28:46+03:00",
		"Mode": 420
	},
	{
		"IsDir": true,
		"Name": "middleware",
		"Size": 850,
		"URL": "middleware/",
		"ModTime": "2015-08-17T21:28:46+03:00",
		"Mode": 2147484141
	},......etc

```

it is possible also to pass an `items` query to get a specific number of files back, so the following will give you the biggest two files

`127.0.0.1:2015/?sort=size&order=desc&json=true&items=2`
```JSON
[
	{
		"IsDir": false,
		"Name": "LICENSE.txt",
		"Size": 11357,
		"URL": "LICENSE.txt",
		"ModTime": "2015-08-17T21:28:46+03:00",
		"Mode": 420
	},
	{
		"IsDir": false,
		"Name": "README.md",
		"Size": 4960,
		"URL": "README.md",
		"ModTime": "2015-08-17T21:28:46+03:00",
		"Mode": 420
	}
]
```