### PR TITLE
letsencrypt: properly retrieve hostname from request.

### DIFF
--- a/caddy/letsencrypt/handler.go
+++ b/caddy/letsencrypt/handler.go
@@ -23,9 +23,9 @@ func RequestCallback(w http.ResponseWriter, r *http.Request) bool {
 			scheme = "https"
 		}
 
-		hostname, _, err := net.SplitHostPort(r.URL.Host)
+		hostname, _, err := net.SplitHostPort(r.Host)
 		if err != nil {
-			hostname = r.URL.Host
+			hostname = r.Host
 		}
 
 		upstream, err := url.Parse(scheme + "://" + hostname + ":" + AlternatePort)


### PR DESCRIPTION
This minor bug did not show in the tests, but in preparations for my "local hack" for #549.

On server side `net/http/Request.URL` is always the empty string. This is IMHO quite underdocumented. See comments at https://github.com/golang/go/blob/3092a63a649ee95865e8b1da4eb2ee4bfe634a7e/src/net/http/request.go#L79 .

Apparently `net/http/httputil.NewSingleHostReverseProxy` is quite happy with `"http://:5033"`(sic!) if the server is on localhost.

`net/http.Request.Host` is apparently the proper way. From the [godoc](https://godoc.org/net/http#Request):  
    // For server requests Host specifies the host on which the
    // URL is sought. Per RFC 2616, this is either the value of
    // the "Host" header or the host name given in the URL itself.
    // It may be of the form "host:port".