### PR TITLE
Test that the host header forwarding on proxy

### DIFF
--- a/caddyhttp/proxy/policy_test.go
+++ b/caddyhttp/proxy/policy_test.go
@@ -31,7 +31,7 @@ func testPool() HostPool {
 			Name: workableServer.URL, // this should resolve (healthcheck test)
 		},
 		{
-			Name: "http://shouldnot.resolve", // this shouldn't
+			Name: "http://localhost:99998", // this shouldn't
 		},
 		{
 			Name: "http://C",


### PR DESCRIPTION
This tests test two cases:
- When no host is specified, the address/host of the proxy should be used as host
- When the host is specified, it should appear in the request