### PR TITLE
gzip: added Vary: Accept-Encoding to response header.

### DIFF
--- a/middleware/gzip/gzip.go
+++ b/middleware/gzip/gzip.go
@@ -47,6 +47,7 @@ outer:
 		r.Header.Del("Accept-Encoding")
 
 		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Vary", "Accept-Encoding")
 		gzipWriter, err := newWriter(c, w)
 		if err != nil {
 			// should not happen

--- a/middleware/gzip/gzip_test.go
+++ b/middleware/gzip/gzip_test.go
@@ -87,6 +87,9 @@ func nextFunc(shouldGzip bool) middleware.Handler {
 			if w.Header().Get("Content-Encoding") != "gzip" {
 				return 0, fmt.Errorf("Content-Encoding must be gzip, found %v", r.Header.Get("Content-Encoding"))
 			}
+			if w.Header().Get("Vary") != "Accept-Encoding" {
+				return 0, fmt.Errorf("Vary must be Accept-Encoding, found %v", r.Header.Get("Vary"))
+			}
 			if _, ok := w.(gzipResponseWriter); !ok {
 				return 0, fmt.Errorf("ResponseWriter should be gzipResponseWriter, found %T", w)
 			}


### PR DESCRIPTION
When the downstream is cache server or CDN, it is important.

FYI, mod_deflate adds `Vary: Accept-Encoding` to the response headers by default also.