### PR TITLE
faster fastcgi

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/mholt/caddy"
 	// plug in the HTTP server type
-	_ "github.com/mholt/caddy/caddyhttp"
+	_ "github.com/echsecutor/caddy/caddyhttp"
 
 	"github.com/mholt/caddy/caddytls"
 	// This is where other plugins get plugged in (imported)

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/mholt/caddy"
 	// plug in the HTTP server type
-	_ "github.com/echsecutor/caddy/caddyhttp"
+	_ "github.com/mholt/caddy/caddyhttp"
 
 	"github.com/mholt/caddy/caddytls"
 	// This is where other plugins get plugged in (imported)

--- a/caddy/main.go
+++ b/caddy/main.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/echsecutor/caddy/caddy/caddymain"
+import "github.com/mholt/caddy/caddy/caddymain"
 
 var run = caddymain.Run // replaced for tests
 

--- a/caddy/main.go
+++ b/caddy/main.go
@@ -5,7 +5,7 @@
 
 package main
 
-import "github.com/mholt/caddy/caddy/caddymain"
+import "github.com/echsecutor/caddy/caddy/caddymain"
 
 var run = caddymain.Run // replaced for tests
 

--- a/caddyhttp/caddyhttp.go
+++ b/caddyhttp/caddyhttp.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mholt/caddy/caddyhttp/errors"
 	_ "github.com/mholt/caddy/caddyhttp/expvar"
 	_ "github.com/mholt/caddy/caddyhttp/extensions"
-	_ "github.com/echsecutor/caddy/caddyhttp/fastcgi"
+	_ "github.com/mholt/caddy/caddyhttp/fastcgi"
 	_ "github.com/mholt/caddy/caddyhttp/gzip"
 	_ "github.com/mholt/caddy/caddyhttp/header"
 	_ "github.com/mholt/caddy/caddyhttp/internalsrv"

--- a/caddyhttp/caddyhttp.go
+++ b/caddyhttp/caddyhttp.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mholt/caddy/caddyhttp/errors"
 	_ "github.com/mholt/caddy/caddyhttp/expvar"
 	_ "github.com/mholt/caddy/caddyhttp/extensions"
-	_ "github.com/mholt/caddy/caddyhttp/fastcgi"
+	_ "github.com/echsecutor/caddy/caddyhttp/fastcgi"
 	_ "github.com/mholt/caddy/caddyhttp/gzip"
 	_ "github.com/mholt/caddy/caddyhttp/header"
 	_ "github.com/mholt/caddy/caddyhttp/internalsrv"

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -76,13 +76,14 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 
 			// Connect to FastCGI gateway
 			network, address := rule.parseAddress()
-			// check if connection is already open
+
+			
+			// re use connection, if possible
 			if persistent_connections == nil{
 					persistent_connections = make(map[string]*FCGIClient)
 			}
-
-			// re use connection, if possible
 			fcgiBackend, ok := persistent_connections[network+address]
+			
 			// otherwise dial:
 			if(!ok || fcgiBackend == nil){
 				var err error

--- a/caddyhttp/fastcgi/fcgiclient.go
+++ b/caddyhttp/fastcgi/fcgiclient.go
@@ -385,7 +385,7 @@ func (w *streamReader) Read(p []byte) (n int, err error) {
 // Do made the request and returns a io.Reader that translates the data read
 // from fcgi responder out of fcgi packet before returning it.
 func (c *FCGIClient) Do(p map[string]string, req io.Reader) (r io.Reader, err error) {
-	err = c.writeBeginRequest(uint16(Responder), 0)
+	err = c.writeBeginRequest(uint16(Responder), FCGIKeepConn)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This is to fix the fastcgi performance issue
https://github.com/mholt/caddy/issues/1082

By keeping the fastcgi connection open, answer latency is reduced by a factor 100 in my local setup.

This is a kind of quick fix, it would be better to include an option into the fastcgi directive to enable/disable connection upkeep and to set timeouts. See
http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_keep_conn
for the nginx equivalent.