### PR TITLE
caddymain: Fix setting and displaying versioning

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -27,6 +27,7 @@ import (
 func init() {
 	caddy.TrapSignals()
 	setVersion()
+	setName()
 
 	flag.BoolVar(&caddytls.Agreed, "agree", false, "Agree to the CA's Subscriber Agreement")
 	flag.StringVar(&caddytls.DefaultCAUrl, "ca", "https://acme-v01.api.letsencrypt.org/directory", "URL to certificate authority's ACME server directory")
@@ -49,10 +50,6 @@ func init() {
 func Run() {
 	flag.Parse()
 	moveStorage() // TODO: This is temporary for the 0.9 release, or until most users upgrade to 0.9+
-
-	caddy.AppName = appName
-	caddy.AppVersion = appVersion
-	acme.UserAgent = appName + "/" + appVersion
 
 	// Set up process log before anything bad happens
 	switch logfile {
@@ -81,7 +78,7 @@ func Run() {
 		os.Exit(0)
 	}
 	if version {
-		fmt.Printf("%s %s\n", appName, appVersion)
+		fmt.Printf("%s %s\n", caddy.AppName, caddy.AppVersion)
 		if devBuild && gitShortStat != "" {
 			fmt.Printf("%s\n%s\n", gitShortStat, gitFilesModified)
 		}
@@ -217,6 +214,13 @@ func setVersion() {
 			appVersion = strings.TrimPrefix(gitTag, "v")
 		}
 	}
+}
+
+// setName sets Caddy's http server plugin versioning information.
+func setName() {
+	caddy.AppName = appName
+	caddy.AppVersion = appVersion
+	acme.UserAgent = appName + "/" + appVersion
 }
 
 // setCPU parses string cpu and sets GOMAXPROCS


### PR DESCRIPTION
Move setting the versioning into the init function and use
caddy.AppVersion and friends when displaying it.

This is useful for servertype plugin that re-use `run.go`, but want to
set their own versioning and naming.