### PR TITLE
Fix race condition in test for AppVeyor

### DIFF
--- a/middleware/markdown/watcher_test.go
+++ b/middleware/markdown/watcher_test.go
@@ -18,7 +18,7 @@ func TestWatcher(t *testing.T) {
 		out += fmt.Sprint(i)
 	})
 	// wait little more because of concurrency
-	time.Sleep(interval * 9)
+	time.Sleep(interval * 12)
 	stopChan <- struct{}{}
 	if !strings.HasPrefix(out, expected) {
 		t.Fatalf("Expected to have prefix %v, found %v", expected, out)
@@ -32,7 +32,7 @@ func TestWatcher(t *testing.T) {
 		out += fmt.Sprint(i)
 		mu.Unlock()
 	})
-	time.Sleep(interval * 10)
+	time.Sleep(interval * 15)
 	mu.Lock()
 	res := out
 	mu.Unlock()

--- a/middleware/markdown/watcher_test.go
+++ b/middleware/markdown/watcher_test.go
@@ -13,14 +13,14 @@ func TestWatcher(t *testing.T) {
 	interval := time.Millisecond * 100
 	i := 0
 	out := ""
+	syncChan := make(chan struct{})
 	stopChan := TickerFunc(interval, func() {
 		i++
 		out += fmt.Sprint(i)
+		syncChan <- struct{}{}
 	})
-	// wait little more because of concurrency
-	time.Sleep(interval * 12)
-	stopChan <- struct{}{}
-	if !strings.HasPrefix(out, expected) {
+	sleepInSync(8, syncChan, stopChan)
+	if out != expected {
 		t.Fatalf("Expected to have prefix %v, found %v", expected, out)
 	}
 	out = ""
@@ -31,12 +31,20 @@ func TestWatcher(t *testing.T) {
 		mu.Lock()
 		out += fmt.Sprint(i)
 		mu.Unlock()
+		syncChan <- struct{}{}
 	})
-	time.Sleep(interval * 15)
+	sleepInSync(9, syncChan, stopChan)
 	mu.Lock()
 	res := out
 	mu.Unlock()
 	if !strings.HasPrefix(res, expected) || res == expected {
 		t.Fatalf("expected (%v) must be a proper prefix of out(%v).", expected, out)
 	}
+}
+
+func sleepInSync(times int, syncChan chan struct{}, stopChan chan struct{}) {
+	for i := 0; i < times; i++ {
+		<-syncChan
+	}
+	stopChan <- struct{}{}
 }


### PR DESCRIPTION
I could not think of many better ways to get rid of the intermittent Windows build failures. Would've loved to maintain the closeness of the intervals to sleep time.