### PR TITLE
Proxy: Allow ignored subpaths.

### DIFF
--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -26,6 +26,8 @@ type Upstream interface {
 	From() string
 	// Selects an upstream host to be routed to.
 	Select() *UpstreamHost
+	// Checks if subpath is not an ignored path
+	IsAllowedPath(string) bool
 }
 
 // UpstreamHostDownFunc can be used to customize how Down behaves.
@@ -59,7 +61,7 @@ func (uh *UpstreamHost) Down() bool {
 func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 
 	for _, upstream := range p.Upstreams {
-		if middleware.Path(r.URL.Path).Matches(upstream.From()) {
+		if middleware.Path(r.URL.Path).Matches(upstream.From()) && upstream.IsAllowedPath(r.URL.Path) {
 			var replacer middleware.Replacer
 			start := time.Now()
 			requestHost := r.Host

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -125,6 +125,10 @@ func (u *fakeUpstream) Select() *UpstreamHost {
 	}
 }
 
+func (u *fakeUpstream) IsAllowedPath(requestPath string) bool {
+	return true
+}
+
 // recorderHijacker is a ResponseRecorder that can
 // be hijacked.
 type recorderHijacker struct {

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -51,3 +51,33 @@ func TestRegisterPolicy(t *testing.T) {
 	}
 
 }
+
+func TestAllowedPaths(t *testing.T) {
+	upstream := &staticUpstream{
+		from:            "/proxy",
+		IgnoredSubPaths: []string{"/download", "/static"},
+	}
+	tests := []struct {
+		url      string
+		expected bool
+	}{
+		{"/proxy", true},
+		{"/proxy/dl", true},
+		{"/proxy/download", false},
+		{"/proxy/download/static", false},
+		{"/proxy/static", false},
+		{"/proxy/static/download", false},
+		{"/proxy/something/download", true},
+		{"/proxy/something/static", true},
+		{"/proxy//static", false},
+		{"/proxy//static//download", false},
+		{"/proxy//download", false},
+	}
+
+	for i, test := range tests {
+		isAllowed := upstream.IsAllowedPath(test.url)
+		if test.expected != isAllowed {
+			t.Errorf("Test %d: expected %v found %v", i+1, test.expected, isAllowed)
+		}
+	}
+}


### PR DESCRIPTION
This will allow `proxy` to ignore subpath(s) if required.

**Syntax**
```
proxy {
    ...
    [except] [subpaths...]
}
```
**Use Case**

Proxy all requests except static and download folder.
```
proxy / 127.0.01:8080 {
    except /static /download
}
```