### PR TITLE
FastCGI: IPv6 when parsing r.RemoteAddr

### DIFF
--- a/middleware/fastcgi/fastcgi.go
+++ b/middleware/fastcgi/fastcgi.go
@@ -182,7 +182,7 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 
 	// Separate remote IP and port; more lenient than net.SplitHostPort
 	var ip, port string
-	if idx := strings.Index(r.RemoteAddr, ":"); idx > -1 {
+	if idx := strings.LastIndex(r.RemoteAddr, ":"); idx > -1 {
 		ip = r.RemoteAddr[:idx]
 		port = r.RemoteAddr[idx+1:]
 	} else {

--- a/middleware/fastcgi/fastcgi_test.go
+++ b/middleware/fastcgi/fastcgi_test.go
@@ -32,24 +32,24 @@ func TestRuleParseAddress(t *testing.T) {
 
 }
 
-func BuildEnvSingle(r *http.Request, rule Rule, fpath string, envExpected map[string]string, t *testing.T) {
-
-	h := Handler{}
-
-	env, err := h.buildEnv(r, rule, fpath)
-	if err != nil {
-		t.Error("Unexpected error:", err.Error())
-	}
-
-	for k, v := range envExpected {
-		if env[k] != v {
-			t.Errorf("Unexpected %v. Got %v, expected %v", k, env[k], v)
-		}
-	}
-
-}
-
 func TestBuildEnv(t *testing.T) {
+
+	buildEnvSingle := func(r *http.Request, rule Rule, fpath string, envExpected map[string]string, t *testing.T) {
+	
+		h := Handler{}
+	
+		env, err := h.buildEnv(r, rule, fpath)
+		if err != nil {
+			t.Error("Unexpected error:", err.Error())
+		}
+	
+		for k, v := range envExpected {
+			if env[k] != v {
+				t.Errorf("Unexpected %v. Got %v, expected %v", k, env[k], v)
+			}
+		}
+	
+	}
 
 	rule := Rule{}
 	url, err := url.Parse("http://localhost:2015/fgci_test.php?test=blabla")
@@ -80,16 +80,16 @@ func TestBuildEnv(t *testing.T) {
 	}
 
 	// 1. Test for full canonical IPv6 address
-	BuildEnvSingle(&r, rule, fpath, envExpected, t)
+	buildEnvSingle(&r, rule, fpath, envExpected, t)
 
 	// 2. Test for shorthand notation of IPv6 address
 	r.RemoteAddr = "[::1]:51688"
 	envExpected["REMOTE_ADDR"] = "[::1]"
-	BuildEnvSingle(&r, rule, fpath, envExpected, t)
+	buildEnvSingle(&r, rule, fpath, envExpected, t)
 
 	// 3. Test for IPv4 address
 	r.RemoteAddr = "192.168.0.10:51688"
 	envExpected["REMOTE_ADDR"] = "192.168.0.10"
-	BuildEnvSingle(&r, rule, fpath, envExpected, t)
+	buildEnvSingle(&r, rule, fpath, envExpected, t)
 
 }

--- a/middleware/fastcgi/fastcgi_test.go
+++ b/middleware/fastcgi/fastcgi_test.go
@@ -1,6 +1,8 @@
 package fastcgi
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -27,5 +29,67 @@ func TestRuleParseAddress(t *testing.T) {
 		}
 
 	}
+
+}
+
+func BuildEnvSingle(r *http.Request, rule Rule, fpath string, envExpected map[string]string, t *testing.T) {
+
+	h := Handler{}
+
+	env, err := h.buildEnv(r, rule, fpath)
+	if err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+
+	for k, v := range envExpected {
+		if env[k] != v {
+			t.Errorf("Unexpected %v. Got %v, expected %v", k, env[k], v)
+		}
+	}
+
+}
+
+func TestBuildEnv(t *testing.T) {
+
+	rule := Rule{}
+	url, err := url.Parse("http://localhost:2015/fgci_test.php?test=blabla")
+	if err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+
+	r := http.Request{
+		Method:     "GET",
+		URL:        url,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Host:       "localhost:2015",
+		RemoteAddr: "[2b02:1810:4f2d:9400:70ab:f822:be8a:9093]:51688",
+		RequestURI: "/fgci_test.php",
+	}
+
+	fpath := "/fgci_test.php"
+
+	var envExpected = map[string]string{
+		"REMOTE_ADDR":     "[2b02:1810:4f2d:9400:70ab:f822:be8a:9093]",
+		"REMOTE_PORT":     "51688",
+		"SERVER_PROTOCOL": "HTTP/1.1",
+		"QUERY_STRING":    "test=blabla",
+		"REQUEST_METHOD":  "GET",
+		"HTTP_HOST":       "localhost:2015",
+	}
+
+	// 1. Test for full canonical IPv6 address
+	BuildEnvSingle(&r, rule, fpath, envExpected, t)
+
+	// 2. Test for shorthand notation of IPv6 address
+	r.RemoteAddr = "[::1]:51688"
+	envExpected["REMOTE_ADDR"] = "[::1]"
+	BuildEnvSingle(&r, rule, fpath, envExpected, t)
+
+	// 3. Test for IPv4 address
+	r.RemoteAddr = "192.168.0.10:51688"
+	envExpected["REMOTE_ADDR"] = "192.168.0.10"
+	BuildEnvSingle(&r, rule, fpath, envExpected, t)
 
 }


### PR DESCRIPTION
When trying Caddy in production I noticed that `REMOTE_ADDR` didn't contain the full IP, in case of IPv6. This happens because you take the index of the first `:`, this works perfectly for IPv4 addresses, but for IPv6 addresses (which contain `:` :smile: ) it doesn't work.
Splitting it on the last `:` should split it correctly into port and ip.

I could only test this (very basically) on my local machine. So maybe you need to test it on your remote environment on some real IPs. (Can't do that right now.)