### PR TITLE
change to official http2 repo

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/bradfitz/http2"
+	"golang.org/x/net/http2"
 )
 
 // Server represents an instance of a server, which serves


### PR DESCRIPTION
The golang.org/x/net/http2 is now the official http2 repo.
It is advised to change the imports to it.