### PR TITLE
Make Browse Great Again ★★★

### DIFF
--- a/caddy/setup/browse.go
+++ b/caddy/setup/browse.go
@@ -385,5 +385,16 @@ footer {
 		<footer>
 			Served with <a href="https://caddyserver.com">Caddy</a>
 		</footer>
+		<script type="text/javascript">
+			function localizeDatetime(e, index, ar) {
+				if (e.textContent === undefined) {
+					return;
+				}
+				var d = new Date(e.getAttribute('datetime'));
+				e.textContent = d.toLocaleString();
+			}
+			var timeList = Array.prototype.slice.call(document.getElementsByTagName("time"));
+			timeList.forEach(localizeDatetime);
+		</script>
 	</body>
 </html>`

--- a/caddy/setup/browse.go
+++ b/caddy/setup/browse.go
@@ -309,6 +309,9 @@ footer {
 				<div class="content">
 					<span class="meta-item"><b>{{.NumDirs}}</b> director{{if eq 1 .NumDirs}}y{{else}}ies{{end}}</span>
 					<span class="meta-item"><b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}</span>
+					{{- if ne 0 .ItemsLimitedTo}}
+					<span class="meta-item">(of which only <b>{{.ItemsLimitedTo}}</b> are displayed)</span>
+					{{- end}}
 				</div>
 			</div>
 			<div class="listing">
@@ -316,29 +319,29 @@ footer {
 					<tr>
 						<th>
 							{{if and (eq .Sort "name") (ne .Order "desc")}}
-							<a href="?sort=name&order=desc">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a>
+							<a href="?sort=name&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a>
 							{{else if and (eq .Sort "name") (ne .Order "asc")}}
-							<a href="?sort=name&order=asc">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a>
+							<a href="?sort=name&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a>
 							{{else}}
-							<a href="?sort=name&order=asc">Name</a>
+							<a href="?sort=name&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name</a>
 							{{end}}
 						</th>
 						<th>
 							{{if and (eq .Sort "size") (ne .Order "desc")}}
-							<a href="?sort=size&order=desc">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
+							<a href="?sort=size&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
 							{{else if and (eq .Sort "size") (ne .Order "asc")}}
-							<a href="?sort=size&order=asc">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
+							<a href="?sort=size&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
 							{{else}}
-							<a href="?sort=size&order=asc">Size</a>
+							<a href="?sort=size&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size</a>
 							{{end}}
 						</th>
 						<th class="hideable">
 							{{if and (eq .Sort "time") (ne .Order "desc")}}
-							<a href="?sort=time&order=desc">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
+							<a href="?sort=time&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
 							{{else if and (eq .Sort "time") (ne .Order "asc")}}
-							<a href="?sort=time&order=asc">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
+							<a href="?sort=time&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
 							{{else}}
-							<a href="?sort=time&order=asc">Modified</a>
+							<a href="?sort=time&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified</a>
 							{{end}}
 						</th>
 					</tr>

--- a/caddy/setup/browse.go
+++ b/caddy/setup/browse.go
@@ -85,7 +85,6 @@ const defaultTemplate = `<!DOCTYPE html>
 <html>
 	<head>
 		<title>{{.Name}}</title>
-		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
 * { padding: 0; margin: 0; }
@@ -106,7 +105,7 @@ h1 a:hover {
 }
 
 header,
-.content {
+#summary {
 	padding-left: 5%;
 	padding-right: 5%;
 }
@@ -306,7 +305,7 @@ footer {
 		</header>
 		<main>
 			<div class="meta">
-				<div class="content">
+				<div id="summary">
 					<span class="meta-item"><b>{{.NumDirs}}</b> director{{if eq 1 .NumDirs}}y{{else}}ies{{end}}</span>
 					<span class="meta-item"><b>{{.NumFiles}}</b> file{{if ne 1 .NumFiles}}s{{end}}</span>
 					{{- if ne 0 .ItemsLimitedTo}}
@@ -315,37 +314,40 @@ footer {
 				</div>
 			</div>
 			<div class="listing">
-				<table>
+				<table aria-describedby="summary">
+					<thead>
 					<tr>
 						<th>
-							{{if and (eq .Sort "name") (ne .Order "desc")}}
+							{{- if and (eq .Sort "name") (ne .Order "desc")}}
 							<a href="?sort=name&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a>
-							{{else if and (eq .Sort "name") (ne .Order "asc")}}
+							{{- else if and (eq .Sort "name") (ne .Order "asc")}}
 							<a href="?sort=name&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a>
-							{{else}}
+							{{- else}}
 							<a href="?sort=name&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Name</a>
-							{{end}}
+							{{- end}}
 						</th>
 						<th>
-							{{if and (eq .Sort "size") (ne .Order "desc")}}
+							{{- if and (eq .Sort "size") (ne .Order "desc")}}
 							<a href="?sort=size&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
-							{{else if and (eq .Sort "size") (ne .Order "asc")}}
+							{{- else if and (eq .Sort "size") (ne .Order "asc")}}
 							<a href="?sort=size&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
-							{{else}}
+							{{- else}}
 							<a href="?sort=size&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Size</a>
-							{{end}}
+							{{- end}}
 						</th>
 						<th class="hideable">
-							{{if and (eq .Sort "time") (ne .Order "desc")}}
+							{{- if and (eq .Sort "time") (ne .Order "desc")}}
 							<a href="?sort=time&order=desc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#up-arrow"></use></svg></a></a>
-							{{else if and (eq .Sort "time") (ne .Order "asc")}}
+							{{- else if and (eq .Sort "time") (ne .Order "asc")}}
 							<a href="?sort=time&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified <svg width="1em" height=".4em" version="1.1" viewBox="0 0 12.922194 6.0358899"><use xlink:href="#down-arrow"></use></svg></a></a>
-							{{else}}
+							{{- else}}
 							<a href="?sort=time&order=asc{{if ne 0 .ItemsLimitedTo}}&limit={{.ItemsLimitedTo}}{{end}}">Modified</a>
-							{{end}}
+							{{- end}}
 						</th>
 					</tr>
-					{{if .CanGoUp}}
+					</thead>
+					<tbody>
+					{{- if .CanGoUp}}
 					<tr>
 						<td>
 							<a href="..">
@@ -353,25 +355,30 @@ footer {
 							</a>
 						</td>
 						<td>&mdash;</td>
-						<td>&mdash;</td>
+						<td class="hideable">&mdash;</td>
 					</tr>
-					{{end}}
-					{{range .Items}}
+					{{- end}}
+					{{- range .Items}}
 					<tr>
 						<td>
 							<a href="{{.URL}}">
-								{{if .IsDir}}
+								{{- if .IsDir}}
 								<svg width="1.5em" height="1em" version="1.1" viewBox="0 0 35.678803 28.527945"><use xlink:href="#folder"></use></svg>
-								{{else}}
+								{{- else}}
 								<svg width="1.5em" height="1em" version="1.1" viewBox="0 0 26.604381 29.144726"><use xlink:href="#file"></use></svg>
-								{{end}}
+								{{- end}}
 								<span class="name">{{.Name}}</span>
 							</a>
 						</td>
-						<td>{{.HumanSize}}</td>
-						<td class="hideable">{{.HumanModTime "01/02/2006 03:04:05 PM"}}</td>
+						{{- if .IsDir}}
+						<td data-order="-1">&mdash;</td>
+						{{- else}}
+						<td data-order="{{.Size}}">{{.HumanSize}}</td>
+						{{- end}}
+						<td class="hideable"><time datetime="{{.HumanModTime "2006-01-02 15:04:05-0700"}}">{{.HumanModTime "01/02/2006 03:04:05 PM"}}</time></td>
 					</tr>
-					{{end}}
+					{{- end}}
+					</tbody>
 				</table>
 			</div>
 		</main>

--- a/middleware/browse/browse.go
+++ b/middleware/browse/browse.go
@@ -217,7 +217,7 @@ func directoryListing(files []os.FileInfo, canGoUp bool, urlPath string) (Listin
 			Name:    f.Name(),
 			Size:    f.Size(),
 			URL:     url.String(),
-			ModTime: f.ModTime(),
+			ModTime: f.ModTime().UTC(),
 			Mode:    f.Mode(),
 		})
 	}

--- a/middleware/browse/browse.go
+++ b/middleware/browse/browse.go
@@ -135,9 +135,20 @@ func (l byName) Less(i, j int) bool {
 }
 
 // By Size
-func (l bySize) Len() int           { return len(l.Items) }
-func (l bySize) Swap(i, j int)      { l.Items[i], l.Items[j] = l.Items[j], l.Items[i] }
-func (l bySize) Less(i, j int) bool { return l.Items[i].Size < l.Items[j].Size }
+func (l bySize) Len() int      { return len(l.Items) }
+func (l bySize) Swap(i, j int) { l.Items[i], l.Items[j] = l.Items[j], l.Items[i] }
+
+const directoryOffset = -1 << 31 // = math.MinInt32
+func (l bySize) Less(i, j int) bool {
+	iSize, jSize := l.Items[i].Size, l.Items[j].Size
+	if l.Items[i].IsDir {
+		iSize = directoryOffset + iSize
+	}
+	if l.Items[j].IsDir {
+		jSize = directoryOffset + jSize
+	}
+	return iSize < jSize
+}
 
 // By Time
 func (l byTime) Len() int           { return len(l.Items) }

--- a/middleware/browse/browse_test.go
+++ b/middleware/browse/browse_test.go
@@ -114,10 +114,10 @@ func TestBrowseHTTPMethods(t *testing.T) {
 		Next: middleware.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
 			return http.StatusTeapot, nil // not t.Fatalf, or we will not see what other methods yield
 		}),
-		Root: "./testdata",
 		Configs: []Config{
 			{
 				PathScope: "/photos",
+				Root:      http.Dir("./testdata"),
 				Template:  tmpl,
 			},
 		},
@@ -153,10 +153,10 @@ func TestBrowseTemplate(t *testing.T) {
 			t.Fatalf("Next shouldn't be called")
 			return 0, nil
 		}),
