### PR TITLE
Overwrite proxy headers based on directive #666

### DIFF
--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -43,8 +43,8 @@ type UpstreamHost struct {
 	Fails             int32
 	FailTimeout       time.Duration
 	Unhealthy         bool
-	UpStreamHeaders   http.Header
-	DownStreamHeaders http.Header
+	UpstreamHeaders   http.Header
+	DownstreamHeaders http.Header
 	CheckDown         UpstreamHostDownFunc
 	WithoutPathPrefix string
 	MaxConns          int64
@@ -100,31 +100,31 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			}
 
 			outreq.Host = host.Name
-			if host.UpStreamHeaders != nil {
+			if host.UpstreamHeaders != nil {
 				if replacer == nil {
 					rHost := r.Host
 					replacer = middleware.NewReplacer(r, nil, "")
 					outreq.Host = rHost
 				}
-				if v, ok := host.UpStreamHeaders["Host"]; ok {
+				if v, ok := host.UpstreamHeaders["Host"]; ok {
 					r.Host = replacer.Replace(v[len(v)-1])
 				}
 				// Modify headers for request that will be sent to the upstream host
-				upHeaders := createHeadersByRules(host.UpStreamHeaders, r.Header, replacer)
+				upHeaders := createHeadersByRules(host.UpstreamHeaders, r.Header, replacer)
 				for k, v := range upHeaders {
 					outreq.Header[k] = v
 				}
 			}
 
 			var downHeaderUpdateFn respUpdateFn
-			if host.DownStreamHeaders != nil {
+			if host.DownstreamHeaders != nil {
 				if replacer == nil {
 					rHost := r.Host
 					replacer = middleware.NewReplacer(r, nil, "")
 					outreq.Host = rHost
 				}
-				//Creates a function that is used to update headeres the response received by the reverseproxy
-				downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownStreamHeaders, replacer)
+				//Creates a function that is used to update headers the response received by the reverse proxy
+				downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownstreamHeaders, replacer)
 			}
 
 			proxy := host.ReverseProxy

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -452,7 +452,7 @@ func TestDownstreamHeadersUpdate(t *testing.T) {
 	p.ServeHTTP(w, r)
 
 	replacer := middleware.NewReplacer(r, nil, "")
-	var actualHeaders http.Header = w.Header()
+	actualHeaders := w.Header()
 
 	headerKey := "Merge-Me"
 	values, ok := actualHeaders[headerKey]

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -392,7 +392,7 @@ func TestHeadersUpdate(t *testing.T) {
 	headerKey := "Merge-Me"
 	values, ok := actualHeaders[headerKey]
 	if !ok {
-		t.Errorf("Request sent to upstream backend does not contain expected header. Expected header to be added", headerKey)
+		t.Errorf("Request sent to upstream backend does not contain expected %v header. Expected header to be added", headerKey)
 	} else if len(values) < 2 && (values[0] != "Initial" || values[1] != replacer.Replace("{hostname}")) {
 		t.Errorf("Values for proxy header `+Merge-Me` should be merged. Got %v", values)
 	}

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -413,7 +413,7 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 	if !ok {
 		t.Errorf("Request sent to upstream backend should not remove %v header", headerKey)
 	} else if len(value) > 0 && headerValue != value[0] {
-		t.Errorf("Request sent to backend should replace value of %v header with %v. Instead value was %v", headerKey, headerValue, value)
+		t.Errorf("Request sent to upstream backend should replace value of %v header with %v. Instead value was %v", headerKey, headerValue, value)
 	}
 
 }
@@ -457,28 +457,28 @@ func TestDownstreamHeadersUpdate(t *testing.T) {
 	headerKey := "Merge-Me"
 	values, ok := actualHeaders[headerKey]
 	if !ok {
-		t.Errorf("Request sent to upstream backend does not contain expected %v header. Expected header to be added", headerKey)
+		t.Errorf("Downstream response does not contain expected %v header. Expected header should be added", headerKey)
 	} else if len(values) < 2 && (values[0] != "Initial" || values[1] != replacer.Replace("{hostname}")) {
-		t.Errorf("Values for proxy header `+Merge-Me` should be merged. Got %v", values)
+		t.Errorf("Values for header `+Merge-Me` should be merged. Got %v", values)
 	}
 
 	headerKey = "Add-Me"
 	if _, ok := actualHeaders[headerKey]; !ok {
-		t.Errorf("Request sent to upstream backend does not contain expected %v header", headerKey)
+		t.Errorf("Downstream response does not contain expected %v header", headerKey)
 	}
 
 	headerKey = "Remove-Me"
 	if _, ok := actualHeaders[headerKey]; ok {
-		t.Errorf("Request sent to upstream backend should not contain %v header", headerKey)
+		t.Errorf("Downstream response should not contain %v header received from upstream", headerKey)
 	}
 
 	headerKey = "Replace-Me"
 	headerValue := replacer.Replace("{hostname}")
 	value, ok := actualHeaders[headerKey]
 	if !ok {
-		t.Errorf("Request sent to upstream backend should not remove %v header", headerKey)
+		t.Errorf("Downstream response should contain %v header and not remove it", headerKey)
 	} else if len(value) > 0 && headerValue != value[0] {
-		t.Errorf("Request sent to backend should replace value of %v header with %v. Instead value was %v", headerKey, headerValue, value)
+		t.Errorf("Downstream response should have header %v with value %v. Instead value was %v", headerKey, headerValue, value)
 	}
 
 }

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -348,7 +348,7 @@ func TestUnixSocketProxyPaths(t *testing.T) {
 	}
 }
 
-func TestUpStreamHeadersUpdate(t *testing.T) {
+func TestUpstreamHeadersUpdate(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
 
@@ -360,7 +360,7 @@ func TestUpStreamHeadersUpdate(t *testing.T) {
 	defer backend.Close()
 
 	upstream := newFakeUpstream(backend.URL, false)
-	upstream.host.UpStreamHeaders = http.Header{
+	upstream.host.UpstreamHeaders = http.Header{
 		"Connection": {"{>Connection}"},
 		"Upgrade":    {"{>Upgrade}"},
 		"+Merge-Me":  {"Merge-Value"},
@@ -418,7 +418,7 @@ func TestUpStreamHeadersUpdate(t *testing.T) {
 
 }
 
-func TestDownStreamHeadersUpdate(t *testing.T) {
+func TestDownstreamHeadersUpdate(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
 
@@ -431,7 +431,7 @@ func TestDownStreamHeadersUpdate(t *testing.T) {
 	defer backend.Close()
 
 	upstream := newFakeUpstream(backend.URL, false)
-	upstream.host.DownStreamHeaders = http.Header{
+	upstream.host.DownstreamHeaders = http.Header{
 		"+Merge-Me":  {"Merge-Value"},
 		"+Add-Me":    {"Add-Value"},
 		"-Remove-Me": {""},
@@ -545,7 +545,7 @@ func (u *fakeWsUpstream) Select() *UpstreamHost {
 	return &UpstreamHost{
 		Name:         u.name,
 		ReverseProxy: NewSingleHostReverseProxy(uri, u.without),
-		UpStreamHeaders: http.Header{
+		UpstreamHeaders: http.Header{
 			"Connection": {"{>Connection}"},
 			"Upgrade":    {"{>Upgrade}"}},
 	}

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -154,9 +154,9 @@ var InsecureTransport http.RoundTripper = &http.Transport{
 	TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 }
 
-type RespHeaderUpdateFn func(src http.Header)
+type respUpdateFn func(resp *http.Response)
 
-func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respHeaderFn RespHeaderUpdateFn) error {
+func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respUpdateFn respUpdateFn) error {
 	transport := p.Transport
 	if transport == nil {
 		transport = http.DefaultTransport
@@ -171,8 +171,8 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, r
 	res, err := transport.RoundTrip(outreq)
 	if err != nil {
 		return err
-	} else if respHeaderFn != nil {
-		respHeaderFn(res.Header)
+	} else if respUpdateFn != nil {
+		respUpdateFn(res)
 	}
 
 	if res.StatusCode == http.StatusSwitchingProtocols && strings.ToLower(res.Header.Get("Upgrade")) == "websocket" {

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -154,6 +154,8 @@ var InsecureTransport http.RoundTripper = &http.Transport{
 	TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 }
 
+type RespHeaderUpdateFn func(src http.Header)
+
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, respHeaderFn RespHeaderUpdateFn) error {
 	transport := p.Transport
 	if transport == nil {

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -20,7 +20,8 @@ var (
 
 type staticUpstream struct {
 	from               string
-	proxyHeaders       http.Header
+	upstreamHeaders    http.Header
+	downstreamHeaders  http.Header
 	Hosts              HostPool
 	Policy             Policy
 	insecureSkipVerify bool
@@ -42,13 +43,14 @@ func NewStaticUpstreams(c parse.Dispenser) ([]Upstream, error) {
 	var upstreams []Upstream
 	for c.Next() {
 		upstream := &staticUpstream{
-			from:         "",
-			proxyHeaders: make(http.Header),
-			Hosts:        nil,
-			Policy:       &Random{},
-			FailTimeout:  10 * time.Second,
-			MaxFails:     1,
-			MaxConns:     0,
+			from:              "",
+			upstreamHeaders:   make(http.Header),
+			downstreamHeaders: make(http.Header),
+			Hosts:             nil,
+			Policy:            &Random{},
+			FailTimeout:       10 * time.Second,
+			MaxFails:          1,
+			MaxConns:          0,
 		}
 
 		if !c.Args(&upstream.from) {
@@ -97,12 +99,13 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		host = "http://" + host
 	}
 	uh := &UpstreamHost{
-		Name:         host,
-		Conns:        0,
-		Fails:        0,
-		FailTimeout:  u.FailTimeout,
-		Unhealthy:    false,
-		ExtraHeaders: u.proxyHeaders,
+		Name:              host,
+		Conns:             0,
+		Fails:             0,
+		FailTimeout:       u.FailTimeout,
+		Unhealthy:         false,
+		UpStreamHeaders:   u.upstreamHeaders,
+		DownStreamHeaders: u.downstreamHeaders,
 		CheckDown: func(u *staticUpstream) UpstreamHostDownFunc {
 			return func(uh *UpstreamHost) bool {
 				if uh.Unhealthy {
@@ -182,15 +185,23 @@ func parseBlock(c *parse.Dispenser, u *staticUpstream) error {
 			}
 			u.HealthCheck.Interval = dur
 		}
+	case "header_upstream":
+		fallthrough
 	case "proxy_header":
 		var header, value string
 		if !c.Args(&header, &value) {
 			return c.ArgErr()
 		}
-		u.proxyHeaders.Add(header, value)
+		u.upstreamHeaders.Add(header, value)
+	case "header_downstream":
+		var header, value string
+		if !c.Args(&header, &value) {
+			return c.ArgErr()
+		}
+		u.downstreamHeaders.Add(header, value)
 	case "websocket":
-		u.proxyHeaders.Add("Connection", "{>Connection}")
-		u.proxyHeaders.Add("Upgrade", "{>Upgrade}")
+		u.upstreamHeaders.Add("Connection", "{>Connection}")
+		u.upstreamHeaders.Add("Upgrade", "{>Upgrade}")
 	case "without":
 		if !c.NextArg() {
 			return c.ArgErr()

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -104,8 +104,8 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		Fails:             0,
 		FailTimeout:       u.FailTimeout,
 		Unhealthy:         false,
-		UpStreamHeaders:   u.upstreamHeaders,
-		DownStreamHeaders: u.downstreamHeaders,
+		UpstreamHeaders:   u.upstreamHeaders,
+		DownstreamHeaders: u.downstreamHeaders,
 		CheckDown: func(u *staticUpstream) UpstreamHostDownFunc {
 			return func(uh *UpstreamHost) bool {
 				if uh.Unhealthy {


### PR DESCRIPTION
Issue #666 

Headers of the request sent by the proxy upstream can now be modified in
the following way:

Header prefixed with `+`: Header will be added if it doesn't exist
otherwise, the values will be merge
Header prefixed with `-': Header will be removed
Header with no prefix: Header will be replaced with given value

Based on the issue reported. This only modifies the headers sent upstream and not the headers of the response received from the upstream. 

I did, however investigate modifying the headers received from the upstream. Which required me changing `reverseproxy.go`. I removed it in the end since it felt like a hack. I feel it would be better to add `proxy_resp_header` to the proxy directive which makes the direction the headers should be applied clear.