### PR TITLE
Re-enable HTTP/2 for Go 1.7.

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -92,6 +92,10 @@ func NewServer(addr string, group []*SiteConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Since Go 1.7 HTTP/2 is enabled only if TLSConfig.NextProtos includes the string "h2".
+	if HTTP2 && s.Server.TLSConfig != nil && len(s.Server.TLSConfig.NextProtos) == 0 {
+		s.Server.TLSConfig.NextProtos = []string{"h2"}
+	}
 
 	// Compile custom middleware for every site (enables virtual hosting)
 	for _, site := range group {


### PR DESCRIPTION
This re-enables HTTP/2 with Go 1.7. I am defensively setting the map to {"h2"}, if caddytls.MakeTLSConfig didn't set anything beforehand. Does that make sense?

It works on my public server.

fixes #975 