### PR TITLE
Added breadcrumb map function to browse

### DIFF
--- a/middleware/browse/browse.go
+++ b/middleware/browse/browse.go
@@ -96,6 +96,34 @@ func (l Listing) LinkedPath() string {
 	return result
 }
 
+// BreadcrumbMap returns l.Path where every element is a map
+// of URLs and path segment names.
+func (l Listing) BreadcrumbMap() map[string]string {
+	result := map[string]string{}
+
+	if len(l.Path) == 0 {
+		return result
+	}
+
+	// skip trailing slash
+	lpath := l.Path
+	if lpath[len(lpath)-1] == '/' {
+		lpath = lpath[:len(lpath)-1]
+	}
+
+	parts := strings.Split(lpath, "/")
+	for i, part := range parts {
+		if i == 0 && part == "" {
+			// Leading slash (root)
+			result["/"] = "/"
+			continue
+		}
+		result[strings.Join(parts[:i+1], "/")] = part
+	}
+
+	return result
+}
+
 // FileInfo is the info about a particular file or directory
 type FileInfo struct {
 	IsDir   bool


### PR DESCRIPTION
In order to being able to really build a custom template for the browse
directive I have added another function to build even custom breadcrumb
paths. The other function `LinkedPath` is not that easy styleable as
this map function. That way we are able to build the breadcrumb path
matching different CSS frameworks like Bootstrap.

An example implementation should look like that, matching the Bootstrap structure:

```
<ol class="breadcrumb">
  {{range $url, $name := .BreadcrumbMap}}
    <li><a href="{{$url}}">{{$name}}</a></li>
  {{end}}
</ol>
```

Signed-off-by: Thomas Boerger <thomas@webhippie.de>