### PR TITLE
Add default "Restricted" realm to HTTP Basic auth

### DIFF
--- a/caddyhttp/basicauth/basicauth.go
+++ b/caddyhttp/basicauth/basicauth.go
@@ -61,7 +61,7 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 
 	if hasAuth {
 		if !isAuthenticated {
-			w.Header().Set("WWW-Authenticate", "Basic")
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"Restricted\"")
 			return http.StatusUnauthorized, nil
 		}
 		// "It's an older code, sir, but it checks out. I was about to clear them."

--- a/caddyhttp/basicauth/basicauth_test.go
+++ b/caddyhttp/basicauth/basicauth_test.go
@@ -52,7 +52,7 @@ func TestBasicAuth(t *testing.T) {
 		if result == http.StatusUnauthorized {
 			headers := rec.Header()
 			if val, ok := headers["Www-Authenticate"]; ok {
-				if val[0] != "Basic" {
+				if val[0] != "Basic realm=\"Restricted\"" {
 					t.Errorf("Test %d, Www-Authenticate should be %s provided %s", i, "Basic", val[0])
 				}
 			} else {


### PR DESCRIPTION
This is hopefully an acceptable workaround for #708, which is currently breaking HTTP Basic auth for many Android apps.