### PR TITLE
Balance round robin evenly when some hosts are down

### DIFF
--- a/caddyhttp/proxy/policy.go
+++ b/caddyhttp/proxy/policy.go
@@ -92,7 +92,8 @@ func (r *RoundRobin) Select(pool HostPool) *UpstreamHost {
 	host := pool[selection]
 	// if the currently selected host is not available, just ffwd to up host
 	for i := uint32(1); !host.Available() && i < poolLen; i++ {
-		host = pool[(selection+i)%poolLen]
+		selection = atomic.AddUint32(&r.Robin, 1) % poolLen
+		host = pool[selection]
 	}
 	if !host.Available() {
 		return nil

--- a/caddyhttp/proxy/policy.go
+++ b/caddyhttp/proxy/policy.go
@@ -82,17 +82,17 @@ func (r *LeastConn) Select(pool HostPool) *UpstreamHost {
 
 // RoundRobin is a policy that selects hosts based on round robin ordering.
 type RoundRobin struct {
-	Robin uint32
+	robin uint32
 }
 
 // Select selects an up host from the pool using a round robin ordering scheme.
 func (r *RoundRobin) Select(pool HostPool) *UpstreamHost {
 	poolLen := uint32(len(pool))
-	selection := atomic.AddUint32(&r.Robin, 1) % poolLen
+	selection := atomic.AddUint32(&r.robin, 1) % poolLen
 	host := pool[selection]
 	// if the currently selected host is not available, just ffwd to up host
 	for i := uint32(1); !host.Available() && i < poolLen; i++ {
-		selection = atomic.AddUint32(&r.Robin, 1) % poolLen
+		selection = atomic.AddUint32(&r.robin, 1) % poolLen
 		host = pool[selection]
 	}
 	if !host.Available() {

--- a/caddyhttp/proxy/policy_test.go
+++ b/caddyhttp/proxy/policy_test.go
@@ -63,11 +63,18 @@ func TestRoundRobinPolicy(t *testing.T) {
 	if h != pool[2] {
 		t.Error("Expected to skip down host.")
 	}
-	// mark host as full
-	pool[2].Conns = 1
-	pool[2].MaxConns = 1
+	// mark host as up
+	pool[1].Unhealthy = false
+
 	h = rrPolicy.Select(pool)
-	if h != pool[0] {
+	if h == pool[2] {
+		t.Error("Expected to balance evenly among healthy hosts")
+	}
+	// mark host as full
+	pool[1].Conns = 1
+	pool[1].MaxConns = 1
+	h = rrPolicy.Select(pool)
+	if h != pool[2] {
 		t.Error("Expected to skip full host.")
 	}
 }


### PR DESCRIPTION
Before, when load balancing across multiple hosts, if a host went down
then the next host in line would be sent a double share of requests.
This is because the round robin counter was only incremented once per
request, regardless of the health of the selection. If current
selection was unhealthy then the policy would advance to the next host,
but this would not be reflected in the policy counter. To fix this, the
counter is now incremented for every attempted host.

This commit adds a test case that identifies the issue, and a fix.