### PR TITLE
Add generated test data to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ access.log
 Caddyfile
 
 og_static/
+config/setup/testdata/generated_site/
+middleware/markdown/generated_site/


### PR DESCRIPTION
The tests for the markdown middleware create some output files that don't need to be added to version control. This PR ignores these directories to make development easier.