### PR TITLE
Fixup mime middleware to use a map and error on duplicate extensions.

### DIFF
--- a/caddy/setup/mime_test.go
+++ b/caddy/setup/mime_test.go
@@ -42,6 +42,11 @@ func TestMime(t *testing.T) {
 		 .html text/html
 		 .txt text/plain
 		} `, false},
+		{`mime {
+		 .foo text/foo
+		 .bar text/bar
+		 .foo text/foobar
+		} `, true},
 		{`mime { .html text/html } `, false},
 		{`mime { .html
 		} `, true},

--- a/middleware/mime/mime.go
+++ b/middleware/mime/mime.go
@@ -2,40 +2,31 @@ package mime
 
 import (
 	"net/http"
-	"path/filepath"
+	"path"
 
 	"github.com/mholt/caddy/middleware"
 )
 
-// Config represent a mime config.
-type Config struct {
-	Ext         string
-	ContentType string
-}
-
-// SetContent sets the Content-Type header of the request if the request path
-// is supported.
-func (c Config) SetContent(w http.ResponseWriter, r *http.Request) bool {
-	ext := filepath.Ext(r.URL.Path)
-	if ext != c.Ext {
-		return false
-	}
-	w.Header().Set("Content-Type", c.ContentType)
-	return true
-}
+// Config represent a mime config.  Map from extension to mime-type.
+// Note, this should be safe with concurrent read access, as this is
+// not modified concurrently.
+type Config map[string]string
 
 // Mime sets Content-Type header of requests based on configurations.
 type Mime struct {
 	Next    middleware.Handler
-	Configs []Config
+	Configs Config
 }
 
 // ServeHTTP implements the middleware.Handler interface.
 func (e Mime) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	for _, c := range e.Configs {
-		if ok := c.SetContent(w, r); ok {
-			break
-		}
+
+	// Get a clean /-path, grab the extension
+	ext := path.Ext(path.Clean(r.URL.Path))
+
+	if contentType, ok := e.Configs[ext]; ok {
+		w.Header().Set("Content-Type", contentType)
 	}
+
 	return e.Next.ServeHTTP(w, r)
 }

--- a/middleware/mime/mime_test.go
+++ b/middleware/mime/mime_test.go
@@ -11,18 +11,13 @@ import (
 
 func TestMimeHandler(t *testing.T) {
 
-	mimes := map[string]string{
+	mimes := Config{
 		".html": "text/html",
 		".txt":  "text/plain",
 		".swf":  "application/x-shockwave-flash",
 	}
 
-	var configs []Config
-	for ext, contentType := range mimes {
-		configs = append(configs, Config{Ext: ext, ContentType: contentType})
-	}
-
-	m := Mime{Configs: configs}
+	m := Mime{Configs: mimes}
 
 	w := httptest.NewRecorder()
 	exts := []string{


### PR DESCRIPTION
 - The mime middleware used filepath where it should arguably use path.
 - Changed the configuration to use a map instead of scanning an array
   during every request.  The map is static (after configuration), so
   should be fine for concurrent access.
 - Catch duplicate extensions within a configuration and error out.
 - Add tests for new error case.