### PR TITLE
Add timeout to health_check

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -243,7 +243,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 
 		// Set defaults
 		u.HealthCheck.Interval = 30 * time.Second
-		u.HealthCheck.Timeout = 30 * time.Second
+		u.HealthCheck.Timeout = 60 * time.Second
 
 		// Update defaults if provided
 		for _, v := range c.RemainingArgs() {

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -143,20 +143,23 @@ func TestParseBlockHealthCheck(t *testing.T) {
 		interval string
 		timeout  string
 	}{
-		// Test #1: both options set correct time
+		// Test #1: Both options set correct time
 		{"health_check /health interval=10s timeout=20s", "10s", "20s"},
 
-		// Test #2: no options set correct time
+		// Test #2: No options set correct time
 		{"health_check /health", "30s", "30s"},
 
-		// Test #3: just interval sets time and timeout defaults to 30s
+		// Test #3: Just interval sets time and timeout defaults to 30s
 		{"health_check /health interval=15s", "15s", "30s"},
 
-		// Test #4: incorrect "interval" still sets default
+		// Test #4: Incorrect "interval" still sets default
 		{"health_check /health interva=15s", "30s", "30s"},
 
-		// Test #5: just timeout sets time and interval defaults to 30s
+		// Test #5: Just timeout sets time and interval defaults to 30s
 		{"health_check /health timeout=15s", "30s", "15s"},
+
+		// Test #6: Some funky spelling to make sure it still defaults
+		{"health_check /health timeout==15s", "30s", "30s"},
 	}
 
 	for i, test := range tests {

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -147,19 +147,19 @@ func TestParseBlockHealthCheck(t *testing.T) {
 		{"health_check /health interval=10s timeout=20s", "10s", "20s"},
 
 		// Test #2: No options set correct time
-		{"health_check /health", "30s", "30s"},
+		{"health_check /health", "30s", "1m0s"},
 
-		// Test #3: Just interval sets time and timeout defaults to 30s
-		{"health_check /health interval=15s", "15s", "30s"},
+		// Test #3: Just interval sets time and timeout defaults to 1m
+		{"health_check /health interval=15s", "15s", "1m0s"},
 
 		// Test #4: Incorrect "interval" still sets default
-		{"health_check /health interva=15s", "30s", "30s"},
+		{"health_check /health interva=15s", "30s", "1m0s"},
 
-		// Test #5: Just timeout sets time and interval defaults to 30s
+		// Test #5: Just timeout sets time and interval defaults to 1m
 		{"health_check /health timeout=15s", "30s", "15s"},
 
 		// Test #6: Some funky spelling to make sure it still defaults
-		{"health_check /health timeout==15s", "30s", "30s"},
+		{"health_check /health timeout==15s", "30s", "1m0s"},
 	}
 
 	for i, test := range tests {

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -144,22 +144,22 @@ func TestParseBlockHealthCheck(t *testing.T) {
 		timeout  string
 	}{
 		// Test #1: Both options set correct time
-		{"health_check /health interval=10s timeout=20s", "10s", "20s"},
+		{"health_check /health\n health_check_interval 10s\n health_check_timeout 20s", "10s", "20s"},
 
-		// Test #2: No options set correct time
+		// Test #2: Health check options flipped around. Making sure health_check doesn't overwrite it
+		{"health_check_interval 10s\n health_check_timeout 20s\n health_check /health", "10s", "20s"},
+
+		// Test #3: No health_check options. So default.
 		{"health_check /health", "30s", "1m0s"},
 
-		// Test #3: Just interval sets time and timeout defaults to 1m
-		{"health_check /health interval=15s", "15s", "1m0s"},
+		// Test #4: Interval sets it to 15s and timeout defaults
+		{"health_check /health\n health_check_interval 15s", "15s", "1m0s"},
 
-		// Test #4: Incorrect "interval" still sets default
-		{"health_check /health interva=15s", "30s", "1m0s"},
-
-		// Test #5: Just timeout sets time and interval defaults to 1m
-		{"health_check /health timeout=15s", "30s", "15s"},
+		// Test #5: Timeout sets it to 15s and interval defaults
+		{"health_check /health\n health_check_timeout 15s", "30s", "15s"},
 
 		// Test #6: Some funky spelling to make sure it still defaults
-		{"health_check /health timeout==15s", "30s", "1m0s"},
+		{"health_check /health health_check_time 15s", "30s", "1m0s"},
 	}
 
 	for i, test := range tests {
@@ -167,22 +167,22 @@ func TestParseBlockHealthCheck(t *testing.T) {
 		c := caddyfile.NewDispenser("Testfile", strings.NewReader(test.config))
 		for c.Next() {
 			parseBlock(&c, &u)
-			if u.HealthCheck.Interval.String() != test.interval {
-				t.Errorf(
-					"Test %d: HealthCheck interval not the same from config. Got %v. Expected: %v",
-					i+1,
-					u.HealthCheck.Interval,
-					test.interval,
-				)
-			}
-			if u.HealthCheck.Timeout.String() != test.timeout {
-				t.Errorf(
-					"Test %d: HealthCheck timeout not the same from config. Got %v. Expected: %v",
-					i+1,
-					u.HealthCheck.Timeout,
-					test.timeout,
-				)
-			}
+		}
+		if u.HealthCheck.Interval.String() != test.interval {
+			t.Errorf(
+				"Test %d: HealthCheck interval not the same from config. Got %v. Expected: %v",
+				i+1,
+				u.HealthCheck.Interval,
+				test.interval,
+			)
+		}
+		if u.HealthCheck.Timeout.String() != test.timeout {
+			t.Errorf(
+				"Test %d: HealthCheck timeout not the same from config. Got %v. Expected: %v",
+				i+1,
+				u.HealthCheck.Timeout,
+				test.timeout,
+			)
 		}
 	}
 }


### PR DESCRIPTION
The `DefaultClient` in net/http doesn't specify a timeout and is 0 by default. Which means if a server is causing a connection to hang the request will hang.

This is to add a way to specify a "timeout" on health_check, as well as set a sensible 60 second default.

Example:

```
localhost {
    proxy / localhost:8080 {
        health_check /health interval=10s timeout=15s
    }
}
```

Looking forward to everyones thoughts. 😄 