### PR TITLE
Add .svg to default ext list in gzip middleware

### DIFF
--- a/middleware/gzip/request_filter.go
+++ b/middleware/gzip/request_filter.go
@@ -15,7 +15,7 @@ type RequestFilter interface {
 }
 
 // defaultExtensions is the list of default extensions for which to enable gzipping.
-var defaultExtensions = []string{"", ".txt", ".htm", ".html", ".css", ".php", ".js", ".json", ".md", ".xml"}
+var defaultExtensions = []string{"", ".txt", ".htm", ".html", ".css", ".php", ".js", ".json", ".md", ".xml", ".svg"}
 
 // DefaultExtFilter creates an ExtFilter with default extensions.
 func DefaultExtFilter() ExtFilter {


### PR DESCRIPTION
SVG files are text based and can be compressed. Also Google PageSpeed Insights service warn if .svg files not compressed.