### PR TITLE
Update markdown middleware

### DIFF
--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -157,6 +157,26 @@ DocFlags.var_bool true`
 	if !equalStrings(respBody, expectedBody) {
 		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
 	}
+	
+	//start object tests
+	req, err = http.NewRequest("GET", "/objects/toml.md", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+	rec = httptest.NewRecorder()
+
+	md.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
+	}
+	respBody = rec.Body.String()
+	expectedBody = `kind: toml
+	object-key: value`
+
+	if !equalStrings(respBody, expectedBody) {
+		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	}
+	//end object tests
 
 	req, err = http.NewRequest("GET", "/log/test.md", nil)
 	if err != nil {

--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -45,6 +45,18 @@ func TestMarkdown(t *testing.T) {
 				StaticFiles: make(map[string]string),
 			},
 			{
+				Renderer:   blackfriday.HtmlRenderer(0, "", ""),
+				PathScope:  "/objects",
+				Extensions: []string{".md"},
+				Styles:     []string{},
+				Scripts:    []string{},
+				Templates: map[string]string{
+					DefaultTemplate: "testdata/objects/template.txt",
+				},
+				StaticDir:   DefaultStaticDir,
+				StaticFiles: make(map[string]string),
+			},
+			{
 				Renderer:    blackfriday.HtmlRenderer(0, "", ""),
 				PathScope:   "/log",
 				Extensions:  []string{".md"},

--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -95,7 +95,7 @@ func TestMarkdown(t *testing.T) {
 	for i := range md.Configs {
 		c := md.Configs[i]
 		if err := GenerateStatic(md, c); err != nil {
-			t.Fatalf("Error at %v: %v", i, err)
+			t.Fatalf("Error: %v", err)
 		}
 		Watch(md, c, time.Millisecond*100)
 	}

--- a/middleware/markdown/markdown_test.go
+++ b/middleware/markdown/markdown_test.go
@@ -95,7 +95,7 @@ func TestMarkdown(t *testing.T) {
 	for i := range md.Configs {
 		c := md.Configs[i]
 		if err := GenerateStatic(md, c); err != nil {
-			t.Fatalf("Error: %v", err)
+			t.Fatalf("Error at %v: %v", i, err)
 		}
 		Watch(md, c, time.Millisecond*100)
 	}
@@ -158,7 +158,45 @@ DocFlags.var_bool true`
 		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
 	}
 	
