### PR TITLE
Support for rewrite match group.

### DIFF
--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -31,6 +31,9 @@ func TestRewrite(t *testing.T) {
 		{"/abcd/", "ab", "/a/{dir}/{file}", ".html|"},
 		{"/abcde/", "ab", "/a#{fragment}", ".html|"},
 		{"/ab/", `.*\.jpg`, "/ajpg", ""},
+		{"/reggrp", `/ad/([0-9]+)([a-z]*)`, "/a{1}/{2}", ""},
+		{"/reg2grp", `(.*)`, "/{1}", ""},
+		{"/reg3grp", `(.*)/(.*)/(.*)`, "/{1}{2}{3}", ""},
 	}
 
 	for _, regexpRule := range regexps {
@@ -81,6 +84,12 @@ func TestRewrite(t *testing.T) {
 		{"/abcde/abcde.html", "/a"},
 		{"/abcde/abcde.html#1234", "/a#1234"},
 		{"/ab/ab.jpg", "/ajpg"},
+		{"/reggrp/ad/12", "/a12"},
+		{"/reggrp/ad/124a", "/a124/a"},
+		{"/reggrp/ad/124abc", "/a124/abc"},
+		{"/reg2grp/ad/124abc", "/ad/124abc"},
+		{"/reg3grp/ad/aa/66", "/adaa66"},
+		{"/reg3grp/ad612/n1n/ab", "/ad612n1nab"},
 	}
 
 	for i, test := range tests {

--- a/middleware/rewrite/to.go
+++ b/middleware/rewrite/to.go
@@ -6,14 +6,15 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/mholt/caddy/middleware"
 )
 
 // To attempts rewrite. It attempts to rewrite to first valid path
 // or the last path if none of the paths are valid.
 // Returns true if rewrite is successful and false otherwise.
-func To(fs http.FileSystem, r *http.Request, to string) bool {
+func To(fs http.FileSystem, r *http.Request, to string, replacer middleware.Replacer) bool {
 	tos := strings.Fields(to)
-	replacer := newReplacer(r)
 
 	// try each rewrite paths
 	t := ""

--- a/middleware/rewrite/to_test.go
+++ b/middleware/rewrite/to_test.go
@@ -36,7 +36,7 @@ func TestTo(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		To(fs, r, test.to)
+		To(fs, r, test.to, newReplacer(r))
 		if uri(r.URL) != test.expected {
 			t.Errorf("Test %v: expected %v found %v", i, test.expected, uri(r.URL))
 		}


### PR DESCRIPTION
Match groups can now be used as placeholder variables `{1}`, `{2}` ...

Something like this is now possible. (From https://github.com/mholt/caddy/issues/30#issuecomment-151588596)
```
rewrite {
    r  ^/media/(.*?)/(.*?)/$
    to /something/{2}/?media={1}
}
```