### PR TITLE
Rewrite, Proxy: read configs in descending order of request path length.

### DIFF
--- a/caddy/setup/rewrite.go
+++ b/caddy/setup/rewrite.go
@@ -27,7 +27,7 @@ func Rewrite(c *Controller) (middleware.Middleware, error) {
 
 func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 	var simpleRules []rewrite.Rule
-	var regexpRules []rewrite.Rule
+	var complexRules []rewrite.Rule
 
 	for c.Next() {
 		var rule rewrite.Rule
@@ -94,7 +94,7 @@ func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 			if rule, err = rewrite.NewComplexRule(base, pattern, to, status, ext, ifs); err != nil {
 				return nil, err
 			}
-			regexpRules = append(regexpRules, rule)
+			complexRules = append(complexRules, rule)
 
 		// the only unhandled case is 2 and above
 		default:
@@ -104,6 +104,21 @@ func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 
 	}
 
+	var configPaths middleware.ConfigPaths
+
 	// put simple rules in front to avoid regexp computation for them
-	return append(simpleRules, regexpRules...), nil
+	for _, v := range append(simpleRules, complexRules...) {
+		// order by longest path
+		configPaths.Add(v)
+	}
+
+	var rules []rewrite.Rule
+
+	// add to rules after ordering
+	configPaths.Each(func(b middleware.ConfigPath) {
+		rule, _ := b.(rewrite.Rule)
+		rules = append(rules, rule)
+	})
+
+	return rules, nil
 }

--- a/caddy/setup/rewrite.go
+++ b/caddy/setup/rewrite.go
@@ -104,19 +104,19 @@ func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 
 	}
 
-	var configPaths middleware.ConfigPaths
+	var configs middleware.Configs
 
 	// put simple rules in front to avoid regexp computation for them
 	for _, v := range append(simpleRules, complexRules...) {
 		// order by longest path
-		configPaths.Add(v)
+		configs.Add(v)
 	}
 
 	var rules []rewrite.Rule
 
 	// add to rules after ordering
