### PR TITLE
Add a few super minor lint fixes

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -33,11 +33,13 @@ import (
 
 // Configurable application parameters
 var (
-	// The name and version of the application.
-	AppName    string
+	// AppName is the name of the application.
+	AppName string
+
+	// AppVersion is the version of the application.
 	AppVersion string
 
-	// If true, initialization will not show any informative output.
+	// Quiet when set to true, will not show any informative output on initialization.
 	Quiet bool
 
 	// HTTP2 indicates whether HTTP2 is enabled or not.

--- a/caddy/config.go
+++ b/caddy/config.go
@@ -348,13 +348,13 @@ func DefaultInput() CaddyfileInput {
 
 // These defaults are configurable through the command line
 var (
-	// Site root
+	// Root is the site root
 	Root = DefaultRoot
 
-	// Site host
+	// Host is the site host
 	Host = DefaultHost
 
-	// Site port
+	// Port is the site port
 	Port = DefaultPort
 )
 


### PR DESCRIPTION
Other lint warnings left behind are ones due to external package and
due to maintainer's preferences.