### PR TITLE
dist/init/linux-sysvinit: caddy for SysVinit

### DIFF
--- a/dist/init/linux-sysvinit/README.md
+++ b/dist/init/linux-sysvinit/README.md
@@ -1,0 +1,11 @@
+SysVinit conf for Caddy
+=======================
+
+Usage
+-----
+
+* Download the appropriate Caddy binary in `/usr/local/bin/caddy` or use `curl https://getcaddy.com | bash`.
+* Save the SysVinit config file in `/etc/init.d/caddy`.
+* Ensure that the folder `/etc/caddy` exists and that the subfolder `ssl` is owned by `www-data`.
+* Create a Caddyfile in `/etc/caddy/Caddyfile`
+* Now you can use `sudo /etc/init.d/caddy start|stop|restart|reload|status`.

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -1,0 +1,93 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          caddy
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts the caddy web server
+# Description:       starts caddy using start-stop-daemon
+### END INIT INFO
+
+# Original Author: Frédéric Galusik (fredg)
+# Maintainer: Daniel van Dorp (djvdorp)
+
+DESC="the caddy web server"
+NAME=caddy
+DAEMON=$(which caddy)
+
+DAEMONUSER=www-data
+PIDFILE=/var/run/$NAME.pid
+LOGFILE=/var/log/$NAME.log
+CONFIGFILE=/etc/caddy/Caddyfile
+DAEMONOPTS="-agree=true --pidfile=$PIDFILE log=$LOGFILE -conf=$CONFIGFILE"
+
+USERBIND="$(which setcap) cap_net_bind_service=+ep"
+STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
+
+test -x $DAEMON || exit 0
+
+# Set the CADDYPATH; Let's Encrypt certificates will be written to this directory.
+export CADDYPATH=/etc/caddy/ssl
+
+# Set the ulimits
+ulimit -n 8192
+
+
+start() {
+    $USERBIND $DAEMON
+    start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE \
+        --background --chuid $DAEMONUSER --exec $DAEMON -- $DAEMONOPTS
+}
+
+stop() {
+    start-stop-daemon --stop --quiet --remove-pidfile --pidfile $PIDFILE \
+        --retry=$STOP_SCHEDULE --name $NAME --oknodo
+}
+
+reload() {
+    start-stop-daemon --stop --quiet --signal USR1 --pidfile $PIDFILE \
+        --name $NAME
+}
+
+status() {
+    if [ -f $PIDFILE ]; then
+        PID=`cat $PIDFILE`
+        if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
+            echo "$NAME process is dead, but pidfile exists"
+        else
+            echo "$NAME is running"
+        fi
+    else
+        echo "$NAME is not running"
+    fi
+}
+
+case "$1" in
+    start)
+        echo "Starting $NAME"
+        start
+    ;;
+    stop)
+        echo "Stopping $NAME"
+        stop
+    ;;
+    restart)
+        echo "Restarting $NAME"
+        stop
+        start
+    ;;
+    reload)
+        echo "Reloading $NAME configuration"
+        reload
+    ;;
+    status)
+        status
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|reload|status}"
+        exit 2
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
In addition to `linux-upstart` and `linux-systemd`, I think this one might be very useful too.

The script is based on [this script](https://git.devuan.org/fredg/stuffs/blob/master/caddy/init.d/caddy) by @fredg, found via [Installation du serveur Caddy sous Devuan &middot;  Frédéric Galusik](http://galusik.xyz/installation-caddy-server-devuan/#démon:d7570338f345f168f3c50f22e7f8c47c). I have modified it into an extended version myself, since I had the need for this.