-		Root: "./testdata",
 		Configs: []Config{
 			{
 				PathScope: "/photos",
+				Root:      http.Dir("./testdata"),
 				Template:  tmpl,
 			},
 		},
@@ -208,16 +208,16 @@ func TestBrowseJson(t *testing.T) {
 			t.Fatalf("Next shouldn't be called")
 			return 0, nil
 		}),
-		Root: "./testdata",
 		Configs: []Config{
 			{
 				PathScope: "/photos/",
+				Root:      http.Dir("./testdata"),
 			},
 		},
 	}
 
 	//Getting the listing from the ./testdata/photos, the listing returned will be used to validate test results
-	testDataPath := b.Root + "/photos/"
+	testDataPath := filepath.Join("./testdata", "photos")
 	file, err := os.Open(testDataPath)
 	if err != nil {
 		if os.IsPermission(err) {

--- a/middleware/browse/browse_test.go
+++ b/middleware/browse/browse_test.go
@@ -315,7 +315,7 @@ func TestBrowseJson(t *testing.T) {
 		code, err := b.ServeHTTP(rec, req)
 
 		if code != http.StatusOK {
-			t.Fatalf("Wrong status, expected %d, got %d", http.StatusOK, code)
+			t.Fatalf("In test %d: Wrong status, expected %d, got %d", i, http.StatusOK, code)
 		}
 		if rec.HeaderMap.Get("Content-Type") != "application/json; charset=utf-8" {
 			t.Fatalf("Expected Content type to be application/json; charset=utf-8, but got %s ", rec.HeaderMap.Get("Content-Type"))

--- a/middleware/browse/browse_test.go
+++ b/middleware/browse/browse_test.go
@@ -238,7 +238,7 @@ func TestBrowseJson(t *testing.T) {
 		// Tests fail in CI environment because all file mod times are the same for
 		// some reason, making the sorting unpredictable. To hack around this,
 		// we ensure here that each file has a different mod time.
-		chTime := f.ModTime().Add(-(time.Duration(i) * time.Second))
+		chTime := f.ModTime().UTC().Add(-(time.Duration(i) * time.Second))
 		if err := os.Chtimes(filepath.Join(testDataPath, name), chTime, chTime); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Middleware browse has been refactored for better maintainability and extendability. As a result features that had been in one format are carried over to all other.

The outstanding cause for much grief—datetimes shown to visitors in the "wrong" format ('wrong' being a mismatch between expected format and what Caddy delivers)—has been addressed by delegating its formatting to the visitor's browser.

Standardizing the timezone of all returned datetime instances on UTC, and not depending on filesystem implementation details when sorting any directories, yields a well-defined user experience no matter where and on what system Caddy is actually deployed.