### PR TITLE
Create pt-BR translation file

### DIFF
--- a/caddy/translate/pt-BR.go
+++ b/caddy/translate/pt-BR.go
@@ -1,0 +1,12 @@
+package translate
+
+func init() {
+	AddLanguage("pt-BR", ptBR)
+}
+
+var ptBR = map[string]string{
+	"Agree to Let's Encrypt Subscriber Agreement": "Concorda com o Acordo de Subscrição do Let's Encrypt",
+	"Certificate authority's ACME server":         "Servidor ACME da autoridade de certificação",
+	"Error opening process log file: %v":          "Erro ao abrir o arquivo de log do proceso: %v",
+	"Revoked certificate for %s\n":                "Certificado revogado para %s\n",
+}


### PR DESCRIPTION
So, here is the pt-BR translation for Caddy. I think that we have a lot of other strings to translate, so would be good to have a default en-US file with all strings on Caddy that need to be translated.