### PR TITLE
FastCGI: separate standard and error output responses.

### DIFF
--- a/middleware/fastcgi/fastcgi.go
+++ b/middleware/fastcgi/fastcgi.go
@@ -115,7 +115,12 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 				return http.StatusBadGateway, err
 			}
 
-			return 0, nil
+			// FastCGI stderr outputs
+			if fcgi.stderr.Len() != 0 {
+				err = LogError(fcgi.stderr.String())
+			}
+
+			return 0, err
 		}
 	}
 
@@ -281,3 +286,11 @@ var (
 	// ErrIndexMissingSplit describes an index configuration error.
 	ErrIndexMissingSplit = errors.New("configured index file(s) must include split value")
 )
+
+// LogError is a non fatal error that allows requests to go through.
+type LogError string
+
+// Error satisfies error interface.
+func (l LogError) Error() string {
+	return string(l)
+}

--- a/middleware/fastcgi/fastcgi.go
+++ b/middleware/fastcgi/fastcgi.go
@@ -117,10 +117,11 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 
 			// FastCGI stderr outputs
 			if fcgi.stderr.Len() != 0 {
-				err = LogError(fcgi.stderr.String())
+				// Remove trailing newline, error logger already does this.
+				err = LogError(strings.TrimSuffix(fcgi.stderr.String(), "\n"))
 			}
 
-			return 0, err
+			return resp.StatusCode, err
 		}
 	}
 


### PR DESCRIPTION
Fix for https://github.com/mholt/caddy/issues/426.