### PR TITLE
Actually set tls.Config.PreferServerCipherSuites

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -350,6 +350,7 @@ func MakeTLSConfig(configs []*Config) (*tls.Config, error) {
 		if i > 0 && cfg.PreferServerCipherSuites != configs[i-1].PreferServerCipherSuites {
 			return nil, fmt.Errorf("cannot both use PreferServerCipherSuites and not use it")
 		}
+		config.PreferServerCipherSuites = cfg.PreferServerCipherSuites
 
 		// Go with the widest range of protocol versions
 		if config.MinVersion == 0 || cfg.ProtocolMinVersion < config.MinVersion {


### PR DESCRIPTION
It was set by default on the caddy-internal config object, and even
checked for conflicts, but it was never actually reflected on the
tls.Config.

This will have user-visible changes: a client that prefers, say, AES-CBC
but also supports AES-GCM would have used AES-CBC befor this, and will
use AES-GCM after.

This is desirable and important behavior, because if for example the
server wanted to support 3DES, but *only if it was strictly necessary*,
it would have had no way of doing so with PreferServerCipherSuites
false, as the client preference would have won.