### PR TITLE
Proposal: Use build tags to load plugins

### DIFF
--- a/caddy/config_test.go
+++ b/caddy/config_test.go
@@ -101,9 +101,9 @@ func TestResolveAddr(t *testing.T) {
 }
 
 func TestMakeOnces(t *testing.T) {
-	directives := []directive{
-		{"dummy", nil},
-		{"dummy2", nil},
+	directives := []Directive{
+		{"dummy", nil, "", ""},
+		{"dummy2", nil, "", ""},
 	}
 	directiveOrder = directives
 	onces := makeOnces()
@@ -120,9 +120,9 @@ func TestMakeOnces(t *testing.T) {
 }
 
 func TestMakeStorages(t *testing.T) {
-	directives := []directive{
-		{"dummy", nil},
-		{"dummy2", nil},
+	directives := []Directive{
+		{"dummy", nil, "", ""},
+		{"dummy2", nil, "", ""},
 	}
 	directiveOrder = directives
 	storages := makeStorages()
@@ -139,9 +139,9 @@ func TestMakeStorages(t *testing.T) {
 }
 
 func TestValidDirective(t *testing.T) {
-	directives := []directive{
-		{"dummy", nil},
-		{"dummy2", nil},
+	directives := []Directive{
+		{"dummy", nil, "", ""},
+		{"dummy2", nil, "", ""},
 	}
 	directiveOrder = directives
 	for i, test := range []struct {

--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -44,6 +44,8 @@ func init() {
 // pages, so it must be registered before the errors
 // middleware and any others that would write to the
 // response.
+//
+// Middleware here with a nil setup func are "external" to caddy core, and must be activated.
 var directiveOrder = []directive{
 	// Essential directives that initialize vital configuration settings
 	{"root", setup.Root},
@@ -59,12 +61,16 @@ var directiveOrder = []directive{
 	{"log", setup.Log},
 	{"gzip", setup.Gzip},
 	{"errors", setup.Errors},
+	{"ipfilter", nil},
+	{"search", nil},
 	{"header", setup.Headers},
+	{"cors", nil},
 	{"rewrite", setup.Rewrite},
 	{"redir", setup.Redir},
 	{"ext", setup.Ext},
 	{"mime", setup.Mime},
 	{"basicauth", setup.BasicAuth},
+	{"jsonp", nil},
 	{"internal", setup.Internal},
 	{"proxy", setup.Proxy},
 	{"fastcgi", setup.FastCGI},
@@ -72,6 +78,7 @@ var directiveOrder = []directive{
 	{"markdown", setup.Markdown},
 	{"templates", setup.Templates},
 	{"browse", setup.Browse},
+	{"hugo", nil},
 }
 
 // RegisterDirective adds the given directive to caddy's list of directives.
@@ -91,8 +98,8 @@ func RegisterDirective(name string, setup SetupFunc, after string) {
 	parse.ValidDirectives[name] = struct{}{}
 }
 
-// ActivateKnownDirective provides a setup func for an external directive that we only have a placeholder for.
-func ActivateKnownDirective(name string, setup SetupFunc) {
+// ActivateDirective provides a setup func for an external directive that we only have a placeholder for.
+func ActivateDirective(name string, setup SetupFunc) {
 	for i, d := range directiveOrder {
 		if d.name == name {
 			if d.setup != nil {

--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mholt/caddy/middleware"
 )
 
+var valid = struct{}{}
+
 func init() {
 	// The parse package must know which directives
 	// are valid, but it must not import the setup
@@ -17,8 +19,8 @@ func init() {
 	// The parse package does not need to know the
 	// ordering of the directives.
 	for _, dir := range directiveOrder {
-		if dir.setup != nil {
-			parse.ValidDirectives[dir.name] = struct{}{}
+		if dir.Setup != nil {
+			parse.ValidDirectives[dir.Name] = valid
 		}
 	}
 }
@@ -46,78 +48,89 @@ func init() {
 // response.
 //
 // Middleware here with a nil setup func are "external" to caddy core, and must be activated.
-var directiveOrder = []directive{
+var directiveOrder = []Directive{
 	// Essential directives that initialize vital configuration settings
-	{"root", setup.Root},
-	{"bind", setup.BindHost},
-	{"tls", https.Setup},
+	{"root", setup.Root, "", ""},
+	{"bind", setup.BindHost, "", ""},
+	{"tls", https.Setup, "", ""},
 
 	// Other directives that don't create HTTP handlers
-	{"startup", setup.Startup},
-	{"shutdown", setup.Shutdown},
-	{"git", nil},
+	{"startup", setup.Startup, "", ""},
+	{"shutdown", setup.Shutdown, "", ""},
+	{"git", nil, "github.com/abiosoft/caddy-git", "Deploy your site with git push."},
 
 	// Directives that inject handlers (middleware)
-	{"log", setup.Log},
-	{"gzip", setup.Gzip},
-	{"errors", setup.Errors},
-	{"ipfilter", nil},
-	{"search", nil},
-	{"header", setup.Headers},
-	{"cors", nil},
-	{"rewrite", setup.Rewrite},
-	{"redir", setup.Redir},
-	{"ext", setup.Ext},
-	{"mime", setup.Mime},
-	{"basicauth", setup.BasicAuth},
-	{"jsonp", nil},
-	{"internal", setup.Internal},
-	{"proxy", setup.Proxy},
-	{"fastcgi", setup.FastCGI},
-	{"websocket", setup.WebSocket},
-	{"markdown", setup.Markdown},
-	{"templates", setup.Templates},
-	{"browse", setup.Browse},
-	{"hugo", nil},
+	{"log", setup.Log, "", ""},
+	{"gzip", setup.Gzip, "", ""},
+	{"errors", setup.Errors, "", ""},
+	{"ipfilter", nil, "github.com/pyed/ipfilter", "Block or allow clients based on IP origin."},
+	{"search", nil, "github.com/pedronasser/caddy-search", "Activates a site search engine"},
+	{"header", setup.Headers, "", ""},
+	{"cors", nil, "github.com/captncraig/cors/caddy", "Enable Cross Origin Resource Sharing"},
+	{"rewrite", setup.Rewrite, "", ""},
+	{"redir", setup.Redir, "", ""},
+	{"ext", setup.Ext, "", ""},
+	{"mime", setup.Mime, "", ""},
+	{"basicauth", setup.BasicAuth, "", ""},
+	{"jsonp", nil, "github.com/pschlump/caddy-jsonp", "Wrap regular JSON responses as JSONP"},
+	{"internal", setup.Internal, "", ""},
+	{"proxy", setup.Proxy, "", ""},
+	{"fastcgi", setup.FastCGI, "", ""},
+	{"websocket", setup.WebSocket, "", ""},
+	{"markdown", setup.Markdown, "", ""},
+	{"templates", setup.Templates, "", ""},
+	{"browse", setup.Browse, "", ""},
+	{"hugo", nil, "github.com/hacdias/caddy-hugo", "Powerful and easy static site generator with admin interface."},
 }
 
 // RegisterDirective adds the given directive to caddy's list of directives.
 // Pass the name of a directive you want it to be placed after,
 // otherwise it will be placed at the bottom of the stack.
 func RegisterDirective(name string, setup SetupFunc, after string) {
-	dir := directive{name: name, setup: setup}
+	dir := Directive{Name: name, Setup: setup}
 	idx := len(directiveOrder)
 	for i := range directiveOrder {
-		if directiveOrder[i].name == after {
+		if directiveOrder[i].Name == after {
 			idx = i + 1
 			break
 		}
 	}
-	newDirectives := append(directiveOrder[:idx], append([]directive{dir}, directiveOrder[idx:]...)...)
+	newDirectives := append(directiveOrder[:idx], append([]Directive{dir}, directiveOrder[idx:]...)...)
 	directiveOrder = newDirectives
-	parse.ValidDirectives[name] = struct{}{}
+	parse.ValidDirectives[name] = valid
 }
 
 // ActivateDirective provides a setup func for an external directive that we only have a placeholder for.
 func ActivateDirective(name string, setup SetupFunc) {
 	for i, d := range directiveOrder {
-		if d.name == name {
-			if d.setup != nil {
+		if d.Name == name {
+			if d.Setup != nil {
 				log.Fatalf("Directive %s already activated", name)
 			}
-			d.setup = setup
+			d.Setup = setup
 			directiveOrder[i] = d
-			parse.ValidDirectives[name] = struct{}{}
+			parse.ValidDirectives[name] = valid
 			return
 		}
 	}
 	log.Fatalf("Unknown directive %s", name)
 }
 
-// directive ties together a directive name with its setup function.
-type directive struct {
-	name  string
-	setup SetupFunc
+// Directive ties together a directive name with its setup function.
+type Directive struct {
+	Name        string    `json:"directive"`
+	Setup       SetupFunc `json:"-"`
+	Package     string    `json:"package"`
+	Description string    `json:"description"`
+}
+
+// GetDirectives returns a read-only copy of the current directive stack
+func GetDirectives() []Directive {
+	d := make([]Directive, len(directiveOrder))
+	for i, dir := range directiveOrder {
+		d[i] = dir
+	}
+	return d
 }
 
 // SetupFunc takes a controller and may optionally return a middleware.

--- a/caddy/directives_test.go
+++ b/caddy/directives_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	directives := []directive{
-		{"dummy", nil},
-		{"dummy2", nil},
+	directives := []Directive{
+		{"dummy", nil, "", ""},
+		{"dummy2", nil, "", ""},
 	}
 	directiveOrder = directives
 	RegisterDirective("foo", nil, "dummy")
@@ -17,7 +17,7 @@ func TestRegister(t *testing.T) {
 	}
 	getNames := func() (s []string) {
 		for _, d := range directiveOrder {
-			s = append(s, d.name)
+			s = append(s, d.Name)
 		}
 		return s
 	}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/mholt/caddy/caddy/https"
 	"github.com/xenolf/lego/acme"
 	"gopkg.in/natefinch/lumberjack.v2"
+
+	// Load all external directives enabled by build tags
+	_ "github.com/mholt/caddy/middleware/external"
 )
 
 var (

--- a/middleware/external/cors.go
+++ b/middleware/external/cors.go
@@ -1,0 +1,12 @@
+// +build cors all
+
+package external
+
+import (
+	"github.com/captncraig/caddy-cors"
+	"github.com/mholt/caddy/caddy"
+)
+
+func init() {
+	caddy.ActivateDirective("cors", cors.Setup)
+}

--- a/middleware/external/cors.go
+++ b/middleware/external/cors.go
@@ -3,7 +3,7 @@
 package external
 
 import (
-	"github.com/captncraig/caddy-cors"
+	cors "github.com/captncraig/cors/caddy"
 	"github.com/mholt/caddy/caddy"
 )
 

--- a/middleware/external/doc.go
+++ b/middleware/external/doc.go
@@ -1,0 +1,5 @@
+//Package external is a placeholder for external directives that are known to caddy and made availible for general use.
+//
+//Each directive has a placeholder in caddy/directives.go, and an initializer file in this package. If the build tags are satisfied, the directive will
+//be "activated" in caddy's directive stack.
+package external

--- a/middleware/external/git.go
+++ b/middleware/external/git.go
@@ -1,0 +1,12 @@
+// +build git all
+
+package external
+
+import (
+	"github.com/abiosoft/caddy-git"
+	"github.com/mholt/caddy/caddy"
+)
+
+func init() {
+	caddy.ActivateKnownDirective("git", git.Setup)
+}

--- a/middleware/external/git.go
+++ b/middleware/external/git.go
@@ -8,5 +8,5 @@ import (
 )
 
 func init() {
-	caddy.ActivateKnownDirective("git", git.Setup)
+	caddy.ActivateDirective("git", git.Setup)
 }

--- a/middleware/external/hugo.go
+++ b/middleware/external/hugo.go
@@ -1,0 +1,12 @@
+// +build hugo all
+
+package external
+
+import (
+	"github.com/hacdias/caddy-hugo"
+	"github.com/mholt/caddy/caddy"
+)
+
+func init() {
+	caddy.ActivateDirective("hugo", hugo.Setup)
+}

--- a/middleware/external/ipfilter.go
+++ b/middleware/external/ipfilter.go
@@ -1,0 +1,12 @@
+// +build ipfilter all
+
+package external
+
+import (
+	"github.com/mholt/caddy/caddy"
+	"github.com/pyed/ipfilter"
+)
+
+func init() {
+	caddy.ActivateDirective("ipfilter", ipfilter.Setup)
+}

--- a/middleware/external/jsonp.go
+++ b/middleware/external/jsonp.go
@@ -1,0 +1,12 @@
+// +build jsonp all
+
+package external
+
+import (
+	"github.com/mholt/caddy/caddy"
+	"github.com/pschlump/caddy-jsonp"
+)
+
+func init() {
+	caddy.ActivateDirective("jsonp", jsonp.Setup)
+}

--- a/middleware/external/search.go
+++ b/middleware/external/search.go
@@ -1,0 +1,12 @@
+// +build search all
+
+package external
+
+import (
+	"github.com/mholt/caddy/caddy"
+	"github.com/pedronasser/caddy-search"
+)
+
+func init() {
+	caddy.ActivateDirective("search", search.Setup)
+}


### PR DESCRIPTION
This started as a crazy idea I had, but I actually rather like what it enables.

**What it does**

1. Makes directives.go (not buildsrv) the authoritative registry of "officially acknowledged" plugins. The order can be established in one and only one place. These plugins are still not included in caddy core, and will have a nil setup function in the default registry, and thus be invalid.
2. Allow these plugins to be "Activated" at init time to include them as valid directives and supply the actual setup func.
3. Add convenience files to the `github.com/mholt/caddy/middleware/external` package so that middlewares may be enabled at build time. `go build -tags "git cors hugo"` will build just those three plugins in. `go build -tags all` will build with all known plugins. this also works with `go get` `go install` and friends.

**Is this better?**

I think yes. It makes the job of buildsrv essentially to call `go build` with the right tags. It makes caddyext's job easier for known plugins, which it already treats as a bit of a special case anyway. It does not affect the ability to load non-official plugins using the Register method or the code generation method.

Also reduces duplication between buildsrv and caddy, each having very similar registries.

**To add a plugin**

Old way: 

- add a line to buildsrv's registry.go file. submit pr.
- add docs to caddyserver.com. pr.

New way: 

- add a line to caddy's directives.go
- add a new file with appropriate build tags to middleware/external package. pr.
- add docs. pr.

Still 2 prs required. No significant change. ( I dislike docs separate still, but thats another fight)

**Are non-official plugins second class?**

No, not really. My preferred method is to add a `custom.go` file in package main with an init function:

```
func init(){
  caddy.RegisterDirective("custom",mypkg.Setup, "")
}
```

to manually insert it in the stack at init time. (I think caddyext should do this instead of modifying directives.go too btw).

**Bonus round: Vendoring**

This also enables what I think is the first really viable way to vendor caddy dependencies I have found. If we use govendor or similar package manager, we can put all dependencies *including plugins and their dependencies* into the vendor folder. 

This might reduce some of the pain in buildsrv managing each plugin individually. If a plugin author updates their plugin, update the vendored copy in caddy main repo and pr. This is arguably a pain, or could perhaps be automated. If plugins update between caddy releases, it could also cause weird branch merges and things, which may be undesirable. Just an idea. Not required.

**What do you think?**
Input welcome from people who have looked at buildsrv/caddyext type things before: @abiosoft @pedronasser @mholt and anyone else.