### PR TITLE
Improving TLS Security

### DIFF
--- a/caddy/https/setup.go
+++ b/caddy/https/setup.go
@@ -268,6 +268,8 @@ var supportedProtocols = map[string]uint16{
 //
 // This map, like any map, is NOT ORDERED. Do not range over this map.
 var supportedCiphersMap = map[string]uint16{
+	"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	"ECDHE-RSA-AES128-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
@@ -287,6 +289,8 @@ var supportedCiphersMap = map[string]uint16{
 // Note that TLS_FALLBACK_SCSV is not in this list since it is always
 // added manually.
 var supportedCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
@@ -301,6 +305,8 @@ var supportedCiphers = []uint16{
 
 // List of all the ciphers we want to use by default
 var defaultCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,

--- a/caddy/https/setup_test.go
+++ b/caddy/https/setup_test.go
@@ -57,6 +57,8 @@ func TestSetupParseBasic(t *testing.T) {
 	// Cipher checks
 	expectedCiphers := []uint16{
 		tls.TLS_FALLBACK_SCSV,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
@@ -97,7 +99,7 @@ func TestSetupParseIncompleteParams(t *testing.T) {
 func TestSetupParseWithOptionalParams(t *testing.T) {
 	params := `tls ` + certFile + ` ` + keyFile + ` {
             protocols ssl3.0 tls1.2
-            ciphers RSA-3DES-EDE-CBC-SHA RSA-AES256-CBC-SHA ECDHE-RSA-AES128-GCM-SHA256
+            ciphers RSA-AES256-CBC-SHA ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384
         }`
 	c := setup.NewTestController(params)
 


### PR DESCRIPTION
This pull request adds :

- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

**Should we remove SSL 3.0?**