### PR TITLE
change default ACME server to Let's Encrypt production server

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 func init() {
 	caddy.TrapSignals()
 	flag.BoolVar(&letsencrypt.Agreed, "agree", false, "Agree to Let's Encrypt Subscriber Agreement")
-	flag.StringVar(&letsencrypt.CAUrl, "ca", "https://acme-staging.api.letsencrypt.org/directory", "Certificate authority ACME server")
+	flag.StringVar(&letsencrypt.CAUrl, "ca", "https://acme-v01.api.letsencrypt.org/directory", "Certificate authority ACME server")
 	flag.StringVar(&conf, "conf", "", "Configuration file to use (default="+caddy.DefaultConfigFile+")")
 	flag.StringVar(&cpu, "cpu", "100%", "CPU cap")
 	flag.StringVar(&letsencrypt.DefaultEmail, "email", "", "Default Let's Encrypt account email address")


### PR DESCRIPTION
With the open of the [Public Beta](https://letsencrypt.org/2015/12/03/entering-public-beta.html) today, anyone can now get a valid certificate.

However caddy still points to the staging server by default. This PR just changes the default URL to the production server.

If this is something that you don't want to change just yet, could you please add something to the readme about how to get a valid certificate?

It took me quite a while to figure out why I was getting certificates signed by "happy hacker fake CA."

Thanks!