### PR TITLE
Use P384 for TestUser (privateKey)

### DIFF
--- a/caddytls/user_test.go
+++ b/caddytls/user_test.go
@@ -2,8 +2,9 @@ package caddytls
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"io"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ import (
 func TestUser(t *testing.T) {
 	defer testStorage.clean()
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 128)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		t.Fatalf("Could not generate test private key: %v", err)
 	}


### PR DESCRIPTION
We are using (see below) to generate a new user

```
func newUser(email string) (User, error) {
	user := User{Email: email}
	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
	if err != nil {
		return user, errors.New("error generating private key: " + err.Error())
	}
	user.key = privateKey
	return user, nil
}
```

We should do the same as a test (for the sake of integrity)!