### PR TITLE
Adding support for Let's Encrypt DNS challenge.

### DIFF
--- a/caddy/https/https.go
+++ b/caddy/https/https.go
@@ -127,12 +127,14 @@ func ObtainCerts(configs []server.Config, allowPrompts, proxyACME bool) error {
 			if cfg.Host == "" || existingCertAndKey(cfg.Host) {
 				continue
 			}
-
 			// c.Configure assumes that allowPrompts == !proxyACME,
 			// but that's not always true. For example, a restart where
 			// the user isn't present and we're not listening on port 80.
 			// TODO: This could probably be refactored better.
-			if proxyACME {
+			if cfg.TLS.DNSProvider != nil {
+				client.SetChallengeProvider(acme.DNS01, cfg.TLS.DNSProvider)
+				client.ExcludeChallenges([]acme.Challenge{acme.TLSSNI01, acme.HTTP01})
+			} else if proxyACME {
 				client.SetHTTPAddress(net.JoinHostPort(cfg.BindHost, AlternatePort))
 				client.SetTLSAddress(net.JoinHostPort(cfg.BindHost, AlternatePort))
 				client.ExcludeChallenges([]acme.Challenge{acme.TLSSNI01, acme.DNS01})
@@ -148,7 +150,6 @@ func ObtainCerts(configs []server.Config, allowPrompts, proxyACME bool) error {
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/mholt/caddy/middleware"
+	"github.com/xenolf/lego/acme"
 )
 
 // Config configuration for a single server.
@@ -75,4 +76,5 @@ type TLSConfig struct {
 	ProtocolMaxVersion       uint16
 	PreferServerCipherSuites bool
 	ClientCerts              []string
+	DNSProvider              acme.ChallengeProvider
 }


### PR DESCRIPTION
This adds support for all dns challenges supported by lego (except manual because we can't automatically renew.)

Usage is simple:

```
tls {
   dns provider args...
}
```

```
tls {
   dns cloudflare myname@myemail.tld token1233141241241241deadf00d
}
```