-	configPaths.Each(func(b middleware.ConfigPath) {
-		rule, _ := b.(rewrite.Rule)
+	configs.Each(func(c middleware.Config) {
+		rule, _ := c.(rewrite.Rule)
 		rules = append(rules, rule)
 	})
 

--- a/middleware/path.go
+++ b/middleware/path.go
@@ -13,3 +13,36 @@ type Path string
 func (p Path) Matches(other string) bool {
 	return strings.HasPrefix(string(p), other)
 }
+
+// ConfigPath represents a configuration base path.
+type ConfigPath interface {
+	// Path returns base path value.
+	Path() string
+}
+
+// ConfigPaths is a list of ConfigPath
+type ConfigPaths []ConfigPath
+
+// Add adds a new ConfigPath to the list in descending order of
+// path length.
+func (paths *ConfigPaths) Add(b ConfigPath) {
+	idx := len(*paths)
+	for i, p := range *paths {
+		if len(p.Path()) < len(b.Path()) {
+			idx = i
+			break
+		}
+	}
+	part := []ConfigPath{b}
+	if idx < len(*paths) {
+		part = append(part, (*paths)[idx:]...)
+	}
+	*paths = append((*paths)[:idx], part...)
+}
+
+// Each iterates through all config paths and calls f on each iteration
+func (paths ConfigPaths) Each(f func(ConfigPath)) {
+	for _, p := range paths {
+		f(p)
+	}
+}

--- a/middleware/path.go
+++ b/middleware/path.go
@@ -14,35 +14,35 @@ func (p Path) Matches(other string) bool {
 	return strings.HasPrefix(string(p), other)
 }
 
-// ConfigPath represents a configuration base path.
-type ConfigPath interface {
+// Config represents a configuration.
+type Config interface {
 	// Path returns base path value.
 	Path() string
 }
 
-// ConfigPaths is a list of ConfigPath
-type ConfigPaths []ConfigPath
+// Configs is a list of Config
+type Configs []Config
 
-// Add adds a new ConfigPath to the list in descending order of
+// Add adds a new Config to the list in descending order of
 // path length.
-func (paths *ConfigPaths) Add(b ConfigPath) {
-	idx := len(*paths)
-	for i, p := range *paths {
-		if len(p.Path()) < len(b.Path()) {
+func (configs *Configs) Add(c Config) {
+	idx := len(*configs)
+	for i, config := range *configs {
+		if len(config.Path()) < len(c.Path()) {
 			idx = i
 			break
 		}
 	}
-	part := []ConfigPath{b}
-	if idx < len(*paths) {
-		part = append(part, (*paths)[idx:]...)
+	part := []Config{c}
+	if idx < len(*configs) {
+		part = append(part, (*configs)[idx:]...)
 	}
-	*paths = append((*paths)[:idx], part...)
+	*configs = append((*configs)[:idx], part...)
 }
 
-// Each iterates through all config paths and calls f on each iteration
-func (paths ConfigPaths) Each(f func(ConfigPath)) {
-	for _, p := range paths {
-		f(p)
+// Each iterates through all configs and calls f on each iteration
+func (configs Configs) Each(f func(Config)) {
+	for _, c := range configs {
+		f(c)
 	}
 }

--- a/middleware/path_test.go
+++ b/middleware/path_test.go
@@ -3,15 +3,15 @@ package middleware
 import "testing"
 
 func TestConfigPath(t *testing.T) {
-	testRules := ConfigPaths{
-		testPath("/"),
-		testPath("/school"),
-		testPath("/s"),
-		testPath("/sch"),
-		testPath("/schools"),
+	testRules := Configs{
+		testConfig("/"),
+		testConfig("/school"),
+		testConfig("/s"),
+		testConfig("/sch"),
+		testConfig("/schools"),
 	}
 
-	rules := ConfigPaths{}
+	rules := Configs{}
 	for _, r := range testRules {
 		rules.Add(r)
 	}
@@ -28,8 +28,8 @@ func TestConfigPath(t *testing.T) {
 
 }
 
-type testPath string
+type testConfig string
 
-func (t testPath) Path() string {
+func (t testConfig) Path() string {
 	return string(t)
 }

--- a/middleware/path_test.go
+++ b/middleware/path_test.go
@@ -1,0 +1,35 @@
+package middleware
+
+import "testing"
+
+func TestConfigPath(t *testing.T) {
+	testRules := ConfigPaths{
+		testPath("/"),
+		testPath("/school"),
+		testPath("/s"),
+		testPath("/sch"),
+		testPath("/schools"),
+	}
+
+	rules := ConfigPaths{}
+	for _, r := range testRules {
+		rules.Add(r)
+	}
+
+	expected := []string{
+		"/schools", "/school", "/sch", "/s", "/",
+	}
+
+	for i, r := range rules {
+		if r.Path() != expected[i] {
+			t.Errorf("Expected %v at index %d found %v", expected[i], i, r.Path())
+		}
+	}
+
+}
+
+type testPath string
+
+func (t testPath) Path() string {
+	return string(t)
+}

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -28,6 +28,8 @@ type Upstream interface {
 	Select() *UpstreamHost
 	// Checks if subpath is not an ignored path
 	IsAllowedPath(string) bool
+
+	middleware.ConfigPath
 }
 
 // UpstreamHostDownFunc can be used to customize how Down behaves.

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -29,7 +29,7 @@ type Upstream interface {
 	// Checks if subpath is not an ignored path
 	IsAllowedPath(string) bool
 
-	middleware.ConfigPath
+	middleware.Config
 }
 
 // UpstreamHostDownFunc can be used to customize how Down behaves.

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -111,6 +111,10 @@ func (u *fakeUpstream) From() string {
 	return "/"
 }
 
+func (u *fakeUpstream) Path() string {
+	return "/"
+}
+
 func (u *fakeUpstream) Select() *UpstreamHost {
 	uri, _ := url.Parse(u.name)
 	return &UpstreamHost{

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -34,10 +34,16 @@ type staticUpstream struct {
 	IgnoredSubPaths   []string
 }
 
+// Path satisfies middleware.ConfigPath
+func (s staticUpstream) Path() string {
+	return s.from
+}
+
 // NewStaticUpstreams parses the configuration input and sets up
 // static upstreams for the proxy middleware.
 func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 	var upstreams []Upstream
+	var configPaths middleware.ConfigPaths
 	for c.Next() {
 		upstream := &staticUpstream{
 			from:         "",
@@ -99,8 +105,16 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 		if upstream.HealthCheck.Path != "" {
 			go upstream.HealthCheckWorker(nil)
 		}
-		upstreams = append(upstreams, upstream)
+
+		configPaths.Add(upstream)
 	}
+
+	// retrieve in sorted order
+	configPaths.Each(func(c middleware.ConfigPath) {
+		upstream, _ := c.(Upstream)
+		upstreams = append(upstreams, upstream)
+	})
+
 	return upstreams, nil
 }
 

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -34,7 +34,7 @@ type staticUpstream struct {
 	IgnoredSubPaths   []string
 }
 
-// Path satisfies middleware.ConfigPath
+// Path satisfies middleware.Config
 func (s staticUpstream) Path() string {
 	return s.from
 }
@@ -43,7 +43,7 @@ func (s staticUpstream) Path() string {
 // static upstreams for the proxy middleware.
 func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 	var upstreams []Upstream
-	var configPaths middleware.ConfigPaths
+	var configs middleware.Configs
 	for c.Next() {
 		upstream := &staticUpstream{
 			from:         "",
@@ -106,11 +106,11 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 			go upstream.HealthCheckWorker(nil)
 		}
 
-		configPaths.Add(upstream)
+		configs.Add(upstream)
 	}
 
 	// retrieve in sorted order
-	configPaths.Each(func(c middleware.ConfigPath) {
+	configs.Each(func(c middleware.Config) {
 		upstream, _ := c.(Upstream)
 		upstreams = append(upstreams, upstream)
 	})

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -57,7 +57,7 @@ type Rule interface {
 	// Rewrite rewrites the internal location of the current request.
 	Rewrite(http.FileSystem, *http.Request) Result
 
-	middleware.ConfigPath
+	middleware.Config
 }
 
 // SimpleRule is a simple rewrite rule.
@@ -70,7 +70,7 @@ func NewSimpleRule(from, to string) SimpleRule {
 	return SimpleRule{from, to}
 }
 
-// Path satisfies middleware.ConfigPath
+// Path satisfies middleware.Config
 func (s SimpleRule) Path() string {
 	return s.From
 }
@@ -142,7 +142,7 @@ func NewComplexRule(base, pattern, to string, status int, ext []string, ifs []If
 	}, nil
 }
 
-// Path satisfies middleware.ConfigPath.
+// Path satisfies middleware.Config.
 func (r *ComplexRule) Path() string {
 	return r.Base
 }

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -56,6 +56,8 @@ outer:
 type Rule interface {
 	// Rewrite rewrites the internal location of the current request.
 	Rewrite(http.FileSystem, *http.Request) Result
+
+	middleware.ConfigPath
 }
 
 // SimpleRule is a simple rewrite rule.
@@ -66,6 +68,11 @@ type SimpleRule struct {
 // NewSimpleRule creates a new Simple Rule
 func NewSimpleRule(from, to string) SimpleRule {
 	return SimpleRule{from, to}
+}
+
+// Path satisfies middleware.ConfigPath
+func (s SimpleRule) Path() string {
+	return s.From
 }
 
 // Rewrite rewrites the internal location of the current request.
@@ -133,6 +140,11 @@ func NewComplexRule(base, pattern, to string, status int, ext []string, ifs []If
 		Ifs:    ifs,
 		Regexp: r,
 	}, nil
+}
+
+// Path satisfies middleware.ConfigPath.
+func (r *ComplexRule) Path() string {
+	return r.Base
 }
 
 // Rewrite rewrites the internal location of the current request.


### PR DESCRIPTION
This is a simple but working approach to processing longer paths before shorter ones.

Right now, caddy will not process the second rewrite config except the configuration is modified to put the `/blog` config first. Similar situation occurs in Proxy and possibly other middlewares. This PR will allow `/blog` to be processed first irrespective of the config order.
```
rewrite { ... }
rewrite /blog { ... }
```

The approach can be changed later, it is only a matter of modifying `Configs.Add` function.