### PR TITLE
Add reverse_proxy preset

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -260,6 +260,10 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			return c.ArgErr()
 		}
 		u.downstreamHeaders.Add(header, value)
+	case "reverse_proxy":
+		u.upstreamHeaders.Add("Host", "{host}")
+		u.upstreamHeaders.Add("X-Real-IP", "{remote}")
+		u.upstreamHeaders.Add("X-Forwarded-Proto", "{scheme}")
 	case "websocket":
 		u.upstreamHeaders.Add("Connection", "{>Connection}")
 		u.upstreamHeaders.Add("Upgrade", "{>Upgrade}")

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -260,7 +260,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			return c.ArgErr()
 		}
 		u.downstreamHeaders.Add(header, value)
-	case "reverse_proxy":
+	case "transparent":
 		u.upstreamHeaders.Add("Host", "{host}")
 		u.upstreamHeaders.Add("X-Real-IP", "{remote}")
 		u.upstreamHeaders.Add("X-Forwarded-Proto", "{scheme}")

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -141,14 +141,14 @@ func TestParseBlock(t *testing.T) {
 	tests := []struct {
 		config string
 	}{
-		// Test #1: reverse_proxy preset
-		{"proxy / localhost:8080 {\n reverse_proxy \n}"},
+		// Test #1: transparent preset
+		{"proxy / localhost:8080 {\n transparent \n}"},
 
-		// Test #2: reverse_proxy preset with another param
-		{"proxy / localhost:8080 {\n reverse_proxy \nproxy_header X-Test Tester \n}"},
+		// Test #2: transparent preset with another param
+		{"proxy / localhost:8080 {\n transparent \nproxy_header X-Test Tester \n}"},
 
-		// Test #3: reverse_proxy preset on multiple sites
-		{"proxy / localhost:8080 {\n reverse_proxy \n} \nproxy /api localhost:8081 { \nreverse_proxy \n}"},
+		// Test #3: transparent preset on multiple sites
+		{"proxy / localhost:8080 {\n transparent \n} \nproxy /api localhost:8081 { \ntransparent \n}"},
 	}
 
 	for i, test := range tests {

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -1,8 +1,11 @@
 package proxy
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/mholt/caddy/caddyfile"
 )
 
 func TestNewHost(t *testing.T) {
@@ -130,6 +133,43 @@ func TestAllowedPaths(t *testing.T) {
 		allowed := upstream.AllowedPath(test.url)
 		if test.expected != allowed {
 			t.Errorf("Test %d: expected %v found %v", i+1, test.expected, allowed)
+		}
+	}
+}
+
+func TestParseBlock(t *testing.T) {
+	tests := []struct {
+		config string
+	}{
+		// Test #1: reverse_proxy preset
+		{"proxy / localhost:8080 {\n reverse_proxy \n}"},
+
+		// Test #2: reverse_proxy preset with another param
+		{"proxy / localhost:8080 {\n reverse_proxy \nproxy_header X-Test Tester \n}"},
+
+		// Test #3: reverse_proxy preset on multiple sites
+		{"proxy / localhost:8080 {\n reverse_proxy \n} \nproxy /api localhost:8081 { \nreverse_proxy \n}"},
+	}
+
+	for i, test := range tests {
+		upstreams, err := NewStaticUpstreams(caddyfile.NewDispenser("Testfile", strings.NewReader(test.config)))
+		if err != nil {
+			t.Error("Expected no error. Got:", err.Error())
+		}
+		for _, upstream := range upstreams {
+			headers := upstream.Select().UpstreamHeaders
+
+			if _, ok := headers["Host"]; !ok {
+				t.Errorf("Test %d: Could not find the Host header", i+1)
+			}
+
+			if _, ok := headers["X-Real-Ip"]; !ok {
+				t.Errorf("Test %d: Could not find the X-Real-Ip header", i+1)
+			}
+
+			if _, ok := headers["X-Forwarded-Proto"]; !ok {
+				t.Errorf("Test %d: Could not find the X-Forwarded-Proto header", i+1)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hey! First time contributor and caddy user for that matter.

Based on #851 I've added the `reverse_proxy` preset for the proxy directive and a couple of tests to go with it.

**Example**
```
localhost {
    proxy / localhost:8080 {
        reverse_proxy
    }
}
```

Instead of

```
localhost {
    proxy / localhost:8080 {
        proxy_header Host {host}
        proxy_header X-Real-IP {remote}
        proxy_header X-Forwarded-Proto {scheme}
    }
}
```

Looking forward to a code review