### PR TITLE
Making directives externally registerable

### DIFF
--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -68,6 +68,23 @@ var directiveOrder = []directive{
 	{"browse", setup.Browse},
 }
 
+// RegisterDirective adds the given directive to caddy's list of directives.
+// Pass the name of a directive you want it to be placed after,
+// otherwise it will be placed at the bottom of the stack.
+func RegisterDirective(name string, setup SetupFunc, after string) {
+	dir := directive{name: name, setup: setup}
+	idx := len(directiveOrder)
+	for i := range directiveOrder {
+		if directiveOrder[i].name == after {
+			idx = i + 1
+			break
+		}
+	}
+	newDirectives := append(directiveOrder[:idx], append([]directive{dir}, directiveOrder[idx:]...)...)
+	directiveOrder = newDirectives
+	parse.ValidDirectives[name] = struct{}{}
+}
+
 // directive ties together a directive name with its setup function.
 type directive struct {
 	name  string

--- a/caddy/directives_test.go
+++ b/caddy/directives_test.go
@@ -1,0 +1,31 @@
+package caddy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	directives := []directive{
+		{"dummy", nil},
+		{"dummy2", nil},
+	}
+	directiveOrder = directives
+	RegisterDirective("foo", nil, "dummy")
+	if len(directiveOrder) != 3 {
+		t.Fatal("Should have 3 directives now")
+	}
+	getNames := func() (s []string) {
+		for _, d := range directiveOrder {
+			s = append(s, d.name)
+		}
+		return s
+	}
+	if !reflect.DeepEqual(getNames(), []string{"dummy", "foo", "dummy2"}) {
+		t.Fatalf("directive order doesn't match: %s", getNames())
+	}
+	RegisterDirective("bar", nil, "ASDASD")
+	if !reflect.DeepEqual(getNames(), []string{"dummy", "foo", "dummy2", "bar"}) {
+		t.Fatalf("directive order doesn't match: %s", getNames())
+	}
+}


### PR DESCRIPTION
This will allow other packages using caddy as a library to register directives without modifying caddy's source. 

I can also make a custom fork of caddy and register plugins in an init function in a separate file to make a custom build of caddy.