### PR TITLE
Make Let's Encrypt module honor the Bind settings

### DIFF
--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -42,8 +42,8 @@ func init() {
 var directiveOrder = []directive{
 	// Essential directives that initialize vital configuration settings
 	{"root", setup.Root},
-	{"tls", setup.TLS}, // letsencrypt is set up just after tls
 	{"bind", setup.BindHost},
+	{"tls", setup.TLS}, // letsencrypt is set up just after tls
 
 	// Other directives that don't create HTTP handlers
 	{"startup", setup.Startup},

--- a/caddy/letsencrypt/letsencrypt.go
+++ b/caddy/letsencrypt/letsencrypt.go
@@ -445,8 +445,9 @@ func redirPlaintextHost(cfg server.Config) server.Config {
 	}
 
 	return server.Config{
-		Host: cfg.Host,
-		Port: "http",
+		Host:     cfg.Host,
+		BindHost: cfg.BindHost,
+		Port:     "http",
 		Middleware: map[string][]middleware.Middleware{
 			"/": []middleware.Middleware{redirMidware},
 		},

--- a/caddy/letsencrypt/letsencrypt_test.go
+++ b/caddy/letsencrypt/letsencrypt_test.go
@@ -38,13 +38,17 @@ func TestHostQualifies(t *testing.T) {
 
 func TestRedirPlaintextHost(t *testing.T) {
 	cfg := redirPlaintextHost(server.Config{
-		Host: "example.com",
-		Port: "http",
+		Host:     "example.com",
+		BindHost: "93.184.216.34",
+		Port:     "http",
 	})
 
 	// Check host and port
 	if actual, expected := cfg.Host, "example.com"; actual != expected {
 		t.Errorf("Expected redir config to have host %s but got %s", expected, actual)
+	}
+	if actual, expected := cfg.BindHost, "93.184.216.34"; actual != expected {
+		t.Errorf("Expected redir config to have bindhost %s but got %s", expected, actual)
 	}
 	if actual, expected := cfg.Port, "http"; actual != expected {
 		t.Errorf("Expected redir config to have port '%s' but got '%s'", expected, actual)


### PR DESCRIPTION
Reorder the bind and letsencrypt directives to ensure that BindHost is set in the configuration.

Then propagate that value in redirPlaintextHost to ensure use of user-specified bind address if user configured it thusly.