### PR TITLE
Proxy: Add keepalive directive to proxy to set MaxIdleConnsPerHost on transport

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -108,7 +108,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		if nameURL, err := url.Parse(host.Name); err == nil {
 			outreq.Host = nameURL.Host
 			if proxy == nil {
-				proxy = NewSingleHostReverseProxy(nameURL, host.WithoutPathPrefix)
+				proxy = NewSingleHostReverseProxy(nameURL, host.WithoutPathPrefix, 0)
 			}
 
 			// use upstream credentials by default

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -108,7 +108,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		if nameURL, err := url.Parse(host.Name); err == nil {
 			outreq.Host = nameURL.Host
 			if proxy == nil {
-				proxy = NewSingleHostReverseProxy(nameURL, host.WithoutPathPrefix, 0)
+				proxy = NewSingleHostReverseProxy(nameURL, host.WithoutPathPrefix, http.DefaultMaxIdleConnsPerHost)
 			}
 
 			// use upstream credentials by default

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -716,11 +716,11 @@ func newFakeUpstream(name string, insecure bool) *fakeUpstream {
 		from: "/",
 		host: &UpstreamHost{
 			Name:         name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, ""),
+			ReverseProxy: NewSingleHostReverseProxy(uri, "", 0),
 		},
 	}
 	if insecure {
-		u.host.ReverseProxy.Transport = InsecureTransport
+		u.host.ReverseProxy.UseInsecureTransport()
 	}
 	return u
 }
@@ -744,7 +744,7 @@ func (u *fakeUpstream) Select() *UpstreamHost {
 		}
 		u.host = &UpstreamHost{
 			Name:         u.name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, u.without),
+			ReverseProxy: NewSingleHostReverseProxy(uri, u.without, 0),
 		}
 	}
 	return u.host
@@ -785,7 +785,7 @@ func (u *fakeWsUpstream) Select() *UpstreamHost {
 	uri, _ := url.Parse(u.name)
 	return &UpstreamHost{
 		Name:         u.name,
-		ReverseProxy: NewSingleHostReverseProxy(uri, u.without),
+		ReverseProxy: NewSingleHostReverseProxy(uri, u.without, 0),
 		UpstreamHeaders: http.Header{
 			"Connection": {"{>Connection}"},
 			"Upgrade":    {"{>Upgrade}"}},

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -716,7 +716,7 @@ func newFakeUpstream(name string, insecure bool) *fakeUpstream {
 		from: "/",
 		host: &UpstreamHost{
 			Name:         name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, "", 0),
+			ReverseProxy: NewSingleHostReverseProxy(uri, "", http.DefaultMaxIdleConnsPerHost),
 		},
 	}
 	if insecure {
@@ -744,7 +744,7 @@ func (u *fakeUpstream) Select() *UpstreamHost {
 		}
 		u.host = &UpstreamHost{
 			Name:         u.name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, u.without, 0),
+			ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost),
 		}
 	}
 	return u.host
@@ -785,7 +785,7 @@ func (u *fakeWsUpstream) Select() *UpstreamHost {
 	uri, _ := url.Parse(u.name)
 	return &UpstreamHost{
 		Name:         u.name,
-		ReverseProxy: NewSingleHostReverseProxy(uri, u.without, 0),
+		ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost),
 		UpstreamHeaders: http.Header{
 			"Connection": {"{>Connection}"},
 			"Upgrade":    {"{>Upgrade}"}},

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -122,7 +122,10 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 		rp.Transport = &http.Transport{
 			Dial: socketDial(target.String()),
 		}
-	} else if keepalive != 0 {
+	} else if keepalive != http.DefaultMaxIdleConnsPerHost {
+		// if keepalive is equal to the default,
+		// just use default transport, to avoid creating
+		// a brand new transport
 		rp.Transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			Dial: (&net.Dialer{
@@ -132,7 +135,7 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		}
-		if keepalive < 0 {
+		if keepalive == 0 {
 			rp.Transport.(*http.Transport).DisableKeepAlives = true
 		} else {
 			rp.Transport.(*http.Transport).MaxIdleConnsPerHost = keepalive

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -55,6 +55,7 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 			FailTimeout:       10 * time.Second,
 			MaxFails:          1,
 			MaxConns:          0,
+			KeepAlive:         http.DefaultMaxIdleConnsPerHost,
 		}
 
 		if !c.Args(&upstream.from) {
@@ -320,6 +321,9 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		n, err := strconv.Atoi(c.Val())
 		if err != nil {
 			return err
+		}
+		if n < 0 {
+			return c.ArgErr()
 		}
 		u.KeepAlive = n
 	default:

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -25,6 +25,7 @@ type staticUpstream struct {
 	downstreamHeaders  http.Header
 	Hosts              HostPool
 	Policy             Policy
+	KeepAlive          int
 	insecureSkipVerify bool
 
 	FailTimeout time.Duration
@@ -154,9 +155,9 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		return nil, err
 	}
 
-	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
+	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix, u.KeepAlive)
 	if u.insecureSkipVerify {
-		uh.ReverseProxy.Transport = InsecureTransport
+		uh.ReverseProxy.UseInsecureTransport()
 	}
 
 	return uh, nil
@@ -312,6 +313,15 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		u.IgnoredSubPaths = ignoredPaths
 	case "insecure_skip_verify":
 		u.insecureSkipVerify = true
+	case "keepalive":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.Atoi(c.Val())
+		if err != nil {
+			return err
+		}
+		u.KeepAlive = n
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}


### PR DESCRIPTION
More discussion in #938 - 

if the requests coming into Caddy are much greater than the maximum idle connections allowed in the transport backend, Caddy will continue to create more and more connections until the OS runs out of sockets.

This PR adds a [keepalive](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) option, like nginx that allows you set the number of idle connections for a proxy backend, allowing you to increase it from the default, defined in golang as 2 (or disable it).

To keep consistent with the internal `MaxIdleConnsPerHost` option on `http.Transport`, setting `keepalive` to 0, will actually keep the default value of 2. Setting it to a negative number (-1) will actually disable keepalives (new connection for every request).

I'm not sure what the recommended values should be yet, as the golang ones may be tuned for normal client/server type requests.

[Edited by @mholt: Fixed link to keepalive docs]