### PR TITLE
proxy: make tests workable when offline

### DIFF
--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -1,8 +1,23 @@
 package proxy
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 )
+
+var workableServer *httptest.Server
+
+func TestMain(m *testing.M) {
+	workableServer = httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// do nothing
+		}))
+	r := m.Run()
+	workableServer.Close()
+	os.Exit(r)
+}
 
 type customPolicy struct{}
 
@@ -13,7 +28,7 @@ func (r *customPolicy) Select(pool HostPool) *UpstreamHost {
 func testPool() HostPool {
 	pool := []*UpstreamHost{
 		{
-			Name: "http://google.com", // this should resolve (healthcheck test)
+			Name: workableServer.URL, // this should resolve (healthcheck test)
 		},
 		{
 			Name: "http://shouldnot.resolve", // this shouldn't


### PR DESCRIPTION
Instead of accessing the google website, we setup a local server
for test, then tests will work fine even we are offline.

Fix issue #346

Signed-off-by: Tw <tw19881113@gmail.com>