### PR TITLE
Use less strict condition to avoid problems with concurrency

### DIFF
--- a/middleware/markdown/watcher_test.go
+++ b/middleware/markdown/watcher_test.go
@@ -17,10 +17,11 @@ func TestWatcher(t *testing.T) {
 		i++
 		out += fmt.Sprint(i)
 	})
-	time.Sleep(interval * 8)
+	// wait little more because of concurrency
+	time.Sleep(interval * 9)
 	stopChan <- struct{}{}
-	if expected != out {
-		t.Fatalf("Expected %v, found %v", expected, out)
+	if !strings.HasPrefix(out, expected) {
+		t.Fatalf("Expected to have prefix %v, found %v", expected, out)
 	}
 	out = ""
 	i = 0


### PR DESCRIPTION
In latest go versions TestWatcher fails pretty often, because it is
"more concurrent" now. Reproducible with go master:
while go test github.com/mholt/caddy/middleware/markdown; do :; done