### PR TITLE
Add option to change delims in templates

### DIFF
--- a/config/setup/templates_test.go
+++ b/config/setup/templates_test.go
@@ -2,8 +2,9 @@ package setup
 
 import (
 	"fmt"
-	"github.com/mholt/caddy/middleware/templates"
 	"testing"
+
+	"github.com/mholt/caddy/middleware/templates"
 )
 
 func TestTemplates(t *testing.T) {
@@ -40,7 +41,11 @@ func TestTemplates(t *testing.T) {
 	if fmt.Sprint(myHandler.Rules[0].IndexFiles) != fmt.Sprint(indexFiles) {
 		t.Errorf("Expected %v to be the Default Index files", indexFiles)
 	}
+	if myHandler.Rules[0].Delims != [2]string{} {
+		t.Errorf("Expected %v to be the Default Delims", [2]string{})
+	}
 }
+
 func TestTemplatesParse(t *testing.T) {
 	tests := []struct {
 		inputTemplateConfig    string
@@ -50,19 +55,32 @@ func TestTemplatesParse(t *testing.T) {
 		{`templates /api1`, false, []templates.Rule{{
 			Path:       "/api1",
 			Extensions: defaultTemplateExtensions,
+			Delims:     [2]string{},
 		}}},
 		{`templates /api2 .txt .htm`, false, []templates.Rule{{
 			Path:       "/api2",
 			Extensions: []string{".txt", ".htm"},
+			Delims:     [2]string{},
 		}}},
 
-		{`templates /api3 .htm .html  
+		{`templates /api3 .htm .html
 		  templates /api4 .txt .tpl `, false, []templates.Rule{{
 			Path:       "/api3",
 			Extensions: []string{".htm", ".html"},
+			Delims:     [2]string{},
 		}, {
 			Path:       "/api4",
 			Extensions: []string{".txt", ".tpl"},
+			Delims:     [2]string{},
+		}}},
+		{`templates {
+				path /api5
+				ext .html
+				between {% %}
+			}`, false, []templates.Rule{{
+			Path:       "/api5",
+			Extensions: []string{".html"},
+			Delims:     [2]string{"{%", "%}"},
 		}}},
 	}
 	for i, test := range tests {

--- a/middleware/templates/templates.go
+++ b/middleware/templates/templates.go
@@ -33,9 +33,18 @@ func (t Templates) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 				// Create execution context
 				ctx := middleware.Context{Root: t.FileSys, Req: r, URL: r.URL}
 
+				// New template
+				templateName := filepath.Base(fpath)
+				tpl := template.New(templateName)
+
+				// Set delims
+				if rule.Delims != [2]string{} {
+					tpl.Delims(rule.Delims[0], rule.Delims[1])
+				}
+
 				// Build the template
 				templatePath := filepath.Join(t.Root, fpath)
-				tpl, err := template.ParseFiles(templatePath)
+				tpl, err := tpl.ParseFiles(templatePath)
 				if err != nil {
 					if os.IsNotExist(err) {
 						return http.StatusNotFound, nil
@@ -82,4 +91,5 @@ type Rule struct {
 	Path       string
 	Extensions []string
 	IndexFiles []string
+	Delims     [2]string
 }

--- a/middleware/templates/templates_test.go
+++ b/middleware/templates/templates_test.go
@@ -23,6 +23,7 @@ func Test(t *testing.T) {
 				Extensions: []string{".html", ".htm"},
 				IndexFiles: []string{"index.html", "index.htm"},
 				Path:       "/images",
+				Delims:     [2]string{"{%", "%}"},
 			},
 		},
 		Root:    "./testdata",
@@ -88,6 +89,30 @@ func Test(t *testing.T) {
 	respBody = rec.Body.String()
 	expectedBody = `<!DOCTYPE html><html><head><title>img</title></head><body><h1>Header title</h1>
 </body></html>
+`
+
+	if respBody != expectedBody {
+		t.Fatalf("Test: the expected body %v is different from the response one: %v", expectedBody, respBody)
+	}
+
+	/*
+	* Test tmpl on /images/img2.htm
+	 */
+	req, err = http.NewRequest("GET", "/images/img2.htm", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+
+	tmpl.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Test: Wrong response code: %d, should be %d", rec.Code, http.StatusOK)
+	}
+
+	respBody = rec.Body.String()
+	expectedBody = `<!DOCTYPE html><html><head><title>img</title></head><body>{{.Include "header.html"}}</body></html>
 `
 
 	if respBody != expectedBody {

--- a/middleware/templates/testdata/images/img.htm
+++ b/middleware/templates/testdata/images/img.htm
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>img</title></head><body>{{.Include "header.html"}}</body></html>
+<!DOCTYPE html><html><head><title>img</title></head><body>{%.Include "header.html"%}</body></html>

--- a/middleware/templates/testdata/images/img2.htm
+++ b/middleware/templates/testdata/images/img2.htm
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>img</title></head><body>{{.Include "header.html"}}</body></html>


### PR DESCRIPTION
I created this to use in a project with Angular.js, that not work with default text/html delimiters.
Added delims argument in a new optional block in templates middleware.

How to use:

without block:
```
templates [path [extensions...]]
```

or 

```
templates {
    path path
    exten extens...
    delims leftDelim rightDelim
}
```
example:
```
templates {
    delims {% %}
    path /frontend
}
```