### PR TITLE
Use markdown.Config as pointer everywhere

### DIFF
--- a/config/setup/markdown.go
+++ b/config/setup/markdown.go
@@ -28,7 +28,7 @@ func Markdown(c *Controller) (middleware.Middleware, error) {
 	// Sweep the whole path at startup to at least generate link index, maybe generate static site
 	c.Startup = append(c.Startup, func() error {
 		for i := range mdconfigs {
-			cfg := &mdconfigs[i]
+			cfg := mdconfigs[i]
 
 			// Generate link index and static files (if enabled)
 			if err := markdown.GenerateStatic(md, cfg); err != nil {
@@ -50,11 +50,11 @@ func Markdown(c *Controller) (middleware.Middleware, error) {
 	}, nil
 }
 
-func markdownParse(c *Controller) ([]markdown.Config, error) {
-	var mdconfigs []markdown.Config
+func markdownParse(c *Controller) ([]*markdown.Config, error) {
+	var mdconfigs []*markdown.Config
 
 	for c.Next() {
-		md := markdown.Config{
+		md := &markdown.Config{
 			Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 			Templates:   make(map[string]string),
 			StaticFiles: make(map[string]string),

--- a/middleware/markdown/generator.go
+++ b/middleware/markdown/generator.go
@@ -102,7 +102,7 @@ func generateStaticHTML(md Markdown, cfg *Config) error {
 
 				// Generate the static file
 				ctx := middleware.Context{Root: md.FileSys}
-				_, err = md.Process(*cfg, reqPath, body, ctx)
+				_, err = md.Process(cfg, reqPath, body, ctx)
 				if err != nil {
 					return err
 				}
@@ -115,7 +115,7 @@ func generateStaticHTML(md Markdown, cfg *Config) error {
 }
 
 // computeDirHash computes an hash on static directory of c.
-func computeDirHash(md Markdown, c Config) (string, error) {
+func computeDirHash(md Markdown, c *Config) (string, error) {
 	dir := filepath.Join(md.Root, c.PathScope)
 	if _, err := os.Stat(dir); err != nil {
 		return "", err

--- a/middleware/markdown/markdown.go
+++ b/middleware/markdown/markdown.go
@@ -27,7 +27,7 @@ type Markdown struct {
 	Next middleware.Handler
 
 	// The list of markdown configurations
-	Configs []Config
+	Configs []*Config
 
 	// The list of index files to try
 	IndexFiles []string
@@ -83,7 +83,7 @@ type Config struct {
 
 // IsValidExt checks to see if an extension is a valid markdown extension
 // for config.
-func (c Config) IsValidExt(ext string) bool {
+func (c *Config) IsValidExt(ext string) bool {
 	for _, e := range c.Extensions {
 		if e == ext {
 			return true
@@ -121,7 +121,7 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 
 				// if development is set, scan directory for file changes for links.
 				if cfg.Development {
-					if err := GenerateStatic(md, &cfg); err != nil {
+					if err := GenerateStatic(md, cfg); err != nil {
 						log.Println("On-demand generation error (markdown):", err)
 					}
 				}

--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -21,8 +21,8 @@ func TestMarkdown(t *testing.T) {
 	md := Markdown{
 		Root:    "./testdata",
 		FileSys: http.Dir("./testdata"),
-		Configs: []Config{
-			Config{
+		Configs: []*Config{
+			&Config{
 				Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 				PathScope:   "/blog",
 				Extensions:  []string{".md"},
@@ -32,7 +32,7 @@ func TestMarkdown(t *testing.T) {
 				StaticDir:   DefaultStaticDir,
 				StaticFiles: make(map[string]string),
 			},
-			Config{
+			&Config{
 				Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 				PathScope:   "/log",
 				Extensions:  []string{".md"},
@@ -42,7 +42,7 @@ func TestMarkdown(t *testing.T) {
 				StaticDir:   DefaultStaticDir,
 				StaticFiles: make(map[string]string),
 			},
-			Config{
+			&Config{
 				Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 				PathScope:   "/og",
 				Extensions:  []string{".md"},
@@ -69,7 +69,7 @@ func TestMarkdown(t *testing.T) {
 	}
 
 	for i := range md.Configs {
-		c := &md.Configs[i]
+		c := md.Configs[i]
 		if err := GenerateStatic(md, c); err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -221,7 +221,7 @@ Welcome to title!
 	w.Wait()
 
 	f = func() {
-		GenerateStatic(md, &md.Configs[0])
+		GenerateStatic(md, md.Configs[0])
 		w.Done()
 	}
 	for i := 0; i < 5; i++ {

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -83,7 +83,7 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) bool {
 		return false
 	}
 
-	hash, err := computeDirHash(md, *cfg)
+	hash, err := computeDirHash(md, cfg)
 
 	// same hash, return.
 	if err == nil && hash == cfg.linksHash {

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -26,7 +26,7 @@ type MarkdownData struct {
 
 // Process processes the contents of a page in b. It parses the metadata
 // (if any) and uses the template (if found).
-func (md Markdown) Process(c Config, requestPath string, b []byte, ctx middleware.Context) ([]byte, error) {
+func (md Markdown) Process(c *Config, requestPath string, b []byte, ctx middleware.Context) ([]byte, error) {
 	var metadata = Metadata{Variables: make(map[string]string)}
 	var markdown []byte
 	var err error
@@ -82,7 +82,7 @@ func (md Markdown) Process(c Config, requestPath string, b []byte, ctx middlewar
 
 // processTemplate processes a template given a requestPath,
 // template (tmpl) and metadata
-func (md Markdown) processTemplate(c Config, requestPath string, tmpl []byte, metadata Metadata, ctx middleware.Context) ([]byte, error) {
+func (md Markdown) processTemplate(c *Config, requestPath string, tmpl []byte, metadata Metadata, ctx middleware.Context) ([]byte, error) {
 	// if template is not specified,
 	// use the default template
 	if tmpl == nil {
@@ -123,7 +123,7 @@ func (md Markdown) processTemplate(c Config, requestPath string, tmpl []byte, me
 
 // generatePage generates a static html page from the markdown in content if c.StaticDir
 // is a non-empty value, meaning that the user enabled static site generation.
-func (md Markdown) generatePage(c Config, requestPath string, content []byte) error {
+func (md Markdown) generatePage(c *Config, requestPath string, content []byte) error {
 	// Only generate the page if static site generation is enabled
 	if c.StaticDir != "" {
 		// if static directory is not existing, create it
@@ -160,7 +160,7 @@ func (md Markdown) generatePage(c Config, requestPath string, content []byte) er
 }
 
 // defaultTemplate constructs a default template.
-func defaultTemplate(c Config, metadata Metadata, requestPath string) []byte {
+func defaultTemplate(c *Config, metadata Metadata, requestPath string) []byte {
 	var scripts, styles bytes.Buffer
 	for _, style := range c.Styles {
 		styles.WriteString(strings.Replace(cssTemplate, "{{url}}", style, 1))


### PR DESCRIPTION
* As value mutex was copied and therefore synchronization worked wrong
* It's pretty big structure with reference types, so copying create unnecessary
  pressure on GC