### PR TITLE
Rewrite: Use middleware.Replacer.

### DIFF
--- a/middleware/replacer.go
+++ b/middleware/replacer.go
@@ -41,7 +41,6 @@ func NewReplacer(r *http.Request, rr *responseRecorder, emptyValue string) Repla
 			"{host}":     r.Host,
 			"{path}":     r.URL.Path,
 			"{query}":    r.URL.RawQuery,
-			"{frag}":     r.URL.Fragment,
 			"{fragment}": r.URL.Fragment,
 			"{proto}":    r.Proto,
 			"{remote}": func() string {

--- a/middleware/replacer.go
+++ b/middleware/replacer.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -40,6 +41,7 @@ func NewReplacer(r *http.Request, rr *responseRecorder, emptyValue string) Repla
 			"{host}":     r.Host,
 			"{path}":     r.URL.Path,
 			"{query}":    r.URL.RawQuery,
+			"{frag}":     r.URL.Fragment,
 			"{fragment}": r.URL.Fragment,
 			"{proto}":    r.Proto,
 			"{remote}": func() string {
@@ -62,6 +64,14 @@ func NewReplacer(r *http.Request, rr *responseRecorder, emptyValue string) Repla
 			"{uri}": r.URL.RequestURI(),
 			"{when}": func() string {
 				return time.Now().Format(timeFormat)
+			}(),
+			"{file}": func() string {
+				_, file := path.Split(r.URL.Path)
+				return file
+			}(),
+			"{dir}": func() string {
+				dir, _ := path.Split(r.URL.Path)
+				return dir
 			}(),
 		},
 		emptyValue: emptyValue,

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -28,7 +28,7 @@ func TestRewrite(t *testing.T) {
 		[]string{"/ab/", "ab", "/ab?type=html&{query}", ".html|"},
 		[]string{"/abc/", "ab", "/abc/{file}", ".html|"},
 		[]string{"/abcd/", "ab", "/a/{dir}/{file}", ".html|"},
-		[]string{"/abcde/", "ab", "/a#{frag}", ".html|"},
+		[]string{"/abcde/", "ab", "/a#{fragment}", ".html|"},
 		[]string{"/ab/", `.*\.jpg`, "/ajpg", ""},
 	}
 


### PR DESCRIPTION
* Rewrite now uses `middleware.Replacer`.
* Bug fix for regexps starting with `/`.
* `file` and `dir` variables added to `middleware.Replacer` to conform with existing `rewrite` vars.

I added `frag` (which is same as `fragment`) for compatibility with existing `rewrite` vars. (This may not be needed. Just for non breaking change).