### PR TITLE
Add support for default (wildcard) error page

### DIFF
--- a/caddyhttp/errors/setup.go
+++ b/caddyhttp/errors/setup.go
@@ -122,11 +122,15 @@ func errorsParse(c *caddy.Controller) (*ErrorHandler, error) {
 				}
 				f.Close()
 
-				whatInt, err := strconv.Atoi(what)
-				if err != nil {
-					return hadBlock, c.Err("Expecting a numeric status code, got '" + what + "'")
+				if what == "*" {
+					handler.GenericErrorPage = where
+				} else {
+					whatInt, err := strconv.Atoi(what)
+					if err != nil {
+						return hadBlock, c.Err("Expecting a numeric status code or '*', got '" + what + "'")
+					}
+					handler.ErrorPages[whatInt] = where
 				}
-				handler.ErrorPages[whatInt] = where
 			}
 		}
 		return hadBlock, nil

--- a/caddyhttp/errors/setup_test.go
+++ b/caddyhttp/errors/setup_test.go
@@ -103,6 +103,18 @@ func TestErrorsParse(t *testing.T) {
 				LocalTime:  true,
 			},
 		}},
+		{`errors { log errors.txt
+        * generic_error.html
+        404 404.html
+        503 503.html
+}`, false, ErrorHandler{
+			LogFile:          "errors.txt",
+			GenericErrorPage: "generic_error.html",
+			ErrorPages: map[int]string{
+				404: "404.html",
+				503: "503.html",
+			},
+		}},
 	}
 	for i, test := range tests {
 		actualErrorsRule, err := errorsParse(caddy.NewTestController("http", test.inputErrorsRules))
@@ -149,6 +161,10 @@ func TestErrorsParse(t *testing.T) {
 				t.Fatalf("Test %d expected LogRoller LocalTime to be %t, but got %t",
 					i, test.expectedErrorHandler.LogRoller.LocalTime, actualErrorsRule.LogRoller.LocalTime)
 			}
+		}
+		if actualErrorsRule.GenericErrorPage != test.expectedErrorHandler.GenericErrorPage {
+			t.Fatalf("Test %d expected GenericErrorPage to be %v, but got %v",
+				i, test.expectedErrorHandler.GenericErrorPage, actualErrorsRule.GenericErrorPage)
 		}
 	}
 


### PR DESCRIPTION
Add ability to specify default (fallback) error page in Caddyfile  via '*' as status code. This addresses #752 