### PR TITLE
Add Last-Modified header when serving markdown and templates

### DIFF
--- a/middleware/header.go
+++ b/middleware/header.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+)
+
+// currentTime returns time.Now() everytime it's called. It's used for mocking in tests.
+var currentTime = func() time.Time {
+	return time.Now()
+}
+
+// SetLastModifiedHeader checks if the provided modTime is valid and if it is sets it
+// as a Last-Modified header to the ResponseWriter. If the modTime is in the future
+// the current time is used instead.
+func SetLastModifiedHeader(w http.ResponseWriter, modTime time.Time) {
+	if modTime.IsZero() || modTime.Equal(time.Unix(0, 0)) {
+		// the time does not appear to be valid. Don't put it in the response
+		return
+	}
+
+	// RFC 2616 - Section 14.29 - Last-Modified:
+	// An origin server MUST NOT send a Last-Modified date which is later than the
+	// server's time of message origination. In such cases, where the resource's last
+	// modification would indicate some time in the future, the server MUST replace
+	// that date with the message origination date.
+	now := currentTime()
+	if modTime.After(now) {
+		modTime = now
+	}
+
+	w.Header().Set("Last-Modified", modTime.UTC().Format(http.TimeFormat))
+}

--- a/middleware/header_test.go
+++ b/middleware/header_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSetLastModified(t *testing.T) {
+	nowTime := time.Now()
+
+	// ovewrite the function to return reliable time
+	originalGetCurrentTimeFunc := currentTime
+	currentTime = func() time.Time {
+		return nowTime
+	}
+	defer func() {
+		currentTime = originalGetCurrentTimeFunc
+	}()
+
+	pastTime := nowTime.Truncate(1 * time.Hour)
+	futureTime := nowTime.Add(1 * time.Hour)
+
+	tests := []struct {
+		inputModTime         time.Time
+		expectedIsHeaderSet  bool
+		expectedLastModified string
+	}{
+		{
+			inputModTime:         pastTime,
+			expectedIsHeaderSet:  true,
+			expectedLastModified: pastTime.UTC().Format(http.TimeFormat),
+		},
+		{
+			inputModTime:         nowTime,
+			expectedIsHeaderSet:  true,
+			expectedLastModified: nowTime.UTC().Format(http.TimeFormat),
+		},
+		{
+			inputModTime:         futureTime,
+			expectedIsHeaderSet:  true,
+			expectedLastModified: nowTime.UTC().Format(http.TimeFormat),
+		},
+		{
+			inputModTime:        time.Time{},
+			expectedIsHeaderSet: false,
+		},
+	}
+
+	for i, test := range tests {
+		responseRecorder := httptest.NewRecorder()
+		errorPrefix := fmt.Sprintf("Test [%d]: ", i)
+		SetLastModifiedHeader(responseRecorder, test.inputModTime)
+		actualLastModifiedHeader := responseRecorder.Header().Get("Last-Modified")
+
+		if test.expectedIsHeaderSet && actualLastModifiedHeader == "" {
+			t.Fatalf(errorPrefix + "Expected to find Last-Modified header, but found nothing")
+		}
+
+		if !test.expectedIsHeaderSet && actualLastModifiedHeader != "" {
+			t.Fatalf(errorPrefix+"Did not expect to find Last-Modified header, but found one [%s].", actualLastModifiedHeader)
+		}
+
+		if test.expectedLastModified != actualLastModifiedHeader {
+			t.Errorf(errorPrefix+"Expected Last-Modified content [%s], found [%s}", test.expectedLastModified, actualLastModifiedHeader)
+		}
+	}
+}

--- a/middleware/markdown/markdown.go
+++ b/middleware/markdown/markdown.go
@@ -136,6 +136,7 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 						// generation, serve the static page
 						if fs.ModTime().Before(fs1.ModTime()) {
 							if html, err := ioutil.ReadFile(filepath); err == nil {
+								middleware.SetLastModifiedHeader(w, fs1.ModTime())
 								w.Write(html)
 								return http.StatusOK, nil
 							}
@@ -162,6 +163,7 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 					return http.StatusInternalServerError, err
 				}
 
+				middleware.SetLastModifiedHeader(w, fs.ModTime())
 				w.Write(html)
 				return http.StatusOK, nil
 			}


### PR DESCRIPTION
This PR addresses Issue #263 and adds Last-Modified headers to served markdown and template files.

The Issue mentions also Content-Length, but I did not see any problems with it. The cases, where Content-Length must not be sent are defined in [rfc2616#sec4.4](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4). Most notably when Transfer-Encoding header is also present Content-Length header is to be omitted or ignored by clients.

Note: I do not like the name middleware/header.go, but I could not think of a better place/filename to place the function. The current file name might also be confusing because there's a middleware called headers, which has nothing to do with it. Suggestions are welcomed.