### PR TITLE
Included files in Markdown templates have access to document vars

### DIFF
--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -107,7 +107,7 @@ func TestMarkdown(t *testing.T) {
 <title>Markdown test 1</title>
 </head>
 <body>
-<h1>Header</h1>
+<h1>Header for: Markdown test 1</h1>
 
 Welcome to A Caddy website!
 <h2>Welcome on the blog</h2>
@@ -208,7 +208,7 @@ DocFlags.var_bool true`
 <title>first_post</title>
 </head>
 <body>
-<h1>Header</h1>
+<h1>Header for: first_post</h1>
 
 Welcome to title!
 <h1>Test h1</h1>

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -28,6 +28,12 @@ type Data struct {
 	Links    []PageLink
 }
 
+// Include "overrides" the embedded middleware.Context's Include()
+// method so that included files have access to d's fields.
+func (d Data) Include(filename string) (string, error) {
+	return middleware.ContextInclude(filename, d, d.Root)
+}
+
 // Process processes the contents of a page in b. It parses the metadata
 // (if any) and uses the template (if found).
 func (md Markdown) Process(c *Config, requestPath string, b []byte, ctx middleware.Context) ([]byte, error) {

--- a/middleware/markdown/testdata/header.html
+++ b/middleware/markdown/testdata/header.html
@@ -1,1 +1,1 @@
-<h1>Header</h1>
+<h1>Header for: {{.Doc.title}}</h1>


### PR DESCRIPTION
This should fix #660.

I'm not sure the solution is very elegant and would welcome suggestions for a cleaner way to fix it. I don't like having to create a NewContext() function and then having that unexported field in Context... it just feels hacky.

Edit: Refactored and squashed, so I think this'll do now.