### PR TITLE
Dropped LinkedPath and updated browse template

### DIFF
--- a/caddy/setup/browse.go
+++ b/caddy/setup/browse.go
@@ -264,7 +264,6 @@ footer {
 					</g>
 				</g>
 
-
 				<!-- File -->
 				<linearGradient id="a">
 					<stop stop-color="#cbcbcb" offset="0"/>
@@ -300,14 +299,14 @@ footer {
 			</defs>
 		</svg>
 
-
-
 		<header>
-			<h1>{{.LinkedPath}}</h1>
+			<h1>
+				{{range $url, $name := .BreadcrumbMap}}<a href="{{$url}}">{{$name}}</a>{{if ne $url "/"}}/{{end}}{{end}}
+			</h1>
 		</header>
 		<main>
 			<div class="meta">
-				<div class="content">	
+				<div class="content">
 					<span class="meta-item"><b>{{.NumDirs}}</b> director{{if eq 1 .NumDirs}}y{{else}}ies{{end}}</span>
 					<span class="meta-item"><b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}</span>
 				</div>

--- a/middleware/browse/browse.go
+++ b/middleware/browse/browse.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -67,33 +66,6 @@ type Listing struct {
 	User interface{}
 
 	middleware.Context
-}
-
-// LinkedPath returns l.Path where every element is a clickable
-// link to the path up to that point so far.
-func (l Listing) LinkedPath() string {
-	if len(l.Path) == 0 {
-		return ""
-	}
-
-	// skip trailing slash
-	lpath := l.Path
-	if lpath[len(lpath)-1] == '/' {
-		lpath = lpath[:len(lpath)-1]
-	}
-
-	parts := strings.Split(lpath, "/")
-	var result string
-	for i, part := range parts {
-		if i == 0 && part == "" {
-			// Leading slash (root)
-			result += `<a href="/">/</a>`
-			continue
-		}
-		result += fmt.Sprintf(`<a href="%s/">%s</a>/`, strings.Join(parts[:i+1], "/"), part)
-	}
-
-	return result
 }
 
 // BreadcrumbMap returns l.Path where every element is a map


### PR DESCRIPTION
As discussed with @mholt I have dropped the old LinkedPath function and
replaced it within the browse template with the new BreadcrumbMap
function. Visually it looks exactly the same as before, now the template
functionality is just more powerful.

Signed-off-by: Thomas Boerger <tboerger@suse.de>