### PR TITLE
dist/init: caddy.conf for upstart

### DIFF
--- a/dist/init/linux-upstart/README.md
+++ b/dist/init/linux-upstart/README.md
@@ -1,0 +1,13 @@
+Upstart conf for Caddy
+=====================
+
+Usage
+-----
+
+Usage in this blogpost: [Running Caddy Server as a service with Upstart](https://denbeke.be/blog/servers/running-caddy-server-as-a-service/).
+Short recap:
+
+* Download Caddy in `/usr/bin/caddy` and execute `sudo setcap cap_net_bind_service=+ep /usr/bin/caddy`.
+* Save the upstart config file in `/etc/init/caddy.conf`.
+* Create a Caddyfile in `/etc/caddy/Caddyfile`.
+* Now you can use `sudo service caddy start|stop|restart`.

--- a/dist/init/linux-upstart/caddy.conf
+++ b/dist/init/linux-upstart/caddy.conf
@@ -1,0 +1,18 @@
+description "Caddy startup script"
+author "Mathias Beke"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+
+setuid www-data
+setgid www-data
+
+respawn
+respawn limit 10 5
+
+limit nofile 4096 4096
+
+script
+	exec /usr/bin/caddy -agree=true -conf=/etc/caddy/Caddyfile
+end script


### PR DESCRIPTION
I've added the upstart configuration from my blog to the `dist/init` directory as you asked, @mholt. I also added a very quick overview about how it works.