### PR TITLE
Use localtime for the log roller timestamp

### DIFF
--- a/config/setup/errors_test.go
+++ b/config/setup/errors_test.go
@@ -67,6 +67,7 @@ func TestErrorsParse(t *testing.T) {
 				MaxSize:    2,
 				MaxAge:     10,
 				MaxBackups: 3,
+				LocalTime:  true,
 			},
 		}},
 		{`errors { log errors.txt {
@@ -86,6 +87,7 @@ func TestErrorsParse(t *testing.T) {
 				MaxSize:    3,
 				MaxAge:     11,
 				MaxBackups: 5,
+				LocalTime:  true,
 			},
 		}},
 	}

--- a/config/setup/log_test.go
+++ b/config/setup/log_test.go
@@ -110,6 +110,7 @@ func TestLogParse(t *testing.T) {
 				MaxSize:    2,
 				MaxAge:     10,
 				MaxBackups: 3,
+				LocalTime:  true,
 			},
 		}}},
 	}

--- a/config/setup/roller.go
+++ b/config/setup/roller.go
@@ -35,5 +35,6 @@ func parseRoller(c *Controller) (*middleware.LogRoller, error) {
 		MaxSize:    size,
 		MaxAge:     age,
 		MaxBackups: keep,
+		LocalTime:  true,
 	}, nil
 }


### PR DESCRIPTION
By default the time wasn't the time of the machine but UTC.