### PR TITLE
New function DialWithDialer to create FCGIClient with custom Dialer.

### DIFF
--- a/middleware/fastcgi/fcgiclient.go
+++ b/middleware/fastcgi/fcgiclient.go
@@ -169,12 +169,11 @@ type FCGIClient struct {
 	reqID     uint16
 }
 
-// Dial connects to the fcgi responder at the specified network address.
+// DialWithDialer connects to the fcgi responder at the specified network address, using custom net.Dialer.
 // See func net.Dial for a description of the network and address parameters.
-func Dial(network, address string) (fcgi *FCGIClient, err error) {
+func DialWithDialer(network, address string, dialer net.Dialer) (fcgi *FCGIClient, err error) {
 	var conn net.Conn
-
-	conn, err = net.Dial(network, address)
+	conn, err = dialer.Dial(network, address)
 	if err != nil {
 		return
 	}
@@ -186,6 +185,12 @@ func Dial(network, address string) (fcgi *FCGIClient, err error) {
 	}
 
 	return
+}
+
+// Dial connects to the fcgi responder at the specified network address, using default net.Dialer.
+// See func net.Dial for a description of the network and address parameters.
+func Dial(network, address string) (fcgi *FCGIClient, err error) {
+	return DialWithDialer(network, address, net.Dialer{})
 }
 
 // Close closes fcgi connnection


### PR DESCRIPTION
Sometimes we need to customize some Dialer parameters, e.g. set configurable Timeout. Function DialWithDialer allow to create FCGIClient and dial using custom Dialer, but not only the default net.Dialer. Changes are back compatible: function Dial is still there and use default "empty" net.Dialer.