### PR TITLE
Proxy middleware response codes less than 400 (fix #801).

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -210,7 +210,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	status, _ := s.serveHTTP(w, r)
 
 	// Fallback error response in case error handling wasn't chained in
-	if status >= 400 {
+	if status != 0 {
 		DefaultErrorFunc(w, r, status)
 	}
 }


### PR DESCRIPTION
I'm trying to fix https://github.com/mholt/caddy/issues/801 and finish Sean's work https://github.com/mholt/caddy/pull/802

It looks like that we have no any reason to block middleware from returning any response code, and not only after 400.  Docs also says that only 0 indicates that response has been already written [1]. Currently default 200 (written by Go's net.http.Server internally) is sent.

@mholt, what do you think?

[1]  https://github.com/mholt/caddy/blob/39030d9e1bbbc1e31be49ab7f34bc800f2f2f8d8/middleware/middleware.go#L16-L33