### PR TITLE
Changing refs from /usr/bin to /usr/local/bin

### DIFF
--- a/dist/init/linux-systemd/README.md
+++ b/dist/init/linux-systemd/README.md
@@ -49,7 +49,7 @@ chmod 0770 /etc/ssl/caddy
 [Service]
 ; an empty value clears the original (and preceding) settings
 ExecStart=
-ExecStart=/usr/bin/caddy -conf="/etc/caddy/myCaddy.conf"
+ExecStart=/usr/local/bin/caddy -conf="/etc/caddy/myCaddy.conf"
 ```
 
 - To view the resulting configuration use `systemctl cat caddy`

--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -15,7 +15,7 @@ Group=www-data
 Environment=HOME=/etc/ssl/caddy
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
+ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.

--- a/dist/init/linux-upstart/README.md
+++ b/dist/init/linux-upstart/README.md
@@ -7,7 +7,7 @@ Usage
 Usage in this blogpost: [Running Caddy Server as a service with Upstart](https://denbeke.be/blog/servers/running-caddy-server-as-a-service/).
 Short recap:
 
-* Download Caddy in `/usr/bin/caddy` and execute `sudo setcap cap_net_bind_service=+ep /usr/bin/caddy`.
+* Download Caddy in `/usr/local/bin/caddy` and execute `sudo setcap cap_net_bind_service=+ep /usr/local/bin/caddy`.
 * Save the upstart config file in `/etc/init/caddy.conf`.
 * Ensure that the folder `/etc/caddy` exists and that the subfolder .caddy is owned by `www-data`.
 * Create a Caddyfile in `/etc/caddy/Caddyfile`.

--- a/dist/init/linux-upstart/caddy.conf
+++ b/dist/init/linux-upstart/caddy.conf
@@ -19,5 +19,5 @@ limit nofile 1048576 1048576
 script
         cd /etc/caddy
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
-        exec /usr/bin/caddy -agree -log=stdout -conf=/etc/caddy/Caddyfile -root=$rootdir
+        exec /usr/local/bin/caddy -agree -log=stdout -conf=/etc/caddy/Caddyfile -root=$rootdir
 end script


### PR DESCRIPTION
`/usr/local/bin` is a more appropriate location for the Caddy binary to be installed. I believe `/usr/bin` is more geared towards distribution-managed programs and so there's a possibility that that directory may be changed during a distribution upgrade while `/usr/local/bin` wouldn't be.

As a side note, this change would help me in my efforts to automate the installation of Caddy on my servers.