### PR TITLE
Add flag to list directives.

### DIFF
--- a/caddy/directives.go
+++ b/caddy/directives.go
@@ -69,6 +69,15 @@ var directiveOrder = []directive{
 	{"browse", setup.Browse},
 }
 
+// Directives returns the list of directives in order of priority.
+func Directives() []string {
+	directives := make([]string, len(directiveOrder))
+	for i, d := range directiveOrder {
+		directives[i] = d.name
+	}
+	return directives
+}
+
 // RegisterDirective adds the given directive to caddy's list of directives.
 // Pass the name of a directive you want it to be placed after,
 // otherwise it will be placed at the bottom of the stack.

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/mholt/caddy/caddy"
 	"github.com/mholt/caddy/caddy/https"
-	"github.com/mholt/caddy/caddy/parse"
 	"github.com/xenolf/lego/acme"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -80,7 +79,7 @@ func main() {
 		os.Exit(0)
 	}
 	if directives {
-		for d := range parse.ValidDirectives {
+		for _, d := range caddy.Directives() {
 			fmt.Println(d)
 		}
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mholt/caddy/caddy"
 	"github.com/mholt/caddy/caddy/https"
+	"github.com/mholt/caddy/caddy/parse"
 	"github.com/xenolf/lego/acme"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -36,6 +37,7 @@ func init() {
 	flag.StringVar(&revoke, "revoke", "", "Hostname for which to revoke the certificate")
 	flag.StringVar(&caddy.Root, "root", caddy.DefaultRoot, "Root path to default site")
 	flag.BoolVar(&version, "version", false, "Show version")
+	flag.BoolVar(&directives, "directives", false, "List supported directives")
 }
 
 func main() {
@@ -74,6 +76,12 @@ func main() {
 		fmt.Printf("%s %s\n", appName, appVersion)
 		if devBuild && gitShortStat != "" {
 			fmt.Printf("%s\n%s\n", gitShortStat, gitFilesModified)
+		}
+		os.Exit(0)
+	}
+	if directives {
+		for d := range parse.ValidDirectives {
+			fmt.Println(d)
 		}
 		os.Exit(0)
 	}
@@ -212,11 +220,12 @@ const appName = "Caddy"
 
 // Flags that control program flow or startup
 var (
-	conf    string
-	cpu     string
-	logfile string
-	revoke  string
-	version bool
+	conf       string
+	cpu        string
+	logfile    string
+	revoke     string
+	version    bool
+	directives bool
 )
 
 // Build information obtained with the help of -ldflags


### PR DESCRIPTION
This adds a `-directive` flag. This helps users confirm if custom build includes  a directive.

Example
```
caddy -directives | grep git
```