### PR TITLE
Add the ACL directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -343,6 +343,7 @@ var directives = []string{
 
 	// directives that add middleware to the stack
 	"log",
+	"acl",      // github.com/atenart/caddy-acl
 	"gzip",
 	"locale", // github.com/simia-tech/caddy-locale
 	"errors",


### PR DESCRIPTION
ACL is a middleware allowing to control access of locations to certain client addresses. See https://github.com/atenart/caddy-acl.