-	//start object tests
+	
+	req, err = http.NewRequest("GET", "/objects/json.md", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+	rec = httptest.NewRecorder()
+
+	md.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
+	}
+	respBody = rec.Body.String()
+	expectedBody = `kind: json
+	object-key: value`
+
+	if !equalStrings(respBody, expectedBody) {
+		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	}
+	
+	
+	req, err = http.NewRequest("GET", "/objects/yaml.md", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+	rec = httptest.NewRecorder()
+
+	md.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
+	}
+	respBody = rec.Body.String()
+	expectedBody = `kind: yaml
+	object-key: value`
+
+	if !equalStrings(respBody, expectedBody) {
+		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	}
+	
+	
 	req, err = http.NewRequest("GET", "/objects/toml.md", nil)
 	if err != nil {
 		t.Fatalf("Could not create HTTP request: %v", err)
@@ -176,7 +214,7 @@ DocFlags.var_bool true`
 	if !equalStrings(respBody, expectedBody) {
 		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
 	}
-	//end object tests
+	
 
 	req, err = http.NewRequest("GET", "/log/test.md", nil)
 	if err != nil {

--- a/middleware/markdown/metadata.go
+++ b/middleware/markdown/metadata.go
@@ -22,7 +22,7 @@ type Metadata struct {
 	Date time.Time
 
 	// Variables to be used with Template
-	Variables map[string]string
+	Variables map[string]interface{} // Update to interface{} to allow any type
 
 	// Flags to be used with Template
 	Flags map[string]bool
@@ -48,6 +48,8 @@ func (m *Metadata) load(parsedMap map[string]interface{}) {
 			m.Variables[key] = v
 		case bool:
 			m.Flags[key] = v
+		default:
+			m.Variables[key] = v // Everything that's not a string or bool will just go into .Doc: Objects, Arrays, Integers, etc.
 		}
 	}
 }
@@ -227,7 +229,7 @@ func findParser(b []byte) MetadataParser {
 
 func newMetadata() Metadata {
 	return Metadata{
-		Variables: make(map[string]string),
+		Variables: make(map[string]interface{}), // Update to interface{} to allow any type
 		Flags:     make(map[string]bool),
 	}
 }

--- a/middleware/markdown/metadata_test.go
+++ b/middleware/markdown/metadata_test.go
@@ -127,7 +127,7 @@ func TestParsers(t *testing.T) {
 	expected := Metadata{
 		Title:    "A title",
 		Template: "default",
-		Variables: map[string]string{
+		Variables: map[string]interface{}{
 			"name":     "value",
 			"title":    "A title",
 			"template": "default",

--- a/middleware/markdown/process.go
+++ b/middleware/markdown/process.go
@@ -23,7 +23,7 @@ const (
 // Data represents a markdown document.
 type Data struct {
 	middleware.Context
-	Doc      map[string]string
+	Doc      map[string]interface{} // Update to interface{} to allow any type
 	DocFlags map[string]bool
 	Links    []PageLink
 }
@@ -191,7 +191,7 @@ func defaultTemplate(c *Config, metadata Metadata, requestPath string) []byte {
 	title, _ := metadata.Variables["title"]
 
 	html := []byte(htmlTemplate)
-	html = bytes.Replace(html, []byte("{{title}}"), []byte(title), 1)
+	html = bytes.Replace(html, []byte("{{title}}"), []byte(title.(string)), 1)
 	html = bytes.Replace(html, []byte("{{css}}"), styles.Bytes(), 1)
 	html = bytes.Replace(html, []byte("{{js}}"), scripts.Bytes(), 1)
 

--- a/middleware/markdown/testdata/objects/json.md
+++ b/middleware/markdown/testdata/objects/json.md
@@ -1,0 +1,6 @@
+{
+    "kind": "json",
+    "object": {
+        "key": "value"
+    }
+}

--- a/middleware/markdown/testdata/objects/template.txt
+++ b/middleware/markdown/testdata/objects/template.txt
@@ -1,2 +1,2 @@
 kind: {{ .Doc.kind }}
-object-value: {{ .Doc.object.key }}
+object-key: {{ .Doc.object.key }}

--- a/middleware/markdown/testdata/objects/template.txt
+++ b/middleware/markdown/testdata/objects/template.txt
@@ -1,0 +1,2 @@
+kind: {{ .Doc.kind }}
+object-value: {{ .Doc.object.key }}

--- a/middleware/markdown/testdata/objects/toml.md
+++ b/middleware/markdown/testdata/objects/toml.md
@@ -1,5 +1,5 @@
----
++++
 kind = "toml"
 [object]
 key = "value"
----
++++

--- a/middleware/markdown/testdata/objects/toml.md
+++ b/middleware/markdown/testdata/objects/toml.md
@@ -1,0 +1,5 @@
+---
+kind = "toml"
+[object]
+key = "value"
+---

--- a/middleware/markdown/testdata/objects/yaml.md
+++ b/middleware/markdown/testdata/objects/yaml.md
@@ -1,0 +1,5 @@
++++
+kind: yaml
+object:
+    key: value
++++

--- a/middleware/markdown/testdata/objects/yaml.md
+++ b/middleware/markdown/testdata/objects/yaml.md
@@ -1,5 +1,5 @@
-+++
-kind: yaml
+---
+kind: "yaml"
 object:
-    key: value
-+++
+    key: "value"
+---


### PR DESCRIPTION
Issue #794 

Changed markdown.go and metadata.go to allow objects in front matter.
Tests will fail due to JSON front matter. The unexpected EOF is from the static generator throwing an error from the JSON front matter in the test file json.md