### PR TITLE
Implement .DocFlags directive and tests

### DIFF
--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -33,6 +33,18 @@ func TestMarkdown(t *testing.T) {
 				StaticFiles: make(map[string]string),
 			},
 			{
+				Renderer:   blackfriday.HtmlRenderer(0, "", ""),
+				PathScope:  "/docflags",
+				Extensions: []string{".md"},
+				Styles:     []string{},
+				Scripts:    []string{},
+				Templates: map[string]string{
+					DefaultTemplate: "testdata/docflags/template.txt",
+				},
+				StaticDir:   DefaultStaticDir,
+				StaticFiles: make(map[string]string),
+			},
+			{
 				Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 				PathScope:   "/log",
 				Extensions:  []string{".md"},
@@ -114,6 +126,26 @@ Welcome to A Caddy website!
 		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
 	}
 
+	req, err = http.NewRequest("GET", "/docflags/test.md", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+	rec = httptest.NewRecorder()
+
+	md.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
+	}
+	respBody = rec.Body.String()
+	expectedBody = `Doc.var_string hello
+Doc.var_bool <no value>
+DocFlags.var_string <no value>
+DocFlags.var_bool true`
+
+	if !equalStrings(respBody, expectedBody) {
+		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	}
+
 	req, err = http.NewRequest("GET", "/log/test.md", nil)
 	if err != nil {
 		t.Fatalf("Could not create HTTP request: %v", err)
@@ -190,6 +222,7 @@ Welcome to title!
 
 	expectedLinks := []string{
 		"/blog/test.md",
+		"/docflags/test.md",
 		"/log/test.md",
 	}
 

--- a/middleware/markdown/metadata.go
+++ b/middleware/markdown/metadata.go
@@ -23,6 +23,9 @@ type Metadata struct {
 
 	// Variables to be used with Template
 	Variables map[string]string
+
+	// Flags to be used with Template
+	Flags map[string]bool
 }
 
 // load loads parsed values in parsedMap into Metadata
@@ -40,8 +43,11 @@ func (m *Metadata) load(parsedMap map[string]interface{}) {
 	}
 	// store everything as a variable
 	for key, val := range parsedMap {
-		if v, ok := val.(string); ok {
+		switch v := val.(type) {
+		case string:
 			m.Variables[key] = v
+		case bool:
+			m.Flags[key] = v
 		}
 	}
 }
@@ -219,11 +225,18 @@ func findParser(b []byte) MetadataParser {
 	return nil
 }
 
+func newMetadata() Metadata {
+	return Metadata{
+		Variables: make(map[string]string),
+		Flags:     make(map[string]bool),
+	}
+}
+
 // parsers returns all available parsers
 func parsers() []MetadataParser {
 	return []MetadataParser{
-		&JSONMetadataParser{metadata: Metadata{Variables: make(map[string]string)}},
-		&TOMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}},
-		&YAMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}},
+		&JSONMetadataParser{metadata: newMetadata()},
+		&TOMLMetadataParser{metadata: newMetadata()},
+		&YAMLMetadataParser{metadata: newMetadata()},
 	}
 }

--- a/middleware/markdown/metadata_test.go
+++ b/middleware/markdown/metadata_test.go
@@ -18,11 +18,15 @@ var TOML = [5]string{`
 title = "A title"
 template = "default"
 name = "value"
+positive = true
+negative = false
 `,
 	`+++
 title = "A title"
 template = "default"
 name = "value"
+positive = true
+negative = false
 +++
 Page content
 	`,
@@ -30,12 +34,16 @@ Page content
 title = "A title"
 template = "default"
 name = "value"
+positive = true
+negative = false
 	`,
 	`title = "A title" template = "default" [variables] name = "value"`,
 	`+++
 title = "A title"
 template = "default"
 name = "value"
+positive = true
+negative = false
 +++
 `,
 }
@@ -44,11 +52,15 @@ var YAML = [5]string{`
 title : A title
 template : default
 name : value
+positive : true
+negative : false
 `,
 	`---
 title : A title
 template : default
 name : value
+positive : true
+negative : false
 ---
 	Page content
 	`,
@@ -57,11 +69,13 @@ title : A title
 template : default
 name : value
 	`,
-	`title : A title template : default variables : name : value`,
+	`title : A title template : default variables : name : value : positive : true : negative : false`,
 	`---
 title : A title
 template : default
 name : value
+positive : true
+negative : false
 ---
 `,
 }
