### PR TITLE
Make the TIP test happy again

### DIFF
--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -52,7 +52,13 @@ func TestInclude(t *testing.T) {
 			fileContent:          `str1 {{ .InvalidField }} str2`,
 			expectedContent:      "",
 			shouldErr:            true,
-			expectedErrorContent: `InvalidField is not a field of struct type middleware.Context`,
+			expectedErrorContent: `InvalidField`,
+		},
+		{
+			fileContent:          `str1 {{ .InvalidField }} str2`,
+			expectedContent:      "",
+			shouldErr:            true,
+			expectedErrorContent: `type middleware.Context`,
 		},
 	}
 


### PR DESCRIPTION
As Go tip has changed the error message I have made the tests less
restrictive to match older versions and tip version of the error.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>