### PR TITLE
Fix regression: Ensure TLS defaults are added by LE handlers.

### DIFF
--- a/caddy/letsencrypt/letsencrypt.go
+++ b/caddy/letsencrypt/letsencrypt.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mholt/caddy/caddy/setup"
 	"github.com/mholt/caddy/middleware"
 	"github.com/mholt/caddy/middleware/redirect"
 	"github.com/mholt/caddy/server"
@@ -338,6 +339,9 @@ func autoConfigure(allConfigs []server.Config, cfgIndex int) []server.Config {
 	cfg.TLS.Certificate = storage.SiteCertFile(cfg.Host)
 	cfg.TLS.Key = storage.SiteKeyFile(cfg.Host)
 	cfg.TLS.Enabled = true
+	// Ensure all defaults are set for the TLS config
+	setup.SetDefaultTLSParams(cfg)
+
 	if cfg.Port == "" {
 		cfg.Port = "https"
 	}

--- a/caddy/setup/tls.go
+++ b/caddy/setup/tls.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mholt/caddy/middleware"
+	"github.com/mholt/caddy/server"
 )
 
 func TLS(c *Controller) (middleware.Middleware, error) {
@@ -78,6 +79,14 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 		}
 	}
 
+	SetDefaultTLSParams(c.Config)
+
+	return nil, nil
+}
+
+// SetDefaultTLSParams sets the default TLS cipher suites, protocol versions and server preferences
+// of a server.Config if they were not previously set.
+func SetDefaultTLSParams(c *server.Config) {
 	// If no ciphers provided, use all that Caddy supports for the protocol
 	if len(c.TLS.Ciphers) == 0 {
 		c.TLS.Ciphers = supportedCiphers
@@ -96,8 +105,6 @@ func TLS(c *Controller) (middleware.Middleware, error) {
 
 	// Prefer server cipher suites
 	c.TLS.PreferServerCipherSuites = true
-
-	return nil, nil
 }
 
 // Map of supported protocols


### PR DESCRIPTION
This pull request fixes a regression introduced by the LE changes.

When using a caddyfile without a TLS block, defaults were not set as the handler in tls.go was never executed.