### PR TITLE
Add the multipass plugin to the directives

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -416,9 +416,9 @@ var directives = []string{
 	"cors", // github.com/captncraig/cors/caddy
 	"mime",
 	"basicauth",
-	"jwt",    // github.com/BTBurke/caddy-jwt
-	"jsonp",  // github.com/pschlump/caddy-jsonp
-	"upload", // blitznote.com/src/caddy.upload
+	"jwt",       // github.com/BTBurke/caddy-jwt
+	"jsonp",     // github.com/pschlump/caddy-jsonp
+	"upload",    // blitznote.com/src/caddy.upload
 	"multipass", // github.com/namsral/multipass/caddy
 	"internal",
 	"pprof",

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -419,6 +419,7 @@ var directives = []string{
 	"jwt",    // github.com/BTBurke/caddy-jwt
 	"jsonp",  // github.com/pschlump/caddy-jsonp
 	"upload", // blitznote.com/src/caddy.upload
+	"multipass", // github.com/namsral/multipass/caddy
 	"internal",
 	"pprof",
 	"expvar",


### PR DESCRIPTION
This adds the multipass plugin to the Caddy's directives.

Relates to: https://github.com/caddyserver/caddyserver.com/pull/67