### PR TITLE
dist/init/linux-sysvinit: execute setcap directly

### DIFF
--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -22,7 +22,7 @@ LOGFILE=/var/log/$NAME.log
 CONFIGFILE=/etc/caddy/Caddyfile
 DAEMONOPTS="-agree=true -pidfile=$PIDFILE -log=$LOGFILE -conf=$CONFIGFILE"
 
-USERBIND="$(which setcap) cap_net_bind_service=+ep"
+USERBIND="setcap cap_net_bind_service=+ep"
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
 
 test -x $DAEMON || exit 0


### PR DESCRIPTION
`$(which setcap)` might evaluate to nothing, and this way the error thrown will be more clear.
If setcap is not available on Debian/Ubuntu, you can install the package `libcap2-bin`