### PR TITLE
basicauth: fix go vet (go 1.6)

### DIFF
--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -139,7 +139,7 @@ md5:$apr1$l42y8rex$pOA2VJ0x/0TwaFeAF9nX61`
 		if rule.Password, err = GetHtpasswdMatcher(filename, rule.Username, siteRoot); err != nil {
 			t.Fatalf("GetHtpasswdMatcher(%q, %q): %v", htfh.Name(), rule.Username, err)
 		}
-		t.Logf("%d. username=%q password=%v", i, rule.Username, rule.Password)
+		t.Logf("%d. username=%q password=%v", i, rule.Username, rule.Password())
 		if !rule.Password(htpasswdPasswd) || rule.Password(htpasswdPasswd+"!") {
 			t.Errorf("%d (%s) password does not match.", i, rule.Username)
 		}


### PR DESCRIPTION
Quick go vet fix.

"The go vet command now diagnoses passing function or method values as arguments to Printf, such as when passing f where f() was intended." [Go 1.6 releas notes.](https://tip.golang.org/doc/go1.6#vet_command)