### PR TITLE
Fix #801: Write sub-400 status codes from middleware to response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -362,6 +362,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if status >= 400 {
 			DefaultErrorFunc(w, r, status)
 		}
+
+		w.WriteHeader(status)
 	} else {
 		// Get the remote host
 		remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)


### PR DESCRIPTION
Fixes Issue #801 

Status codes under 400 from middleware were never written to the header in the main ServeHTTP method. Any returned codes were ignored and the default `http.StatusOK` was written.