### PR TITLE
Fix rewrite bug with URL query + test case (#884)

### DIFF
--- a/caddyhttp/rewrite/to.go
+++ b/caddyhttp/rewrite/to.go
@@ -18,8 +18,15 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 
 	// try each rewrite paths
 	t := ""
+	query := ""
 	for _, v := range tos {
-		t = path.Clean(replacer.Replace(v))
+		t = replacer.Replace(v)
+		tparts := strings.Split(t, "?")
+		t = path.Clean(tparts[0])
+
+		if len(tparts) > 1 {
+			query = tparts[1]
+		}
 
 		// add trailing slash for directories, if present
 		if strings.HasSuffix(v, "/") && !strings.HasSuffix(t, "/") {
@@ -47,9 +54,9 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 
 	// perform rewrite
 	r.URL.Path = u.Path
-	if u.RawQuery != "" {
+	if query != "" {
 		// overwrite query string if present
-		r.URL.RawQuery = u.RawQuery
+		r.URL.RawQuery = query
 	}
 	if u.Fragment != "" {
 		// overwrite fragment if present

--- a/caddyhttp/rewrite/to.go
+++ b/caddyhttp/rewrite/to.go
@@ -21,7 +21,7 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 	query := ""
 	for _, v := range tos {
 		t = replacer.Replace(v)
-		tparts := strings.Split(t, "?")
+		tparts := strings.SplitN(t, "?", 2)
 		t = path.Clean(tparts[0])
 
 		if len(tparts) > 1 {

--- a/caddyhttp/rewrite/to_test.go
+++ b/caddyhttp/rewrite/to_test.go
@@ -22,6 +22,7 @@ func TestTo(t *testing.T) {
 		{"/?a=b", "/testfile /index.php?{query}", "/testfile?a=b"},
 		{"/?a=b", "/testdir /index.php?{query}", "/index.php?a=b"},
 		{"/?a=b", "/testdir/ /index.php?{query}", "/testdir/?a=b"},
+		{"/test?url=http://caddyserver.com", " /p/{path}?{query}", "/p/test?url=http://caddyserver.com"},
 	}
 
 	uri := func(r *url.URL) string {


### PR DESCRIPTION
Prevent `rewrite.To()` method to use `path.Clean()` on URL's query.
Closes #884.