### PR TITLE
Adding pprof middleware for profiling caddy.

### DIFF
--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -61,6 +61,7 @@ var directiveOrder = []directive{
 	{"mime", setup.Mime},
 	{"basicauth", setup.BasicAuth},
 	{"internal", setup.Internal},
+	{"pprof", setup.PProf},
 	{"proxy", setup.Proxy},
 	{"fastcgi", setup.FastCGI},
 	{"websocket", setup.WebSocket},

--- a/caddy/setup/pprof.go
+++ b/caddy/setup/pprof.go
@@ -1,0 +1,26 @@
+package setup
+
+import (
+	"github.com/mholt/caddy/middleware"
+	"github.com/mholt/caddy/middleware/pprof"
+)
+
+//PProf returns a new instance of a pprof handler. It accepts no arguments or options.
+func PProf(c *Controller) (middleware.Middleware, error) {
+	found := false
+	for c.Next() {
+		if found {
+			return nil, c.Err("pprof can only be specified once")
+		}
+		if len(c.RemainingArgs()) != 0 {
+			return nil, c.ArgErr()
+		}
+		if c.NextBlock() {
+			return nil, c.ArgErr()
+		}
+		found = true
+	}
+	return func(next middleware.Handler) middleware.Handler {
+		return pprof.New(next)
+	}, nil
+}

--- a/caddy/setup/pprof_test.go
+++ b/caddy/setup/pprof_test.go
@@ -1,0 +1,28 @@
+package setup
+
+import "testing"
+
+func TestPProf(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+	}{
+		{`pprof`, false},
+		{`pprof {}`, true},
+		{`pprof /foo`, true},
+		{`pprof {
+            a b
+        }`, true},
+		{`pprof
+          pprof`, true},
+	}
+	for i, test := range tests {
+		c := NewTestController(test.input)
+		_, err := PProf(c)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+		}
+	}
+}

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -1,0 +1,34 @@
+package pprof
+
+import (
+	"net/http"
+	pp "net/http/pprof"
+
+	"github.com/mholt/caddy/middleware"
+)
+
+//Handler is a simple struct whose ServeHTTP will delegate relevant pprof endpoints to net/http/pprof
+type handler struct {
+	mux *http.ServeMux
+}
+
+//New creates a new pprof middleware
+func New(next middleware.Handler) middleware.Handler {
+	//pretty much copying what pprof does on init: https://golang.org/src/net/http/pprof/pprof.go#L67
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pp.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pp.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pp.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pp.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pp.Trace)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+	return &handler{mux}
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	rec := middleware.NewResponseRecorder(w)
+	h.mux.ServeHTTP(rec, r)
+	return rec.Status(), nil
+}


### PR DESCRIPTION
This is a really simple middleware for profiling caddy. It simply adds the pprof routes at the same paths the pprof package adds when you import it.

config is simply adding `pprof` to your caddyfile. Nothing else is supported.

I added it as a default middleware simply because I can't see any reason it would ever need serious changes or issues. 

Is this valuable enough to merge? Does it need documentation, or should it just be for caddy devs who know about it? It doesn't have a ton of use for general users, but I think it can be real useful in analyzing caddy's memory/cpu footprint if issues arise.

Fixes #610 