### PR TITLE
proxy: make http header block scoped

### DIFF
--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -98,11 +98,6 @@ func TestWebSocketReverseProxyFromWSClient(t *testing.T) {
 // also sets up the rules/environment for testing WebSocket
 // proxy.
 func newWebSocketTestProxy(backendAddr string) *Proxy {
-	proxyHeaders = http.Header{
-		"Connection": {"{>Connection}"},
-		"Upgrade":    {"{>Upgrade}"},
-	}
-
 	return &Proxy{
 		Upstreams: []Upstream{&fakeUpstream{name: backendAddr}},
 	}
@@ -121,7 +116,9 @@ func (u *fakeUpstream) Select() *UpstreamHost {
 	return &UpstreamHost{
 		Name:         u.name,
 		ReverseProxy: NewSingleHostReverseProxy(uri, ""),
-		ExtraHeaders: proxyHeaders,
+		ExtraHeaders: http.Header{
+			"Connection": {"{>Connection}"},
+			"Upgrade":    {"{>Upgrade}"}},
 	}
 }
 


### PR DESCRIPTION
Each proxy block should could specify its own http header
instead of sharing a global one.

Fix issue #341

Signed-off-by: Tw <tw19881113@gmail.com>