### PR TITLE
Add check for per-host maximum connections

### DIFF
--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -53,11 +53,22 @@ func TestRoundRobinPolicy(t *testing.T) {
 	if h != pool[2] {
 		t.Error("Expected second round robin host to be third host in the pool.")
 	}
-	// mark host as down
-	pool[0].Unhealthy = true
 	h = rrPolicy.Select(pool)
-	if h != pool[1] {
+	if h != pool[0] {
 		t.Error("Expected third round robin host to be first host in the pool.")
+	}
+	// mark host as down
+	pool[1].Unhealthy = true
+	h = rrPolicy.Select(pool)
+	if h != pool[2] {
+		t.Error("Expected to skip down host.")
+	}
+	// mark host as full
+	pool[2].Conns = 1
+	pool[2].MaxConns = 1
+	h = rrPolicy.Select(pool)
+	if h != pool[0] {
+		t.Error("Expected to skip full host.")
 	}
 }
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -44,6 +44,7 @@ type UpstreamHost struct {
 	ExtraHeaders      http.Header
 	CheckDown         UpstreamHostDownFunc
 	WithoutPathPrefix string
+	MaxConns          int64
 }
 
 // Down checks whether the upstream host is down or not.
@@ -55,6 +56,16 @@ func (uh *UpstreamHost) Down() bool {
 		return uh.Unhealthy || uh.Fails > 0
 	}
 	return uh.CheckDown(uh)
+}
+
+// Full checks whether the upstream host has reached its maximum connections
+func (uh *UpstreamHost) Full() bool {
+	return uh.MaxConns > 0 && uh.Conns >= uh.MaxConns
+}
+
+// Available checks whether the upstream host is available for proxying to
+func (uh *UpstreamHost) Available() bool {
+	return !uh.Down() && !uh.Full()
 }
 
 // tryDuration is how long to try upstream hosts; failures result in

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -40,6 +40,19 @@ func TestSelect(t *testing.T) {
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}
+	upstream.Hosts[0].Conns = 1
+	upstream.Hosts[0].MaxConns = 1
+	upstream.Hosts[1].Conns = 1
+	upstream.Hosts[1].MaxConns = 1
+	upstream.Hosts[2].Conns = 1
+	upstream.Hosts[2].MaxConns = 1
+	if h := upstream.Select(); h != nil {
+		t.Error("Expected select to return nil as all hosts are full")
+	}
+	upstream.Hosts[2].Conns = 0
+	if h := upstream.Select(); h == nil {
+		t.Error("Expected select to not return nil")
+	}
 }
 
 func TestRegisterPolicy(t *testing.T) {


### PR DESCRIPTION
As per my comment https://github.com/mholt/caddy/issues/613#issuecomment-193796875, checking along with the other per-server checks makes for fewer code added, but with somewhat confusing method name.

The alternative is adding a `Full()` method on the host, with `CheckFull()` function on the upstream, and do do the `Full()` check in basically all the same places are where the `Down()` check is done.