### PR TITLE
Proxy: Set MaxIdleConnsPerHost to -1 to prevent Idle Conns

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -304,7 +304,7 @@ func newConnHijackerTransport(base http.RoundTripper) *connHijackerTransport {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
-		DisableKeepAlives:   true,
+		MaxIdleConnsPerHost: -1,
 	}
 	if base != nil {
 		if baseTransport, ok := base.(*http.Transport); ok {
@@ -313,7 +313,7 @@ func newConnHijackerTransport(base http.RoundTripper) *connHijackerTransport {
 			transport.TLSHandshakeTimeout = baseTransport.TLSHandshakeTimeout
 			transport.Dial = baseTransport.Dial
 			transport.DialTLS = baseTransport.DialTLS
-			transport.DisableKeepAlives = true
+			transport.MaxIdleConnsPerHost = -1
 		}
 	}
 	hjTransport := &connHijackerTransport{transport, nil, bufferPool.Get().([]byte)[:0]}


### PR DESCRIPTION
Instead of setting DisableKeepAlives, set MaxIdleConnsPerHost to -1 to prevent net/http from pooling the connections. DisableKeepAlives causes net/http to send a Connection: Closed header which is bad. Fixes #1056