### PR TITLE
basicauth: fixed 'go vet' printing function value

### DIFF
--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -139,7 +139,7 @@ md5:$apr1$l42y8rex$pOA2VJ0x/0TwaFeAF9nX61`
 		if rule.Password, err = GetHtpasswdMatcher(filename, rule.Username, siteRoot); err != nil {
 			t.Fatalf("GetHtpasswdMatcher(%q, %q): %v", htfh.Name(), rule.Username, err)
 		}
-		t.Logf("%d. username=%q password=%v", i, rule.Username, rule.Password)
+		t.Logf("%d. username=%q", i, rule.Username)
 		if !rule.Password(htpasswdPasswd) || rule.Password(htpasswdPasswd+"!") {
 			t.Errorf("%d (%s) password does not match.", i, rule.Username)
 		}


### PR DESCRIPTION
`go vet` on tip (Travis) yielded the following error:

```
$ go vet ./...
middleware/basicauth/basicauth_test.go:142: arg rule.Password in printf call is a function value, not a function call
```

This is newly introduced in Go 1.6, where it complains about using the value of a function instead of the call (`rule.Password` is a function, and not a field with some value). Which was exactly what was happening in the line I changed: it just printed the address of the function pointer:

```go
t.Logf("%d. username=%q password=%v", i, rule.Username, rule.Password)
```

```
basicauth_test.go:142: 1. username="md5" password=0x88330
```

I removed the output of that function value, since it's useless and doesn't gives any info. (Or I misunderstood this whole bit of code...)

P.S. I hope Travis accepts this build :D