### PR TITLE
Handle host names case insensitively.

### DIFF
--- a/caddy/parse/parsing.go
+++ b/caddy/parse/parsing.go
@@ -104,6 +104,7 @@ func (p *parser) addresses() error {
 			if err != nil {
 				return err
 			}
+
 			p.block.Addresses = append(p.block.Addresses, addr)
 		}
 
@@ -328,6 +329,9 @@ func standardAddress(str string) (address, error) {
 			host = str
 		}
 	}
+
+	// "The host subcomponent is case-insensitive." (RFC 3986)
+	host = strings.ToLower(host)
 
 	// see if we can set port based off scheme
 	if port == "" {

--- a/caddy/parse/parsing_test.go
+++ b/caddy/parse/parsing_test.go
@@ -13,7 +13,9 @@ func TestStandardAddress(t *testing.T) {
 		shouldErr          bool
 	}{
 		{`localhost`, "", "localhost", "", false},
+		{`LOCALHOST`, "", "localhost", "", false},
 		{`localhost:1234`, "", "localhost", "1234", false},
+		{`LOCALHOST:1234`, "", "localhost", "1234", false},
 		{`localhost:`, "", "localhost", "", false},
 		{`0.0.0.0`, "", "0.0.0.0", "", false},
 		{`127.0.0.1:1234`, "", "127.0.0.1", "1234", false},
@@ -35,6 +37,7 @@ func TestStandardAddress(t *testing.T) {
 		{`https://127.0.0.1`, "https", "127.0.0.1", "443", false},
 		{`http://[::1]`, "http", "::1", "80", false},
 		{`http://localhost:1234`, "http", "localhost", "1234", false},
+		{`http://LOCALHOST:1234`, "http", "localhost", "1234", false},
 		{`https://127.0.0.1:1234`, "https", "127.0.0.1", "1234", false},
 		{`http://[::1]:1234`, "http", "::1", "1234", false},
 		{``, "", "", "", false},

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -300,6 +301,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		host = r.Host // oh well
 	}
+
+	// "The host subcomponent is case-insensitive." (RFC 3986)
+	host = strings.ToLower(host)
 
 	// Try the host as given, or try falling back to 0.0.0.0 (wildcard)
 	if _, ok := s.vhosts[host]; !ok {


### PR DESCRIPTION
RFC 3986 3.2.2: The host subcomponent is case-insensitive.