### PR TITLE
Refactoring to remove lint

### DIFF
--- a/caddyhttp/markdown/markdown.go
+++ b/caddyhttp/markdown/markdown.go
@@ -127,11 +127,11 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 	}
 	defer f.Close()
 
-	if fs, err := f.Stat(); err != nil {
+	fs, err := f.Stat()
+	if err != nil {
 		return http.StatusGone, nil
-	} else {
-		lastModTime = latest(lastModTime, fs.ModTime())
 	}
+	lastModTime = latest(lastModTime, fs.ModTime())
 
 	ctx := httpserver.Context{
 		Root: md.FileSys,

--- a/caddyhttp/markdown/metadata/metadata.go
+++ b/caddyhttp/markdown/metadata/metadata.go
@@ -33,7 +33,7 @@ type Metadata struct {
 	Flags map[string]bool
 }
 
-// NewMetadata() returns a new Metadata struct, loaded with the given map
+// NewMetadata returns a new Metadata struct, loaded with the given map
 func NewMetadata(parsedMap map[string]interface{}) Metadata {
 	md := Metadata{
 		Variables: make(map[string]string),
@@ -74,8 +74,8 @@ func (m *Metadata) load(parsedMap map[string]interface{}) {
 	}
 }
 
-// MetadataParser is a an interface that must be satisfied by each parser
-type MetadataParser interface {
+// Parser is a an interface that must be satisfied by each parser
+type Parser interface {
 	// Initialize a parser
 	Init(b *bytes.Buffer) bool
 
@@ -90,7 +90,7 @@ type MetadataParser interface {
 }
 
 // GetParser returns a parser for the given data
-func GetParser(buf []byte) MetadataParser {
+func GetParser(buf []byte) Parser {
 	for _, p := range parsers() {
 		b := bytes.NewBuffer(buf)
 		if p.Init(b) {
@@ -102,14 +102,14 @@ func GetParser(buf []byte) MetadataParser {
 }
 
 // parsers returns all available parsers
-func parsers() []MetadataParser {
-	return []MetadataParser{
-		&TOMLMetadataParser{},
-		&YAMLMetadataParser{},
-		&JSONMetadataParser{},
+func parsers() []Parser {
+	return []Parser{
+		&TOMLParser{},
+		&YAMLParser{},
+		&JSONParser{},
 
 		// This one must be last
-		&NoneMetadataParser{},
+		&NoneParser{},
 	}
 }
 

--- a/caddyhttp/markdown/metadata/metadata_json.go
+++ b/caddyhttp/markdown/metadata/metadata_json.go
@@ -5,29 +5,31 @@ import (
 	"encoding/json"
 )
 
-// JSONMetadataParser is the MetadataParser for JSON
-type JSONMetadataParser struct {
+// JSONParser is the MetadataParser for JSON
+type JSONParser struct {
 	metadata Metadata
 	markdown *bytes.Buffer
 }
 
-func (j *JSONMetadataParser) Type() string {
+// Type returns the kind of metadata parser implemented by this struct.
+func (j *JSONParser) Type() string {
 	return "JSON"
 }
 
-// Parse metadata/markdown file
-func (j *JSONMetadataParser) Init(b *bytes.Buffer) bool {
+// Init prepares the metadata metadata/markdown file and parses it
+func (j *JSONParser) Init(b *bytes.Buffer) bool {
 	m := make(map[string]interface{})
 
 	err := json.Unmarshal(b.Bytes(), &m)
 	if err != nil {
 		var offset int
 
-		if jerr, ok := err.(*json.SyntaxError); !ok {
+		jerr, ok := err.(*json.SyntaxError)
+		if !ok {
 			return false
-		} else {
-			offset = int(jerr.Offset)
 		}
+
+		offset = int(jerr.Offset)
 
 		m = make(map[string]interface{})
 		err = json.Unmarshal(b.Next(offset-1), &m)
@@ -44,10 +46,11 @@ func (j *JSONMetadataParser) Init(b *bytes.Buffer) bool {
 
 // Metadata returns parsed metadata.  It should be called
 // only after a call to Parse returns without error.
-func (j *JSONMetadataParser) Metadata() Metadata {
+func (j *JSONParser) Metadata() Metadata {
 	return j.metadata
 }
 
-func (j *JSONMetadataParser) Markdown() []byte {
+// Markdown returns the markdown text.  It should be called only after a call to Parse returns without error.
+func (j *JSONParser) Markdown() []byte {
 	return j.markdown.Bytes()
 }

--- a/caddyhttp/markdown/metadata/metadata_none.go
+++ b/caddyhttp/markdown/metadata/metadata_none.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 )
 
-// TOMLMetadataParser is the MetadataParser for TOML
-type NoneMetadataParser struct {
+// NoneParser is the parser for plaintext markdown with no metadata.
+type NoneParser struct {
 	metadata Metadata
 	markdown *bytes.Buffer
 }
 
-func (n *NoneMetadataParser) Type() string {
+// Type returns the kind of parser this struct is.
+func (n *NoneParser) Type() string {
 	return "None"
 }
 
-// Parse metadata/markdown file
-func (n *NoneMetadataParser) Init(b *bytes.Buffer) bool {
+// Init prepases and parses the metadata and markdown file
+func (n *NoneParser) Init(b *bytes.Buffer) bool {
 	m := make(map[string]interface{})
 	n.metadata = NewMetadata(m)
 	n.markdown = bytes.NewBuffer(b.Bytes())
@@ -24,16 +25,18 @@ func (n *NoneMetadataParser) Init(b *bytes.Buffer) bool {
 }
 
 // Parse the metadata
-func (n *NoneMetadataParser) Parse(b []byte) ([]byte, error) {
+func (n *NoneParser) Parse(b []byte) ([]byte, error) {
 	return nil, nil
 }
 
 // Metadata returns parsed metadata.  It should be called
 // only after a call to Parse returns without error.
-func (n *NoneMetadataParser) Metadata() Metadata {
+func (n *NoneParser) Metadata() Metadata {
 	return n.metadata
 }
 
-func (n *NoneMetadataParser) Markdown() []byte {
+// Markdown returns parsed markdown.  It should be called
+// only after a call to Parse returns without error.
+func (n *NoneParser) Markdown() []byte {
 	return n.markdown.Bytes()
 }

--- a/caddyhttp/markdown/metadata/metadata_test.go
+++ b/caddyhttp/markdown/metadata/metadata_test.go
@@ -158,13 +158,13 @@ func TestParsers(t *testing.T) {
 	}
 
 	data := []struct {
-		parser   MetadataParser
+		parser   Parser
 		testData [5]string
 		name     string
 	}{
-		{&JSONMetadataParser{}, JSON, "JSON"},
-		{&YAMLMetadataParser{}, YAML, "YAML"},
-		{&TOMLMetadataParser{}, TOML, "TOML"},
+		{&JSONParser{}, JSON, "JSON"},
+		{&YAMLParser{}, YAML, "YAML"},
+		{&TOMLParser{}, TOML, "TOML"},
 	}
 
 	for _, v := range data {

--- a/caddyhttp/markdown/metadata/metadata_toml.go
+++ b/caddyhttp/markdown/metadata/metadata_toml.go
@@ -6,18 +6,19 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// TOMLMetadataParser is the MetadataParser for TOML
-type TOMLMetadataParser struct {
+// TOMLParser is the Parser for TOML
+type TOMLParser struct {
 	metadata Metadata
 	markdown *bytes.Buffer
 }
 
-func (t *TOMLMetadataParser) Type() string {
+// Type returns the kind of parser this struct is.
+func (t *TOMLParser) Type() string {
 	return "TOML"
 }
 
-// Parse metadata/markdown file
-func (t *TOMLMetadataParser) Init(b *bytes.Buffer) bool {
+// Init prepares and parses the metadata and markdown file itself
+func (t *TOMLParser) Init(b *bytes.Buffer) bool {
 	meta, data := splitBuffer(b, "+++")
 	if meta == nil || data == nil {
 		return false
@@ -35,10 +36,11 @@ func (t *TOMLMetadataParser) Init(b *bytes.Buffer) bool {
 
 // Metadata returns parsed metadata.  It should be called
 // only after a call to Parse returns without error.
-func (t *TOMLMetadataParser) Metadata() Metadata {
+func (t *TOMLParser) Metadata() Metadata {
 	return t.metadata
 }
 
-func (t *TOMLMetadataParser) Markdown() []byte {
+// Markdown returns parser markdown.  It should be called only after a call to Parse returns without error.
+func (t *TOMLParser) Markdown() []byte {
 	return t.markdown.Bytes()
 }

--- a/caddyhttp/markdown/metadata/metadata_yaml.go
+++ b/caddyhttp/markdown/metadata/metadata_yaml.go
@@ -6,17 +6,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// YAMLMetadataParser is the MetadataParser for YAML
-type YAMLMetadataParser struct {
+// YAMLParser is the Parser for YAML
+type YAMLParser struct {
 	metadata Metadata
 	markdown *bytes.Buffer
 }
 
-func (y *YAMLMetadataParser) Type() string {
+// Type returns the kind of metadata parser.
+func (y *YAMLParser) Type() string {
 	return "YAML"
 }
 
-func (y *YAMLMetadataParser) Init(b *bytes.Buffer) bool {
+// Init prepares the metadata parser for parsing.
+func (y *YAMLParser) Init(b *bytes.Buffer) bool {
 	meta, data := splitBuffer(b, "---")
 	if meta == nil || data == nil {
 		return false
@@ -34,10 +36,11 @@ func (y *YAMLMetadataParser) Init(b *bytes.Buffer) bool {
 
 // Metadata returns parsed metadata.  It should be called
 // only after a call to Parse returns without error.
-func (y *YAMLMetadataParser) Metadata() Metadata {
+func (y *YAMLParser) Metadata() Metadata {
 	return y.metadata
 }
 
-func (y *YAMLMetadataParser) Markdown() []byte {
+// Markdown renders the text as a byte array
+func (y *YAMLParser) Markdown() []byte {
 	return y.markdown.Bytes()
 }

--- a/caddyhttp/markdown/process.go
+++ b/caddyhttp/markdown/process.go
@@ -11,11 +11,14 @@ import (
 	"github.com/russross/blackfriday"
 )
 
+// FileInfo represents a file in a particular server context. It wraps the os.FileInfo struct.
 type FileInfo struct {
 	os.FileInfo
 	ctx httpserver.Context
 }
 
+// Summarize returns an abbreviated string representation of the markdown stored in this file.
+// wordcount is the number of words returned in the summary.
 func (f FileInfo) Summarize(wordcount int) (string, error) {
 	fp, err := f.ctx.Root.Open(f.Name())
 	if err != nil {

--- a/caddyhttp/markdown/template.go
+++ b/caddyhttp/markdown/template.go
@@ -45,6 +45,7 @@ func execTemplate(c *Config, mdata metadata.Metadata, files []FileInfo, ctx http
 	return b.Bytes(), nil
 }
 
+// SetTemplate reads in the template with the filename provided. If the file does not exist or is not parsable, it will return an error.
 func SetTemplate(t *template.Template, name, filename string) error {
 
 	// Read template
@@ -64,6 +65,7 @@ func SetTemplate(t *template.Template, name, filename string) error {
 	return err
 }
 
+// GetDefaultTemplate returns the default template.
 func GetDefaultTemplate() *template.Template {
 	return template.Must(template.New("").Parse(defaultTemplate))
 }


### PR DESCRIPTION
Hi Caddy community!

I took [Matt's advice](https://twitter.com/mholt6/status/744976277552062464) and wanted to get involved. 

I added comments to the `markdown` package to remove `golint` warnings. This commit removes all warnings that are possible to be removed. The interface required by `blackfriday`, the markdown library forces the remaining two warnings to remain.

I threw this together pretty quickly so if you'd like me to change something, feel free to comment with feedback.

Thanks!