### PR TITLE
Allow mixed case Upgrade headers

### DIFF
--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -207,7 +207,7 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request, extr
 		return err
 	}
 
-	if res.StatusCode == http.StatusSwitchingProtocols && res.Header.Get("Upgrade") == "websocket" {
+	if res.StatusCode == http.StatusSwitchingProtocols && strings.ToLower(res.Header.Get("Upgrade")) == "websocket" {
 		res.Body.Close()
 		hj, ok := rw.(http.Hijacker)
 		if !ok {


### PR DESCRIPTION
Caddy expects "websocket" to be completely lowercase.
Some applications send websocket Upgrade headers as shown below:
`Upgrade: WebSocket`

This change allows all variations of "websocket" and fixes https://github.com/rancher/rancher/issues/4278.