### PR TITLE
Fix test failures on Windows.

### DIFF
--- a/config/setup/basicauth_test.go
+++ b/config/setup/basicauth_test.go
@@ -38,7 +38,7 @@ func TestBasicAuthParse(t *testing.T) {
 md5:$apr1$l42y8rex$pOA2VJ0x/0TwaFeAF9nX61`
 
 	var skipHtpassword bool
-	htfh, err := ioutil.TempFile("", "basicauth-")
+	htfh, err := ioutil.TempFile(".", "basicauth-")
 	if err != nil {
 		t.Logf("Error creating temp file (%v), will skip htpassword test", err)
 		skipHtpassword = true

--- a/config/setup/controller.go
+++ b/config/setup/controller.go
@@ -24,7 +24,9 @@ type Controller struct {
 // add-ons can use this as a convenience.
 func NewTestController(input string) *Controller {
 	return &Controller{
-		Config:    &server.Config{},
+		Config: &server.Config{
+			Root: ".",
+		},
 		Dispenser: parse.NewDispenser("Testfile", strings.NewReader(input)),
 	}
 }

--- a/config/setup/errors.go
+++ b/config/setup/errors.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/hashicorp/go-syslog"
@@ -105,7 +105,7 @@ func errorsParse(c *Controller) (*errors.ErrorHandler, error) {
 				}
 			} else {
 				// Error page; ensure it exists
-				where = path.Join(c.Root, where)
+				where = filepath.Join(c.Root, where)
 				f, err := os.Open(where)
 				if err != nil {
 					fmt.Println("Warning: Unable to open error page '" + where + "': " + err.Error())

--- a/config/setup/markdown.go
+++ b/config/setup/markdown.go
@@ -114,11 +114,11 @@ func loadParams(c *Controller, mdc *markdown.Config) error {
 			if _, ok := mdc.Templates[markdown.DefaultTemplate]; ok {
 				return c.Err("only one default template is allowed, use alias.")
 			}
-			fpath := filepath.Clean(c.Root + string(filepath.Separator) + tArgs[0])
+			fpath := filepath.ToSlash(filepath.Clean(c.Root + string(filepath.Separator) + tArgs[0]))
 			mdc.Templates[markdown.DefaultTemplate] = fpath
 			return nil
 		case 2:
-			fpath := filepath.Clean(c.Root + string(filepath.Separator) + tArgs[1])
+			fpath := filepath.ToSlash(filepath.Clean(c.Root + string(filepath.Separator) + tArgs[1]))
 			mdc.Templates[tArgs[0]] = fpath
 			return nil
 		default:

--- a/config/setup/markdown_test.go
+++ b/config/setup/markdown_test.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -92,7 +93,7 @@ func TestMarkdownStaticGen(t *testing.T) {
 		t.Fatalf("An error occured when getting the file content: %v", err)
 	}
 
-	expectedBody := `<!DOCTYPE html>
+	expectedBody := []byte(`<!DOCTYPE html>
 <html>
 <head>
 <title>first_post</title>
@@ -104,9 +105,10 @@ func TestMarkdownStaticGen(t *testing.T) {
 
 </body>
 </html>
-`
-	if string(html) != expectedBody {
-		t.Fatalf("Expected file content: %v got: %v", expectedBody, html)
+`)
+	// TODO: html contains Windows line endings, expectedBody doesn't...
+	if !bytes.Equal(html, expectedBody) {
+		//t.Fatalf("Expected file content: %s got: %s", string(expectedBody), string(html))
 	}
 
 	fp := filepath.Join(c.Root, markdown.DefaultStaticDir)

--- a/config/setup/markdown_test.go
+++ b/config/setup/markdown_test.go
@@ -106,9 +106,9 @@ func TestMarkdownStaticGen(t *testing.T) {
 </body>
 </html>
 `)
-	// TODO: html contains Windows line endings, expectedBody doesn't...
+
 	if !bytes.Equal(html, expectedBody) {
-		//t.Fatalf("Expected file content: %s got: %s", string(expectedBody), string(html))
+		t.Fatalf("Expected file content: %s got: %s", string(expectedBody), string(html))
 	}
 
 	fp := filepath.Join(c.Root, markdown.DefaultStaticDir)

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -87,6 +87,7 @@ var (
 )
 
 func GetHtpasswdMatcher(filename, username, siteRoot string) (PasswordMatcher, error) {
+	fmt.Printf("ZBZB joining '%s' and '%s' and trying to open\n", siteRoot, filename)
 	filename = filepath.Join(siteRoot, filename)
 	htpasswordsMu.Lock()
 	if htpasswords == nil {

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -87,7 +87,6 @@ var (
 )
 
 func GetHtpasswdMatcher(filename, username, siteRoot string) (PasswordMatcher, error) {
-	fmt.Printf("ZBZB joining '%s' and '%s' and trying to open\n", siteRoot, filename)
 	filename = filepath.Join(siteRoot, filename)
 	htpasswordsMu.Lock()
 	if htpasswords == nil {

--- a/middleware/markdown/generator.go
+++ b/middleware/markdown/generator.go
@@ -70,7 +70,7 @@ func generateLinks(md Markdown, cfg *Config) (bool, error) {
 	return generated, g.lastErr
 }
 
-// generateStaticFiles generates static html files from markdowns.
+// generateStaticHTML generates static HTML files from markdowns.
 func generateStaticHTML(md Markdown, cfg *Config) error {
 	// If generated site already exists, clear it out
 	_, err := os.Stat(cfg.StaticDir)
@@ -98,6 +98,7 @@ func generateStaticHTML(md Markdown, cfg *Config) error {
 				if err != nil {
 					return err
 				}
+				reqPath = filepath.ToSlash(reqPath)
 				reqPath = "/" + reqPath
 
 				// Generate the static file

--- a/middleware/markdown/page.go
+++ b/middleware/markdown/page.go
@@ -116,7 +116,7 @@ func (l *linkGen) generateLinks(md Markdown, cfg *Config) bool {
 			if err != nil {
 				return err
 			}
-			reqPath = "/" + reqPath
+			reqPath = "/" + filepath.ToSlash(reqPath)
 
 			parser := findParser(body)
 			if parser == nil {

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -134,7 +134,10 @@ func (md Markdown) generatePage(c *Config, requestPath string, content []byte) e
 			}
 		}
 
-		filePath := filepath.Join(c.StaticDir, requestPath)
+		// the URL will always use "/" as a path separator,
+		// convert that to a native path to support OS that
+		// use different path separators
+		filePath := filepath.Join(c.StaticDir, filepath.FromSlash(requestPath))
 
 		// If it is index file, use the directory instead
 		if md.IsIndexFile(filepath.Base(requestPath)) {
@@ -154,7 +157,7 @@ func (md Markdown) generatePage(c *Config, requestPath string, content []byte) e
 		}
 
 		c.Lock()
-		c.StaticFiles[requestPath] = filePath
+		c.StaticFiles[requestPath] = filepath.ToSlash(filePath)
 		c.Unlock()
 	}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,7 +3,7 @@ package middleware
 
 import (
 	"net/http"
-	"path/filepath"
+	"path"
 )
 
 type (
@@ -57,12 +57,19 @@ func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, err
 // and false is returned. fpath must end in a forward slash '/'
 // otherwise no index files will be tried (directory paths must end
 // in a forward slash according to HTTP).
+//
+// All paths passed into and returned from this function use '/' as the
+// path separator, just like URLs.  IndexFle handles path manipulation
+// internally for systems that use different path separators.
 func IndexFile(root http.FileSystem, fpath string, indexFiles []string) (string, bool) {
 	if fpath[len(fpath)-1] != '/' || root == nil {
 		return "", false
 	}
 	for _, indexFile := range indexFiles {
-		fp := filepath.Join(fpath, indexFile)
+		// func (http.FileSystem).Open wants all paths separated by "/",
+		// regardless of operating system convention, so use
+		// path.Join instead of filepath.Join
+		fp := path.Join(fpath, indexFile)
 		f, err := root.Open(fp)
 		if err == nil {
 			f.Close()

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 )
@@ -26,7 +25,6 @@ func TestIndexfile(t *testing.T) {
 	}
 	for i, test := range tests {
 		actualFilePath, actualBoolValue := IndexFile(test.rootDir, test.fpath, test.indexFiles)
-		fmt.Println("ZBZB IndexFile returned", actualFilePath, ",", actualBoolValue)
 		if actualBoolValue == true && test.shouldErr {
 			t.Errorf("Test %d didn't error, but it should have", i)
 		} else if actualBoolValue != true && !test.shouldErr {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -15,13 +16,17 @@ func TestIndexfile(t *testing.T) {
 		expectedBoolValue bool   //return value
 	}{
 		{
-			http.Dir("./templates/testdata"), "/images/", []string{"img.htm"},
+			http.Dir("./templates/testdata"),
+			"/images/",
+			[]string{"img.htm"},
 			false,
-			"/images/img.htm", true,
+			"/images/img.htm",
+			true,
 		},
 	}
 	for i, test := range tests {
 		actualFilePath, actualBoolValue := IndexFile(test.rootDir, test.fpath, test.indexFiles)
+		fmt.Println("ZBZB IndexFile returned", actualFilePath, ",", actualBoolValue)
 		if actualBoolValue == true && test.shouldErr {
 			t.Errorf("Test %d didn't error, but it should have", i)
 		} else if actualBoolValue != true && !test.shouldErr {


### PR DESCRIPTION
Most of the Windows test failures are due to the path separator not being "/".  The general approach I took here was to keep paths in "URL form" (ie using "/" separators) as much as possible, and only convert to native paths when we attempt to open a file.  This will allow the most consistency between different host OS.  For example, data structures that store paths still store them with "/" delimiters.  Functions that accepted paths as input and return them as outputs still use "/".

There are still a few test failures that need to be sorted out.

- config/setup/TestRoot (I hear this has already been fixed by someone else)
- middleware/basicauth/TestBrowseTemplate and middleware/templates/Test (a line endings issue that I'm still working through)