### PR TITLE
Change position of locale directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -342,11 +342,11 @@ var directives = []string{
 	"git",    // github.com/abiosoft/caddy-git
 
 	// directives that add middleware to the stack
+	"locale", // github.com/simia-tech/caddy-locale
 	"log",
 	"rewrite",
 	"ext",
 	"gzip",
-	"locale", // github.com/simia-tech/caddy-locale
 	"errors",
 	"minify",    // github.com/hacdias/caddy-minify
 	"ipfilter",  // github.com/pyed/ipfilter


### PR DESCRIPTION
First, great job on the 0.9 release! It seems caddy's path lead into a bright future. Thanks also for including the locale plugin.

Trying it, I've figured out, that there might be a problem with the order of the directives. In the typical use case, the result of the locale detection might be used in the `rewrite` and `log` plugin. If I'm not mistaken, it makes sense to put the `locale` directive before those.