### PR TITLE
Restart gracefully with in-process restart

### DIFF
--- a/caddy/restart.go
+++ b/caddy/restart.go
@@ -4,22 +4,13 @@ package caddy
 
 import (
 	"bytes"
-	"encoding/gob"
 	"errors"
-	"io/ioutil"
 	"log"
 	"net"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"sync/atomic"
 
 	"github.com/mholt/caddy/caddy/https"
 )
-
-func init() {
-	gob.Register(CaddyfileInput{})
-}
 
 // Restart restarts the entire application; gracefully with zero
 // downtime if on a POSIX-compatible system, or forcefully if on
@@ -52,87 +43,14 @@ func Restart(newCaddyfile Input) error {
 		return errors.New("TLS preload: " + err.Error())
 	}
 
-	if RestartMode == "inproc" {
-		return restartInProc(newCaddyfile)
-	}
-
-	if len(os.Args) == 0 { // this should never happen, but...
-		os.Args = []string{""}
-	}
-
-	// Tell the child that it's a restart
-	os.Setenv("CADDY_RESTART", "true")
-
-	// Prepare our payload to the child process
-	cdyfileGob := caddyfileGob{
-		ListenerFds:            make(map[string]uintptr),
-		Caddyfile:              newCaddyfile,
-		OnDemandTLSCertsIssued: atomic.LoadInt32(https.OnDemandIssuedCount),
-	}
-
-	// Prepare a pipe to the fork's stdin so it can get the Caddyfile
-	rpipe, wpipe, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-
-	// Prepare a pipe that the child process will use to communicate
-	// its success with us by sending > 0 bytes
-	sigrpipe, sigwpipe, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-
-	// Pass along relevant file descriptors to child process; ordering
-	// is very important since we rely on these being in certain positions.
-	extraFiles := []*os.File{sigwpipe} // fd 3
-
-	// Add file descriptors of all the sockets
+	// Add file descriptors of all the sockets for new instance
 	serversMu.Lock()
-	for i, s := range servers {
-		extraFiles = append(extraFiles, s.ListenerFd())
-		cdyfileGob.ListenerFds[s.Addr] = uintptr(4 + i) // 4 fds come before any of the listeners
+	for _, s := range servers {
+		restartFds[s.Addr] = s.ListenerFd()
 	}
 	serversMu.Unlock()
 
-	// Set up the command
-	cmd := exec.Command(os.Args[0], os.Args[1:]...)
-	cmd.Stdin = rpipe      // fd 0
-	cmd.Stdout = os.Stdout // fd 1
-	cmd.Stderr = os.Stderr // fd 2
-	cmd.ExtraFiles = extraFiles
-
-	// Spawn the child process
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	// Immediately close our dup'ed fds and the write end of our signal pipe
-	for _, f := range extraFiles {
-		f.Close()
-	}
-
-	// Feed Caddyfile to the child
-	err = gob.NewEncoder(wpipe).Encode(cdyfileGob)
-	if err != nil {
-		return err
-	}
-	wpipe.Close()
-
-	// Determine whether child startup succeeded
-	answer, readErr := ioutil.ReadAll(sigrpipe)
-	if answer == nil || len(answer) == 0 {
-		cmdErr := cmd.Wait() // get exit status
-		log.Printf("[ERROR] Restart: child failed to initialize (%v) - changes not applied", cmdErr)
-		if readErr != nil {
-			log.Printf("[ERROR] Restart: additionally, error communicating with child process: %v", readErr)
-		}
-		return errIncompleteRestart
-	}
-
-	// Looks like child is successful; we can exit gracefully.
-	return Stop()
+	return restartInProc(newCaddyfile)
 }
 
 func getCertsForNewCaddyfile(newCaddyfile Input) error {

--- a/caddy/restartinproc.go
+++ b/caddy/restartinproc.go
@@ -5,6 +5,7 @@ import "log"
 // restartInProc restarts Caddy forcefully in process using newCaddyfile.
 func restartInProc(newCaddyfile Input) error {
 	wg.Add(1) // barrier so Wait() doesn't unblock
+	defer wg.Done()
 
 	err := Stop()
 	if err != nil {
@@ -20,13 +21,8 @@ func restartInProc(newCaddyfile Input) error {
 		// revert to old Caddyfile
 		if oldErr := Start(oldCaddyfile); oldErr != nil {
 			log.Printf("[ERROR] Restart: in-process restart failed and cannot revert to old Caddyfile: %v", oldErr)
-		} else {
-			wg.Done() // take down our barrier
 		}
-		return err
 	}
 
-	wg.Done() // take down our barrier
-
-	return nil
+	return err
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ func init() {
 	flag.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
 	flag.StringVar(&caddy.Port, "port", caddy.DefaultPort, "Default port")
 	flag.BoolVar(&caddy.Quiet, "quiet", false, "Quiet mode (no initialization output)")
-	flag.StringVar(&caddy.RestartMode, "restart", "", "Restart mode (inproc for in process restart)")
 	flag.StringVar(&revoke, "revoke", "", "Hostname for which to revoke the certificate")
 	flag.StringVar(&caddy.Root, "root", caddy.DefaultRoot, "Root path to default site")
 	flag.BoolVar(&version, "version", false, "Show version")


### PR DESCRIPTION
This patch allows Caddy to restart in-process gracefully without the `-restart=inproc` flag, replacing the current default Restart on POSIX system.