### PR TITLE
Fix for invalid environment variable names used on windows that start…

### DIFF
--- a/caddyhttp/httpserver/context.go
+++ b/caddyhttp/httpserver/context.go
@@ -64,7 +64,7 @@ func (c Context) Env() map[string]string {
 	envVars := make(map[string]string, len(osEnv))
 	for _, env := range osEnv {
 		data := strings.SplitN(env, "=", 2)
-		if len(data) == 2 {
+		if len(data) == 2 && len(data[0]) > 0 {
 			envVars[data[0]] = data[1]
 		}
 	}

--- a/caddyhttp/httpserver/context_test.go
+++ b/caddyhttp/httpserver/context_test.go
@@ -234,6 +234,9 @@ func TestEnv(t *testing.T) {
 	notExisting := "ENV_TEST_NOT_EXISTING"
 	os.Unsetenv(notExisting)
 
+	invalidName := "ENV_TEST_INVALID_NAME"
+	os.Setenv("="+invalidName, testValue)
+
 	env := context.Env()
 	if value := env[name]; value != testValue {
 		t.Errorf("Expected env-variable %s value '%s', found '%s'",
@@ -244,6 +247,17 @@ func TestEnv(t *testing.T) {
 		t.Errorf("Expected empty env-variable %s, found '%s'",
 			notExisting, value)
 	}
+
+	for k, v := range env {
+		if strings.Contains(k, invalidName) {
+			t.Errorf("Expected invalid name not to be included in Env %s, found in key '%s'", invalidName, k)
+		}
+		if strings.Contains(v, invalidName) {
+			t.Errorf("Expected invalid name not be be included in Env %s, found in value '%s'", invalidName, v)
+		}
+	}
+
+	os.Unsetenv("=" + invalidName)
 }
 
 func TestIP(t *testing.T) {


### PR DESCRIPTION
… with an equals symbol. Even though this contradicts the Microsoft docs.