### PR TITLE
Parse address from fastcgi directive, pass results to Dial()

### DIFF
--- a/middleware/fastcgi/fastcgi.go
+++ b/middleware/fastcgi/fastcgi.go
@@ -70,7 +70,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 			}
 
 			// Connect to FastCGI gateway
-			fcgi, err := getClient(&rule)
+			network, address := rule.parseAddress()
+			fcgi, err := Dial(network, address)
 			if err != nil {
 				return http.StatusBadGateway, err
 			}
@@ -128,15 +129,28 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	return h.Next.ServeHTTP(w, r)
 }
 
-func getClient(r *Rule) (*FCGIClient, error) {
-	// check if unix socket or TCP
+// parseAddress returns the network and address of r.
+// The first string is the network, "tcp" or "unix", implied from the scheme and address.
+// The second string is r.Address, with scheme prefixes removed.
+// The two returned strings can be used as parameters to the Dial() function.
+func (r Rule) parseAddress() (string, string) {
+	// check if address has tcp scheme explicitly set
+	if strings.HasPrefix(r.Address, "tcp://") {
+		return "tcp", r.Address[len("tcp://"):]
+	}
+	// check if address has fastcgi scheme explicity set
+	if strings.HasPrefix(r.Address, "fastcgi://") {
+		return "tcp", r.Address[len("fastcgi://"):]
+	}
+	// check if unix socket
 	if trim := strings.HasPrefix(r.Address, "unix"); strings.HasPrefix(r.Address, "/") || trim {
 		if trim {
-			r.Address = r.Address[len("unix:"):]
+			return "unix", r.Address[len("unix:"):]
 		}
-		return Dial("unix", r.Address)
+		return "unix", r.Address
 	}
-	return Dial("tcp", r.Address)
+	// default case, a plain tcp address with no scheme
+	return "tcp", r.Address
 }
 
 func writeHeader(w http.ResponseWriter, r *http.Response) {

--- a/middleware/fastcgi/fastcgi_test.go
+++ b/middleware/fastcgi/fastcgi_test.go
@@ -1,0 +1,31 @@
+package fastcgi
+
+import (
+	"testing"
+)
+
+func TestRuleParseAddress(t *testing.T) {
+
+	getClientTestTable := []struct {
+		rule            *Rule
+		expectednetwork string
+		expectedaddress string
+	}{
+		{&Rule{Address: "tcp://172.17.0.1:9000"}, "tcp", "172.17.0.1:9000"},
+		{&Rule{Address: "fastcgi://localhost:9000"}, "tcp", "localhost:9000"},
+		{&Rule{Address: "172.17.0.15"}, "tcp", "172.17.0.15"},
+		{&Rule{Address: "/my/unix/socket"}, "unix", "/my/unix/socket"},
+		{&Rule{Address: "unix:/second/unix/socket"}, "unix", "/second/unix/socket"},
+	}
+
+	for _, entry := range getClientTestTable {
+		if actualnetwork, _ := entry.rule.parseAddress(); actualnetwork != entry.expectednetwork {
+			t.Errorf("Unexpected network for address string %v. Got %v, expected %v", entry.rule.Address, actualnetwork, entry.expectednetwork)
+		}
+		if _, actualaddress := entry.rule.parseAddress(); actualaddress != entry.expectedaddress {
+			t.Errorf("Unexpected parsed address for address string %v. Got %v, expected %v", entry.rule.Address, actualaddress, entry.expectedaddress)
+		}
+
+	}
+
+}


### PR DESCRIPTION
This allows scheme prefixes "tcp://" and "fastcgi://" in configuration.

Fixes #540