### PR TITLE
Add .Markdown directive

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/russross/blackfriday"
 )
 
 // This file contains the context and functions available for
@@ -189,4 +191,18 @@ func (c Context) StripExt(path string) string {
 // Replace replaces instances of find in input with replacement.
 func (c Context) Replace(input, find, replacement string) string {
 	return strings.Replace(input, find, replacement, -1)
+}
+
+// Markdown returns the HTML contents of the markdown contained in filename
+// (relative to the site root).
+func (c Context) Markdown(filename string) (string, error) {
+	body, err := c.Include(filename)
+	if err != nil {
+		return "", err
+	}
+	renderer := blackfriday.HtmlRenderer(0, "", "")
+	extns := blackfriday.EXTENSION_TABLES | blackfriday.EXTENSION_FENCED_CODE | blackfriday.EXTENSION_STRIKETHROUGH | blackfriday.EXTENSION_DEFINITION_LISTS
+	markdown := blackfriday.Markdown([]byte(body), renderer, extns)
+
+	return string(markdown), nil
 }

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -92,6 +92,45 @@ func TestIncludeNotExisting(t *testing.T) {
 	}
 }
 
+func TestMarkdown(t *testing.T) {
+	context := getContextOrFail(t)
+
+	inputFilename := "test_file"
+	absInFilePath := filepath.Join(fmt.Sprintf("%s", context.Root), inputFilename)
+	defer func() {
+		err := os.Remove(absInFilePath)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("Failed to clean test file!")
+		}
+	}()
+
+	tests := []struct {
+		fileContent          string
+		expectedContent      string
+	}{
+		// Test 0 - test parsing of markdown
+		{
+			fileContent:          "* str1\n* str2\n",
+			expectedContent:      "<ul>\n<li>str1</li>\n<li>str2</li>\n</ul>\n",
+		},
+	}
+
+	for i, test := range tests {
+		testPrefix := getTestPrefix(i)
+
+		// WriteFile truncates the contentt
+		err := ioutil.WriteFile(absInFilePath, []byte(test.fileContent), os.ModePerm)
+		if err != nil {
+			t.Fatal(testPrefix+"Failed to create test file. Error was: %v", err)
+		}
+
+		content, _ := context.Markdown(inputFilename)
+		if content != test.expectedContent {
+			t.Errorf(testPrefix+"Expected content [%s] but found [%s]. Input file was: %s", test.expectedContent, content, inputFilename)
+		}
+	}
+}
+
 func TestCookie(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
This allows any template to use:
{{.Markdown "filename"}} which will convert the markdown contents
of filename to HTML and then include the HTML in the template.