### PR TITLE
Added support for environment variables to 'templates' module.

### DIFF
--- a/caddyhttp/httpserver/context.go
+++ b/caddyhttp/httpserver/context.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/russross/blackfriday"
+	"os"
 )
 
 // This file contains the context and functions available for
@@ -55,6 +56,24 @@ func (c Context) Cookie(name string) string {
 // Header gets the value of a request header with field name.
 func (c Context) Header(name string) string {
 	return c.Req.Header.Get(name)
+}
+
+// Env gets a map of the environment variables.
+func (c Context) Env() map[string]string {
+	osEnv := os.Environ()
+	envVars := make(map[string]string, len(osEnv))
+	for _, env := range osEnv {
+		data := strings.SplitN(env, "=", 2)
+		if len(data) == 2 {
+			envVars[data[0]] = data[1]
+		}
+	}
+	return envVars
+}
+
+// PrintEnv gets the values of all environment variables (for debug purposes).
+func (c Context) PrintEnv() string {
+	return c.Join(os.Environ(), "\n")
 }
 
 // IP gets the (remote) IP address of the client making the request.
@@ -243,9 +262,14 @@ func (c Context) ToUpper(s string) string {
 	return strings.ToUpper(s)
 }
 
-// Split is a passthrough to strings.Split. It will split the first argument at each instance of the separator and return a slice of strings.
+// Split is a pass-through to strings.Split. It will split the first argument at each instance of the separator and return a slice of strings.
 func (c Context) Split(s string, sep string) []string {
 	return strings.Split(s, sep)
+}
+
+// Join is a pass-through to strings.Join. It will join the first argument slice with the separator in the second argument and return the result.
+func (c Context) Join(a []string, sep string) string {
+	return strings.Join(a, sep)
 }
 
 // Slice will convert the given arguments into a slice.

--- a/caddyhttp/httpserver/context.go
+++ b/caddyhttp/httpserver/context.go
@@ -71,11 +71,6 @@ func (c Context) Env() map[string]string {
 	return envVars
 }
 
-// PrintEnv gets the values of all environment variables (for debug purposes).
-func (c Context) PrintEnv() string {
-	return c.Join(os.Environ(), "\n")
-}
-
 // IP gets the (remote) IP address of the client making the request.
 func (c Context) IP() string {
 	ip, _, err := net.SplitHostPort(c.Req.RemoteAddr)

--- a/caddyhttp/httpserver/context_test.go
+++ b/caddyhttp/httpserver/context_test.go
@@ -246,29 +246,6 @@ func TestEnv(t *testing.T) {
 	}
 }
 
-func TestPrintEnv(t *testing.T) {
-	context := getContextOrFail(t)
-
-	name := "ENV_TEST_NAME"
-	testValue := "TEST_VALUE"
-	os.Setenv(name, testValue)
-
-	notExisting := "ENV_TEST_NOT_EXISTING"
-	os.Unsetenv(notExisting)
-
-	env := context.PrintEnv()
-
-	test1 := name + "=" + testValue
-	if strings.Contains(env, test1) == false {
-		t.Errorf("Expected env-variable %s in '%s'", name, env)
-	}
-
-	test2 := notExisting + "="
-	if strings.Contains(env, test2) == true {
-		t.Errorf("Not expecting env-variable %s in '%s'", notExisting, env)
-	}
-}
-
 func TestIP(t *testing.T) {
 	context := getContextOrFail(t)
 

--- a/caddyhttp/httpserver/context_test.go
+++ b/caddyhttp/httpserver/context_test.go
@@ -224,6 +224,51 @@ func TestHeader(t *testing.T) {
 	}
 }
 
+func TestEnv(t *testing.T) {
+	context := getContextOrFail(t)
+
+	name := "ENV_TEST_NAME"
+	testValue := "TEST_VALUE"
+	os.Setenv(name, testValue)
+
+	notExisting := "ENV_TEST_NOT_EXISTING"
+	os.Unsetenv(notExisting)
+
+	env := context.Env()
+	if value := env[name]; value != testValue {
+		t.Errorf("Expected env-variable %s value '%s', found '%s'",
+			name, testValue, value)
+	}
+
+	if value, ok := env[notExisting]; ok {
+		t.Errorf("Expected empty env-variable %s, found '%s'",
+			notExisting, value)
+	}
+}
+
+func TestPrintEnv(t *testing.T) {
+	context := getContextOrFail(t)
+
+	name := "ENV_TEST_NAME"
+	testValue := "TEST_VALUE"
+	os.Setenv(name, testValue)
+
+	notExisting := "ENV_TEST_NOT_EXISTING"
+	os.Unsetenv(notExisting)
+
+	env := context.PrintEnv()
+
+	test1 := name + "=" + testValue
+	if strings.Contains(env, test1) == false {
+		t.Errorf("Expected env-variable %s in '%s'", name, env)
+	}
+
+	test2 := notExisting + "="
+	if strings.Contains(env, test2) == true {
+		t.Errorf("Not expecting env-variable %s in '%s'", notExisting, env)
+	}
+}
+
 func TestIP(t *testing.T) {
 	context := getContextOrFail(t)
 

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -121,7 +121,7 @@ func TestSet(t *testing.T) {
 
 	request, err := http.NewRequest("POST", "http://localhost", reader)
 	if err != nil {
-		t.Fatalf("Request Formation Failed \n")
+		t.Fatalf("Request Formation Failed: %s\n", err.Error())
 	}
 	repl := NewReplacer(request, recordRequest, "")
 


### PR DESCRIPTION
Feature request from [forum post](https://forum.caddyserver.com/t/environment-variables-in-templates/321)
* Environment variables in templates work as:

   `{{.Env.NAME}}` ~~and for debugging you can do `{{.PrintEnv}}` to get them all with new-line breaks.~~

Includes test cases.