### PR TITLE
Handle file system case sensitivity.

### DIFF
--- a/middleware/path.go
+++ b/middleware/path.go
@@ -1,6 +1,32 @@
 package middleware
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
+
+const caseSensitivePathEnv = "CASE_SENSITIVE_PATH"
+
+func init() {
+	initCaseSettings()
+}
+
+// CaseSensitivePath determines if paths should be case sensitive.
+// This is configurable via CASE_SENSITIVE_PATH environment variable.
+// It defaults to false.
+var CaseSensitivePath = true
+
+// initCaseSettings loads case sensitivity config from environment variable.
+//
+// This could have been in init, but init cannot be called from tests.
+func initCaseSettings() {
+	switch os.Getenv(caseSensitivePathEnv) {
+	case "0", "false":
+		CaseSensitivePath = false
+	default:
+		CaseSensitivePath = true
+	}
+}
 
 // Path represents a URI path, maybe with pattern characters.
 type Path string
@@ -11,5 +37,8 @@ type Path string
 // comparison; this method assures that paths can be
 // easily and consistently matched.
 func (p Path) Matches(other string) bool {
-	return strings.HasPrefix(string(p), other)
+	if CaseSensitivePath {
+		return strings.HasPrefix(string(p), other)
+	}
+	return strings.HasPrefix(strings.ToLower(string(p)), strings.ToLower(other))
 }

--- a/middleware/path_test.go
+++ b/middleware/path_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPathCaseSensitivity(t *testing.T) {
+	tests := []struct {
+		basePath      string
+		path          string
+		caseSensitive bool
+		expected      bool
+	}{
+		{"/", "/file", true, true},
+		{"/a", "/file", true, false},
+		{"/f", "/file", true, true},
+		{"/f", "/File", true, false},
+		{"/f", "/File", false, true},
+		{"/file", "/file", true, true},
+		{"/file", "/file", false, true},
+		{"/files", "/file", false, false},
+		{"/files", "/file", true, false},
+		{"/folder", "/folder/file.txt", true, true},
+		{"/folders", "/folder/file.txt", true, false},
+		{"/folder", "/Folder/file.txt", false, true},
+		{"/folders", "/Folder/file.txt", false, false},
+	}
+
+	for i, test := range tests {
+		CaseSensitivePath = test.caseSensitive
+		valid := Path(test.path).Matches(test.basePath)
+		if test.expected != valid {
+			t.Errorf("Test %d: Expected %v, found %v", i, test.expected, valid)
+		}
+	}
+}
+
+func TestPathCaseSensitiveEnv(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected bool
+	}{
+		{"1", true},
+		{"0", false},
+		{"false", false},
+		{"true", true},
+		{"", true},
+	}
+
+	for i, test := range tests {
+		os.Setenv(caseSensitivePathEnv, test.envValue)
+		initCaseSettings()
+		if test.expected != CaseSensitivePath {
+			t.Errorf("Test %d: Expected %v, found %v", i, test.expected, CaseSensitivePath)
+		}
+	}
+}


### PR DESCRIPTION
This adds ability to check for file systems case sensitivity. Middlewares can now call `middleware.CaseSensitiveFS` to know if the file system is case sensitive or not and handle it as required.

This also caters for FastCGI middleware.