### PR TITLE
Gzip: Append to Vary header instead of replacing.

### DIFF
--- a/middleware/gzip/gzip.go
+++ b/middleware/gzip/gzip.go
@@ -113,7 +113,7 @@ type gzipResponseWriter struct {
 func (w gzipResponseWriter) WriteHeader(code int) {
 	w.Header().Del("Content-Length")
 	w.Header().Set("Content-Encoding", "gzip")
-	w.Header().Set("Vary", "Accept-Encoding")
+	w.Header().Add("Vary", "Accept-Encoding")
 	w.ResponseWriter.WriteHeader(code)
 }
 


### PR DESCRIPTION
Other middlewares could potentially add to the Accept header. Cors does. This will make it so neither of them overwrite the other.