### PR TITLE
Use environment variables for configuration

### DIFF
--- a/caddy/parse/parsing.go
+++ b/caddy/parse/parsing.go
@@ -9,8 +9,7 @@ import (
 )
 
 var (
-	unixEnvRegEx    = regexp.MustCompile("{\\$[^}]+}")
-	windowsEnvRegEx = regexp.MustCompile("{%[^}]+%}")
+	envRegEx = regexp.MustCompile("{\\$[^}]+}")
 )
 
 type parser struct {
@@ -338,18 +337,11 @@ func (sb serverBlock) HostList() []string {
 }
 
 func getValFromEnv(s string) string {
-	envRefsUnix := unixEnvRegEx.FindAllString(s, -1)
+	envRefs := envRegEx.FindAllString(s, -1)
 
-	for _, ref := range envRefsUnix {
+	for _, ref := range envRefs {
 		s = strings.Replace(s, ref, os.Getenv(ref[2:len(ref)-1]), -1)
 	}
 
-	envRefsWin := unixEnvRegEx.FindAllString(s, -1)
-
-	for _, ref := range envRefsWin {
-		s = strings.Replace(s, ref, os.Getenv(ref[2:len(ref)-2]), -1)
-	}
-
 	return s
-
 }

--- a/caddy/parse/parsing.go
+++ b/caddy/parse/parsing.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+var (
+	unixEnvRegEx    = regexp.MustCompile("{\\$[^}]+}")
+	windowsEnvRegEx = regexp.MustCompile("{%[^}]+%}")
+)
+
 type parser struct {
 	Dispenser
 	block           serverBlock // current server block being parsed
@@ -333,12 +338,18 @@ func (sb serverBlock) HostList() []string {
 }
 
 func getValFromEnv(s string) string {
-	re := regexp.MustCompile("{\\$[^}]+}")
-	envRefs := re.FindAllString(s, -1)
+	envRefsUnix := unixEnvRegEx.FindAllString(s, -1)
 
-	for _, ref := range envRefs {
+	for _, ref := range envRefsUnix {
 		s = strings.Replace(s, ref, os.Getenv(ref[2:len(ref)-1]), -1)
 	}
 
+	envRefsWin := unixEnvRegEx.FindAllString(s, -1)
+
+	for _, ref := range envRefsWin {
+		s = strings.Replace(s, ref, os.Getenv(ref[2:len(ref)-2]), -1)
+	}
+
 	return s
+
 }

--- a/caddy/parse/parsing_test.go
+++ b/caddy/parse/parsing_test.go
@@ -391,6 +391,22 @@ func TestEnvironmentReplacement(t *testing.T) {
 			[]address{{"127.0.0.1", "1234"}},
 			[]address{{"localhost", "8080"}},
 		}},
+
+		{`{%MY_ADDRESS%}`, [][]address{
+			{{"servername.com", ""}},
+		}},
+
+		{`{%MY_ADDRESS%}:{%MY_PORT%}`, [][]address{
+			[]address{{"servername.com", "8080"}},
+		}},
+
+		{`{%MY_ADDRESS2%}:1234 {
+		  }
+		  localhost:{%MY_PORT%} {
+		  }`, [][]address{
+			[]address{{"127.0.0.1", "1234"}},
+			[]address{{"localhost", "8080"}},
+		}},
 	} {
 		p := testParser(test.input)
 		blocks, err := p.parseAll()


### PR DESCRIPTION
This fixes #304 - environment variables can be used in the `Caddyfile` with the `{$VAR_NAME}` syntax.