### PR TITLE
Fix error which lead to skipping tests in 'errors.TestErrorsParse'

### DIFF
--- a/caddyhttp/errors/setup_test.go
+++ b/caddyhttp/errors/setup_test.go
@@ -132,7 +132,7 @@ func TestErrorsParse(t *testing.T) {
 			t.Errorf("Test %d didn't error, but it should have", i)
 		} else if err != nil && !test.shouldErr {
 			t.Errorf("Test %d errored, but it shouldn't have; got '%v'", i, err)
-		} else {
+		} else if err != nil && test.shouldErr {
 			continue
 		}
 		if actualErrorsRule.LogFile != test.expectedErrorHandler.LogFile {


### PR DESCRIPTION
Fix mistake in checking error conditions