@@ -69,12 +83,16 @@ name : value
 var JSON = [5]string{`
 	"title" : "A title",
 	"template" : "default",
-	"name" : "value"
+	"name" : "value",
+	"positive" : true,
+	"negative" : false
 `,
 	`{
 	"title" : "A title",
 	"template" : "default",
-	"name" : "value"
+	"name" : "value",
+	"positive" : true,
+	"negative" : false
 }
 Page content
 	`,
@@ -82,19 +100,25 @@ Page content
 {
 	"title" : "A title",
 	"template" : "default",
-	"name" : "value"
+	"name" : "value",
+	"positive" : true,
+	"negative" : false
 	`,
 	`
 {
 	"title" :: "A title",
 	"template" : "default",
-	"name" : "value"
+	"name" : "value",
+	"positive" : true,
+	"negative" : false
 }
 	`,
 	`{
 	"title" : "A title",
 	"template" : "default",
-	"name" : "value"
+	"name" : "value",
+	"positive" : true,
+	"negative" : false
 }
 `,
 }
@@ -107,6 +131,10 @@ func TestParsers(t *testing.T) {
 			"name":     "value",
 			"title":    "A title",
 			"template": "default",
+		},
+		Flags: map[string]bool{
+			"positive": true,
+			"negative": false,
 		},
 	}
 	compare := func(m Metadata) bool {
@@ -121,7 +149,14 @@ func TestParsers(t *testing.T) {
 				return false
 			}
 		}
-		return len(m.Variables) == len(expected.Variables)
+		for k, v := range m.Flags {
+			if v != expected.Flags[k] {
+				return false
+			}
+		}
+		varLenOK := len(m.Variables) == len(expected.Variables)
+		flagLenOK := len(m.Flags) == len(expected.Flags)
+		return varLenOK && flagLenOK
 	}
 
 	data := []struct {
@@ -129,9 +164,9 @@ func TestParsers(t *testing.T) {
 		testData [5]string
 		name     string
 	}{
-		{&JSONMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, JSON, "json"},
-		{&YAMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, YAML, "yaml"},
-		{&TOMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, TOML, "toml"},
+		{&JSONMetadataParser{metadata: newMetadata()}, JSON, "json"},
+		{&YAMLMetadataParser{metadata: newMetadata()}, YAML, "yaml"},
+		{&TOMLMetadataParser{metadata: newMetadata()}, TOML, "toml"},
 	}
 
 	for _, v := range data {
@@ -207,9 +242,9 @@ Mycket olika byggnader har man i de nordiska rikena: pyramidformiga, kilformiga,
 		testData string
 		name     string
 	}{
-		{&JSONMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, JSON, "json"},
-		{&YAMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, YAML, "yaml"},
-		{&TOMLMetadataParser{metadata: Metadata{Variables: make(map[string]string)}}, TOML, "toml"},
+		{&JSONMetadataParser{metadata: newMetadata()}, JSON, "json"},
+		{&YAMLMetadataParser{metadata: newMetadata()}, YAML, "yaml"},
+		{&TOMLMetadataParser{metadata: newMetadata()}, TOML, "toml"},
 	}
 	for _, v := range data {
 		// metadata without identifiers

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -23,14 +23,15 @@ const (
 // Data represents a markdown document.
 type Data struct {
 	middleware.Context
-	Doc   map[string]string
-	Links []PageLink
+	Doc      map[string]string
+	DocFlags map[string]bool
+	Links    []PageLink
 }
 
 // Process processes the contents of a page in b. It parses the metadata
 // (if any) and uses the template (if found).
 func (md Markdown) Process(c *Config, requestPath string, b []byte, ctx middleware.Context) ([]byte, error) {
-	var metadata = Metadata{Variables: make(map[string]string)}
+	var metadata = newMetadata()
 	var markdown []byte
 	var err error
 
@@ -100,9 +101,10 @@ func (md Markdown) processTemplate(c *Config, requestPath string, tmpl []byte, m
 		return nil, err
 	}
 	mdData := Data{
-		Context: ctx,
-		Doc:     metadata.Variables,
-		Links:   c.Links,
+		Context:  ctx,
+		Doc:      metadata.Variables,
+		DocFlags: metadata.Flags,
+		Links:    c.Links,
 	}
 
 	c.RLock()

--- a/middleware/markdown/testdata/docflags/template.txt
+++ b/middleware/markdown/testdata/docflags/template.txt
@@ -1,0 +1,4 @@
+Doc.var_string {{.Doc.var_string}}
+Doc.var_bool {{.Doc.var_bool}}
+DocFlags.var_string {{.DocFlags.var_string}}
+DocFlags.var_bool {{.DocFlags.var_bool}}

--- a/middleware/markdown/testdata/docflags/test.md
+++ b/middleware/markdown/testdata/docflags/test.md
@@ -1,0 +1,4 @@
+---
+var_string: hello
+var_bool: true
+---


### PR DESCRIPTION
Hello, I've noticed that markdown middleware picks only those variables in JSON/TOML/YAML front matter that have type of string. There's a `map[string]string` that later gets into `{{.Doc.blah}}` directives.

However, it gets confusing when I try to use these variables as switch flags. e.g. `math: true` or `math: yes` both got skipped and set to `<no value>`. Which was very disturbing. So I've implemented `{{.DocFlags.blah}}` that maps to a `map[string]bool` where things like `math: yes` being stored.

Test looks like this:

**test.md**
```
---
var_string: hello
var_bool: true
---
```

**template.txt**
```
Doc.var_string {{.Doc.var_string}}
Doc.var_bool {{.Doc.var_bool}}
DocFlags.var_string {{.DocFlags.var_string}}
DocFlags.var_bool {{.DocFlags.var_bool}}
```

**RESULT**

```
Doc.var_string hello
Doc.var_bool <no value>
DocFlags.var_string <no value>
DocFlags.var_bool true
```