### PR TITLE
Added "go up" link to browse template

### DIFF
--- a/caddy/setup/browse.go
+++ b/caddy/setup/browse.go
@@ -210,7 +210,8 @@ td:first-child svg {
 	position: absolute;
 }
 
-td .name {
+td .name,
+td .goup {
 	margin-left: 1.75em;
 	word-break: break-all;
 	overflow-wrap: break-word;
@@ -342,6 +343,17 @@ footer {
 							{{end}}
 						</th>
 					</tr>
+					{{if .CanGoUp}}
+					<tr>
+						<td>
+							<a href="..">
+								<span class="goup">Go up</span>
+							</a>
+						</td>
+						<td>&mdash;</td>
+						<td>&mdash;</td>
+					</tr>
+					{{end}}
 					{{range .Items}}
 					<tr>
 						<td>


### PR DESCRIPTION
In order to have directly a link within the browse listing I have added
a link to the top of the table to get one level up in the tree. Added
that after a chat with @mholt.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>