### PR TITLE
A new feature for the "tls" directive

### DIFF
--- a/caddy/https/https.go
+++ b/caddy/https/https.go
@@ -404,7 +404,7 @@ const AlternatePort = "5033"
 // KeyType is the type to use for new keys.
 // This shouldn't need to change except for in tests;
 // the size can be drastically reduced for speed.
-var KeyType = acme.EC384
+var KeyType acme.KeyType
 
 // stopChan is used to signal the maintenance goroutine
 // to terminate.

--- a/caddy/https/setup_test.go
+++ b/caddy/https/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mholt/caddy/caddy/setup"
+	"github.com/xenolf/lego/acme"
 )
 
 func TestMain(m *testing.M) {
@@ -170,6 +171,16 @@ func TestSetupParseWithWrongOptionalParams(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected errors, but no error returned")
 	}
+
+	// Test key_type wrong params
+	params = `tls {
+			key_type ab123
+		}`
+	c = setup.NewTestController(params)
+	_, err = Setup(c)
+	if err == nil {
+		t.Errorf("Expected errors, but no error returned")
+	}
 }
 
 func TestSetupParseWithClientAuth(t *testing.T) {
@@ -200,6 +211,22 @@ func TestSetupParseWithClientAuth(t *testing.T) {
 	_, err = Setup(c)
 	if err == nil {
 		t.Errorf("Expected an error, but no error returned")
+	}
+}
+
+func TestSetupParseWithKeyType(t *testing.T) {
+	params := `tls {
+            key_type ec384
+        }`
+	c := setup.NewTestController(params)
+
+	_, err := Setup(c)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
+
+	if KeyType != acme.EC384 {
+		t.Errorf("Expected 'P384' as KeyType, got %#v", KeyType)
 	}
 }
 


### PR DESCRIPTION
Now it´s possible to do this:

```
domain.com {
    tls me@domain.com {
        key_type ec384 // ec256, rsa8192, rsa4096 or rsa2048
    }
}
```