### PR TITLE
Make ACME listener ports configurable

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -40,6 +40,8 @@ func init() {
 	flag.StringVar(&revoke, "revoke", "", "Hostname for which to revoke the certificate")
 	flag.StringVar(&serverType, "type", "http", "Type of server to run")
 	flag.BoolVar(&version, "version", false, "Show version")
+	flag.StringVar(&caddytls.HTTPChallengePort, "external-port-80-is-local-port", "80", "Local port exposed externally as port 80")
+	flag.StringVar(&caddytls.TLSSNIChallengePort, "external-port-443-is-local-port", "443", "Local port exposed externally as port 443")
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))

--- a/caddyhttp/httpserver/https.go
+++ b/caddyhttp/httpserver/https.go
@@ -108,6 +108,10 @@ func enableAutoHTTPS(configs []*SiteConfig, loadCertificates bool) error {
 func makePlaintextRedirects(allConfigs []*SiteConfig) []*SiteConfig {
 	for i, cfg := range allConfigs {
 		if cfg.TLS.Managed &&
+			// don't trigger automatic redirects if port 80 and 443 might not be
+			// bindable
+			caddytls.HTTPChallengePort == "80" &&
+			caddytls.TLSSNIChallengePort == "443" &&
 			!hostHasOtherPort(allConfigs, i, "80") &&
 			(cfg.Addr.Port == "443" || !hostHasOtherPort(allConfigs, i, "443")) {
 			allConfigs = append(allConfigs, redirPlaintextHost(cfg))

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -103,10 +103,10 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 		// Use HTTP and TLS-SNI challenges by default
 
 		// See if HTTP challenge needs to be proxied
-		useHTTPPort := "" // empty port value will use challenge default
+		useHTTPPort := HTTPChallengePort
 		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, HTTPChallengePort)) {
 			useHTTPPort = config.AltHTTPPort
-			if useHTTPPort == "" {
+			if useHTTPPort == HTTPChallengePort {
 				useHTTPPort = DefaultHTTPAlternatePort
 			}
 		}
@@ -121,7 +121,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 		if err != nil {
 			return nil, err
 		}
-		err = c.SetTLSAddress(net.JoinHostPort(config.ListenHost, ""))
+		err = c.SetTLSAddress(net.JoinHostPort(config.ListenHost, TLSSNIChallengePort))
 		if err != nil {
 			return nil, err
 		}

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -528,15 +528,15 @@ var defaultCiphers = []uint16{
 	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 }
 
-const (
-	// HTTPChallengePort is the officially designated port for
-	// the HTTP challenge.
+var (
+	// HTTPChallengePort must be externally visible as port 80.
 	HTTPChallengePort = "80"
 
-	// TLSSNIChallengePort is the officially designated port for
-	// the TLS-SNI challenge.
+	// TLSSNIChallengePort must be externally visible as port 443.
 	TLSSNIChallengePort = "443"
+)
 
+const (
 	// DefaultHTTPAlternatePort is the port on which the ACME
 	// client will open a listener and solve the HTTP challenge.
 	// If this alternate port is used instead of the default


### PR DESCRIPTION
Adds new command-line options that describe which ports are externally
    visible as ports 80 and 443 and instructs the ACME listener to use them
    instead of the default ports. This allows non-DNS ACME challenges to work
    without special privileges or privilege delegation mechanisms.

This is my first PR to Caddy and my first time playing with Go. :) I've probably made some poor architectural decisions in the interest of producing a simple, concrete artifact for feedback. I tested it on a AWS instance with [iptables port forwarding](https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+on+Port+80+or+443+using+iptables) and it looks like it behaves correctly. I haven't attempted unit tests.

I hope this isn't too frustrating to review!

Fixes #918.