### PR TITLE
Fix missing Content-Type for certain errors

### DIFF
--- a/caddy/setup/errors.go
+++ b/caddy/setup/errors.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mholt/caddy/middleware/errors"
 )
 
-// Errors configures a new gzip middleware instance.
+// Errors configures a new errors middleware instance.
 func Errors(c *Controller) (middleware.Middleware, error) {
 	handler, err := errorsParse(c)
 	if err != nil {

--- a/middleware/errors/errors.go
+++ b/middleware/errors/errors.go
@@ -34,6 +34,7 @@ func (h ErrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, er
 
 		if h.Debug {
 			// Write error to response instead of to log
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(status)
 			fmt.Fprintln(w, errMsg)
 			return 0, err // returning < 400 signals that a response has been written
@@ -124,6 +125,7 @@ func (h ErrorHandler) recovery(w http.ResponseWriter, r *http.Request) {
 		// Write error and stack trace to the response rather than to a log
 		var stackBuf [4096]byte
 		stack := stackBuf[:runtime.Stack(stackBuf[:], false)]
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "%s\n\n%s", panicMsg, stack)
 	} else {


### PR DESCRIPTION
The missing Content-Type for some errors that will be shown to the client will cause a Content-Type of `application/x-gzip` to be returned. This has undesirable results as it either causes a file download, or in the case for Google Chrome, I received an `ERR_INVALID_RESPONSE`.