### PR TITLE
Allow just one TLS Protocol (Caddyfile)

### DIFF
--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -75,21 +75,27 @@ func setupTLS(c *caddy.Controller) error {
 				config.KeyType = value
 			case "protocols":
 				args := c.RemainingArgs()
-				if len(args) != 2 {
-					return c.ArgErr()
-				}
-				value, ok := supportedProtocols[strings.ToLower(args[0])]
-				if !ok {
-					return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[0])
-				}
-				config.ProtocolMinVersion = value
-				value, ok = supportedProtocols[strings.ToLower(args[1])]
-				if !ok {
-					return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[1])
-				}
-				config.ProtocolMaxVersion = value
-				if config.ProtocolMinVersion > config.ProtocolMaxVersion {
-					return c.Errf("Minimum protocol version cannot be higher than maximum (reverse the order)")
+				if len(args) == 1 {
+					value, ok := supportedProtocols[strings.ToLower(args[0])]
+					if !ok {
+						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[0])
+					}
+
+					config.ProtocolMinVersion, config.ProtocolMaxVersion = value, value
+				} else {
+					value, ok := supportedProtocols[strings.ToLower(args[0])]
+					if !ok {
+						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[0])
+					}
+					config.ProtocolMinVersion = value
+					value, ok = supportedProtocols[strings.ToLower(args[1])]
+					if !ok {
+						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[1])
+					}
+					config.ProtocolMaxVersion = value
+					if config.ProtocolMinVersion > config.ProtocolMaxVersion {
+						return c.Errf("Minimum protocol version cannot be higher than maximum (reverse the order)")
+					}
 				}
 			case "ciphers":
 				for c.NextArg() {

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -287,7 +287,7 @@ func TestSetupParseWithOneTLSProtocol(t *testing.T) {
 	}
 
 	if cfg.ProtocolMinVersion != tls.VersionTLS12 && cfg.ProtocolMaxVersion != tls.VersionTLS12 {
-		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion/ProtocolMaxVersion/, got %v/%v", cfg.ProtocolMinVersion, cfg.ProtocolMaxVersion)
+		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion/ProtocolMaxVersion, got %v/%v", cfg.ProtocolMinVersion, cfg.ProtocolMaxVersion)
 	}
 }
 

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -269,6 +269,28 @@ func TestSetupParseWithKeyType(t *testing.T) {
 	}
 }
 
+func TestSetupParseWithOneTLSProtocol(t *testing.T) {
+	params := `tls {
+            protocols tls1.2
+        }`
+	cfg := new(Config)
+	RegisterConfigGetter("", func(c *caddy.Controller) *Config { return cfg })
+	c := caddy.NewTestController("", params)
+
+	err := setupTLS(c)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
+
+	if cfg.ProtocolMinVersion != cfg.ProtocolMaxVersion {
+		t.Errorf("Expected ProtocolMinVersion to be the same as ProtocolMaxVersion")
+	}
+
+	if cfg.ProtocolMinVersion != tls.VersionTLS12 && cfg.ProtocolMaxVersion != tls.VersionTLS12 {
+		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion/ProtocolMaxVersion/, got %v/%v", cfg.ProtocolMinVersion, cfg.ProtocolMaxVersion)
+	}
+}
+
 const (
 	certFile = "test_cert.pem"
 	keyFile  = "test_key.pem"


### PR DESCRIPTION
With this pull request, you can define just one TLS Protocol (Caddyfile)

> Caddyfile

```
example.com {
	tls {
		protocols tls1.2
	}
}
```

**Why ?**

Caddy should be simple :heart:

> Caddyfile

```
example.com {
	tls {
		protocols tls1.2 tls.1.2
	}
}
```

P.S.: I know you like tests @mholt, so I already included one!