### PR TITLE
Two small proxy websocket fixes

### DIFF
--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -169,7 +169,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 		}
 		defer conn.Close()
 
-		backendConn, err := net.Dial("tcp", outreq.Host)
+		backendConn, err := net.Dial("tcp", outreq.URL.Host)
 		if err != nil {
 			return err
 		}

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -155,9 +155,9 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusSwitchingProtocols && res.Header.Get("Upgrade") == "websocket" {
+		res.Body.Close()
 		hj, ok := rw.(http.Hijacker)
 		if !ok {
 			return nil
@@ -182,6 +182,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 		}()
 		io.Copy(conn, backendConn) // read tcp stream from backend.
 	} else {
+		defer res.Body.Close()
 		for _, h := range hopHeaders {
 			res.Header.Del(h)
 		}


### PR DESCRIPTION
The Host header one is a bug, the res.Body.Close() is one I just noticed in the code, not in traffic. I think the connection is already closed by then, so if you're not convinced or don't want the commit for any reason you may ignore this one and only pull the Host header fixing commit.