### PR TITLE
Allow {host} in proxy upstream

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -119,7 +119,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			outreq.Host = host.Name
 		}
 		if proxy == nil {
-			return http.StatusInternalServerError, errors.New("proxy for host '" + host.Name + "' is nil. Previous host was " + lastHost)
+			return http.StatusInternalServerError, errors.New("proxy for host '" + host.Name + "' is nil.")
 		}
 
 		// set headers for request going upstream

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -123,9 +123,6 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			return http.StatusInternalServerError, errors.New("proxy for host '" + host.Name + "' is nil")
 		}
 
-		// parse the placeholders
-		outreq.Host = replacer.Replace(outreq.Host)
-
 		// set headers for request going upstream
 		if host.UpstreamHeaders != nil {
 			// modify headers for request that will be sent to the upstream host

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -46,6 +46,7 @@ type UpstreamHost struct {
 	CheckDown         UpstreamHostDownFunc
 	WithoutPathPrefix string
 	MaxConns          int64
+	Dynamic           bool
 }
 
 // Down checks whether the upstream host is down or not.

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -13,8 +13,6 @@ import (
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
-var errUnreachable = errors.New("unreachable backend")
-
 // Proxy represents a middleware instance that can proxy requests.
 type Proxy struct {
 	Next      httpserver.Handler
@@ -95,7 +93,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for time.Now().Sub(start) < tryDuration {
 		host := upstream.Select(r)
 		if host == nil {
-			return http.StatusBadGateway, errUnreachable
+			return http.StatusBadGateway, errors.New("unreachable backend: host is nil")
 		}
 		if rr, ok := w.(*httpserver.ResponseRecorder); ok && rr.Replacer != nil {
 			rr.Replacer.Set("upstream", host.Name)
@@ -159,7 +157,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		}(host, timeout)
 	}
 
-	return http.StatusBadGateway, errUnreachable
+	return http.StatusBadGateway, errors.New("unreachable backend: timed out")
 }
 
 // match finds the best match for a proxy config based

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -123,6 +123,9 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			return http.StatusInternalServerError, errors.New("proxy for host '" + host.Name + "' is nil")
 		}
 
+		// parse the placeholders
+		outreq.Host = replacer.Replace(outreq.Host)
+
 		// set headers for request going upstream
 		if host.UpstreamHeaders != nil {
 			// modify headers for request that will be sent to the upstream host

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -710,7 +710,7 @@ func basicAuthTestcase(t *testing.T, upstreamUser, clientUser *url.Userinfo) {
 }
 
 func newFakeUpstream(name string, insecure bool) *fakeUpstream {
-	if strings.Contains(name,"{") && strings.Contains(name,"}") {
+	if strings.Contains(name, "{") && strings.Contains(name, "}") {
 		ReverseProxy := NewDynamicHostReverseProxy(name, "")
 	} else {
 		uri, _ := url.Parse(name)

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -710,7 +710,7 @@ func basicAuthTestcase(t *testing.T, upstreamUser, clientUser *url.Userinfo) {
 }
 
 func newFakeUpstream(name string, insecure bool) *fakeUpstream {
-	if strings.Contains(name,"{") && strings.Contains(name,"{") {
+	if strings.Contains(name,"{") && strings.Contains(name,"}") {
 		ReverseProxy := NewDynamicHostReverseProxy(name, "")
 	} else {
 		uri, _ := url.Parse(name)

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -710,13 +710,18 @@ func basicAuthTestcase(t *testing.T, upstreamUser, clientUser *url.Userinfo) {
 }
 
 func newFakeUpstream(name string, insecure bool) *fakeUpstream {
-	uri, _ := url.Parse(name)
+	if strings.Contains(name,"{") && strings.Contains(name,"{") {
+		ReverseProxy := NewDynamicHostReverseProxy(name, "")
+	} else {
+		uri, _ := url.Parse(name)
+		ReverseProxy := NewSingleHostReverseProxy(uri, "")
+	}
 	u := &fakeUpstream{
 		name: name,
 		from: "/",
 		host: &UpstreamHost{
 			Name:         name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, ""),
+			ReverseProxy: ReverseProxy,
 		},
 	}
 	if insecure {

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -137,7 +137,7 @@ func NewDynamicHostReverseProxy(templateUrl string, without string) *ReverseProx
 		targetQuery := target.RawQuery
 
 		req.URL.Scheme = target.Scheme
-		req.URL.Host = replacer.Replace(strings.Replace(target.Host, "HOST", "{host}", -1))
+		req.URL.Host = target.Host
 
 		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
 		if targetQuery == "" || req.URL.RawQuery == "" {

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -13,7 +13,6 @@ package proxy
 
 import (
 	"crypto/tls"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"io"
 	"net"
 	"net/http"
@@ -21,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
 var bufferPool = sync.Pool{New: createBuffer}

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -13,6 +13,7 @@ package proxy
 
 import (
 	"crypto/tls"
+	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"io"
 	"net"
 	"net/http"
@@ -20,7 +21,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
 var bufferPool = sync.Pool{New: createBuffer}
@@ -139,7 +139,7 @@ func NewDynamicHostReverseProxy(templateUrl string, without string) *ReverseProx
 
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = replacer.Replace(strings.Replace(target.Host, "HOST", "{host}", -1))
-		
+
 		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
 		if targetQuery == "" || req.URL.RawQuery == "" {
 			req.URL.RawQuery = targetQuery + req.URL.RawQuery

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -133,7 +133,7 @@ func NewDynamicHostReverseProxy(templateUrl string, without string) *ReverseProx
 
 		templateUrl = replacer.Replace(templateUrl)
 
-		target,_ := url.Parse(templateUrl)
+		target, _ := url.Parse(templateUrl)
 		targetQuery := target.RawQuery
 
 		req.URL.Scheme = target.Scheme

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -138,7 +138,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 				if uh.Unhealthy {
 					return true
 				}
-				if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") {
+				if uh.Dynamic {
 					return false
 				}
 				if uh.Fails >= u.MaxFails &&
@@ -329,7 +329,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 
 func (u *staticUpstream) healthCheck() {
 	for _, host := range u.Hosts {
-		if strings.Contains(host.Name, "{") && strings.Contains(host.Name, "}") {
+		if host.Dynamic {
 			host.Unhealthy = false //dynamic hosts can never be unhealthy
 		} else {
 			hostURL := host.Name + u.HealthCheck.Path

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -149,7 +149,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		MaxConns:          u.MaxConns,
 	}
 
-	if strings.Contains(uh.Name, "{host}") {
+	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") {
 		uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
 	} else {
 		baseURL, err := url.Parse(uh.Name)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -150,10 +150,12 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		}(u),
 		WithoutPathPrefix: u.WithoutPathPrefix,
 		MaxConns:          u.MaxConns,
+		Dynamic:           false,
 	}
 
 	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") && strings.Index(uh.Name, "unix:") != 0 {
 		uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
+		uh.Dynamic = true
 	} else {
 		baseURL, err := url.Parse(uh.Name)
 		if err != nil {

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -150,13 +150,13 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 	}
 
 	if strings.Contains(uh.Name, "{host}") {
-    	uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
+		uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
 	} else {
-   	 	baseURL, err := url.Parse(uh.Name)
-    	if err != nil {
-        	return nil, err
-    	}
-    	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
+		baseURL, err := url.Parse(uh.Name)
+		if err != nil {
+			return nil, err
+		}
+		uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
 	}
 
 	if u.insecureSkipVerify {

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -149,9 +149,14 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		MaxConns:          u.MaxConns,
 	}
 
-	baseURL, err := url.Parse(uh.Name)
-	if err != nil {
-		return nil, err
+	if strings.Contains(uh.Name, "{host}") {
+    	uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
+	} else {
+   	 	baseURL, err := url.Parse(uh.Name)
+    	if err != nil {
+        	return nil, err
+    	}
+    	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
 	}
 
 	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -149,7 +149,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		MaxConns:          u.MaxConns,
 	}
 
-	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") {
+	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") && strings.Index(uh.Name,"unix://") != 0 {
 		uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
 	} else {
 		baseURL, err := url.Parse(uh.Name)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -149,7 +149,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 		MaxConns:          u.MaxConns,
 	}
 
-	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") && strings.Index(uh.Name,"unix://") != 0 {
+	if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") && strings.Index(uh.Name,"unix:") != 0 {
 		uh.ReverseProxy = NewDynamicHostReverseProxy(uh.Name, uh.WithoutPathPrefix)
 	} else {
 		baseURL, err := url.Parse(uh.Name)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -138,6 +138,9 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 				if uh.Unhealthy {
 					return true
 				}
+				if strings.Contains(uh.Name, "{") && strings.Contains(uh.Name, "}") {
+					return false
+				}
 				if uh.Fails >= u.MaxFails &&
 					u.MaxFails != 0 {
 					return true

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -159,7 +159,6 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
     	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
 	}
 
-	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix)
 	if u.insecureSkipVerify {
 		uh.ReverseProxy.Transport = InsecureTransport
 	}


### PR DESCRIPTION
This PR allow to use {host} in the proxy upstream to you can proxy the request to a specific server/path based on what hostname was requested. (discussed in #990 )

*Note: I have barely any experience in Go, and the implementation I used seems very hacky to me. Any suggestions are welcome* 