### PR TITLE
Add plugin capabilities for tls storage.

### DIFF
--- a/caddyhttp/caddyhttp_test.go
+++ b/caddyhttp/caddyhttp_test.go
@@ -11,7 +11,7 @@ import (
 // ensure that the standard plugins are in fact plugged in
 // and registered properly; this is a quick/naive way to do it.
 func TestStandardPlugins(t *testing.T) {
-	numStandardPlugins := 25 // importing caddyhttp plugs in this many plugins
+	numStandardPlugins := 26 // importing caddyhttp plugs in this many plugins
 	s := caddy.DescribePlugins()
 	if got, want := strings.Count(s, "\n"), numStandardPlugins+5; got != want {
 		t.Errorf("Expected all standard plugins to be plugged in, got:\n%s", s)

--- a/caddytls/filestorage.go
+++ b/caddytls/filestorage.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+func init() {
+	RegisterStorageProvider("file", FileStorageCreator)
+}
+
 // storageBasePath is the root path in which all TLS/ACME assets are
 // stored. Do not change this value during the lifetime of the program.
 var storageBasePath = filepath.Join(caddy.AssetsPath(), "acme")

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -146,6 +146,16 @@ func setupTLS(c *caddy.Controller) error {
 					return c.Errf("Unsupported DNS provider '%s'", args[0])
 				}
 				config.DNSProvider = args[0]
+			case "storage":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return c.ArgErr()
+				}
+				storageProvName := args[0]
+				if _, ok := storageProviders[storageProvName]; !ok {
+					return c.Errf("Unsupported Storage provider '%s'", args[0])
+				}
+				config.StorageProvider = args[0]
 			default:
 				return c.Errf("Unknown keyword '%s'", c.Val())
 			}

--- a/caddytls/tls.go
+++ b/caddytls/tls.go
@@ -168,3 +168,11 @@ var (
 	// when no other key type is specified.
 	DefaultKeyType = acme.RSA2048
 )
+
+var storageProviders = make(map[string]StorageCreator)
+
+// RegisterStorageProvider registers provider by name for storing tls data
+func RegisterStorageProvider(name string, provider StorageCreator) {
+	storageProviders[name] = provider
+	caddy.RegisterPlugin("tls.storage."+name, caddy.Plugin{})
+}


### PR DESCRIPTION
To use a plugged in storage, specify "storage storage_name" in the tls block of the Caddyfile, by default, file storage will be used