### PR TITLE
Allow rewrite status to be 2xx or 4xx.

### DIFF
--- a/caddy/setup/rewrite.go
+++ b/caddy/setup/rewrite.go
@@ -80,8 +80,8 @@ func rewriteParse(c *Controller) ([]rewrite.Rule, error) {
 						return nil, c.ArgErr()
 					}
 					status, _ = strconv.Atoi(c.Val())
-					if status < 400 || status > 499 {
-						return nil, c.Err("status must be 4xx")
+					if status < 200 || (status > 299 && status < 400) || status > 499 {
+						return nil, c.Err("status must be 2xx or 4xx")
 					}
 				default:
 					return nil, c.ArgErr()

--- a/caddy/setup/rewrite_test.go
+++ b/caddy/setup/rewrite_test.go
@@ -138,6 +138,11 @@ func TestRewriteParse(t *testing.T) {
 			&rewrite.ComplexRule{Base: "/", To: "/to", Ifs: []rewrite.If{{A: "{path}", Operator: "is", B: "a"}}},
 		}},
 		{`rewrite {
+			status 500
+		 }`, true, []rewrite.Rule{
+			&rewrite.ComplexRule{},
+		}},
+		{`rewrite {
 			status 400
 		 }`, false, []rewrite.Rule{
 			&rewrite.ComplexRule{Base: "/", Regexp: regexp.MustCompile(".*"), Status: 400},
@@ -150,6 +155,22 @@ func TestRewriteParse(t *testing.T) {
 		}},
 		{`rewrite {
 			status 399
+		 }`, true, []rewrite.Rule{
+			&rewrite.ComplexRule{},
+		}},
+		{`rewrite {
+			status 200
+		 }`, false, []rewrite.Rule{
+			&rewrite.ComplexRule{Base: "/", Regexp: regexp.MustCompile(".*"), Status: 200},
+		}},
+		{`rewrite {
+			to /to
+			status 200
+		 }`, false, []rewrite.Rule{
+			&rewrite.ComplexRule{Base: "/", To: "/to", Regexp: regexp.MustCompile(".*"), Status: 200},
+		}},
+		{`rewrite {
+			status 199
 		 }`, true, []rewrite.Rule{
 			&rewrite.ComplexRule{},
 		}},

--- a/caddy/setup/rewrite_test.go
+++ b/caddy/setup/rewrite_test.go
@@ -145,13 +145,13 @@ func TestRewriteParse(t *testing.T) {
 		{`rewrite {
 			status 400
 		 }`, false, []rewrite.Rule{
-			&rewrite.ComplexRule{Base: "/", Regexp: regexp.MustCompile(".*"), Status: 400},
+			&rewrite.ComplexRule{Base: "/", Status: 400},
 		}},
 		{`rewrite {
 			to /to
 			status 400
 		 }`, false, []rewrite.Rule{
-			&rewrite.ComplexRule{Base: "/", To: "/to", Regexp: regexp.MustCompile(".*"), Status: 400},
+			&rewrite.ComplexRule{Base: "/", To: "/to", Status: 400},
 		}},
 		{`rewrite {
 			status 399
@@ -161,13 +161,13 @@ func TestRewriteParse(t *testing.T) {
 		{`rewrite {
 			status 200
 		 }`, false, []rewrite.Rule{
-			&rewrite.ComplexRule{Base: "/", Regexp: regexp.MustCompile(".*"), Status: 200},
+			&rewrite.ComplexRule{Base: "/", Status: 200},
 		}},
 		{`rewrite {
 			to /to
 			status 200
 		 }`, false, []rewrite.Rule{
-			&rewrite.ComplexRule{Base: "/", To: "/to", Regexp: regexp.MustCompile(".*"), Status: 200},
+			&rewrite.ComplexRule{Base: "/", To: "/to", Status: 200},
 		}},
 		{`rewrite {
 			status 199


### PR DESCRIPTION
Matt, first thanks for the Caddy project...a true showcase of Golang's strengths!

I have a case where it would be useful to do the following:

```
# Headfake the editor
rewrite /editor/spec {
  if {method} is PUT
  status 200
}
```

However, the current implementation prevents this use case, which I think is safe and reasonable. This PR allow status to be 2xx or 4xx. _Tests are included_. I hope you agree that this simple change is OK. Thanks again!