### PR TITLE
Fastcgi persistent fix

### DIFF
--- a/caddyhttp/fastcgi/dialer.go
+++ b/caddyhttp/fastcgi/dialer.go
@@ -1,0 +1,58 @@
+package fastcgi
+
+import "sync"
+
+type dialer interface {
+	Dial() (*FCGIClient, error)
+	Close(*FCGIClient) error
+}
+
+// basicDialer is a basic dialer that wraps default fcgi functions.
+type basicDialer struct {
+	network, address string
+}
+
+func (b basicDialer) Dial() (*FCGIClient, error) { return Dial(b.network, b.address) }
+func (b basicDialer) Close(c *FCGIClient) error  { return c.Close() }
+
+// persistentDialer keeps a pool of fcgi connections.
+// connections are not closed after use, rather added back to the pool for reuse.
+type persistentDialer struct {
+	size    int
+	network string
+	address string
+	pool    []*FCGIClient
+	sync.Mutex
+}
+
+func (p *persistentDialer) Dial() (*FCGIClient, error) {
+	p.Lock()
+
+	// connection is available, return first one.
+	if len(p.pool) > 0 {
+		client := p.pool[0]
+		p.pool = p.pool[1:]
+		p.Unlock()
+
+		return client, nil
+	}
+
+	p.Unlock()
+
+	// no connection available, create new one
+	return Dial(p.network, p.address)
+}
+
+func (p *persistentDialer) Close(client *FCGIClient) error {
+	p.Lock()
+	if len(p.pool) < p.size {
+		// pool is not full yet, add connection for reuse
+		p.pool = append(p.pool, client)
+		p.Unlock()
+	} else {
+		// otherwise, close the connection.
+		p.Unlock()
+		return client.Close()
+	}
+	return nil
+}

--- a/caddyhttp/fastcgi/dialer.go
+++ b/caddyhttp/fastcgi/dialer.go
@@ -49,10 +49,12 @@ func (p *persistentDialer) Close(client *FCGIClient) error {
 		// pool is not full yet, add connection for reuse
 		p.pool = append(p.pool, client)
 		p.Unlock()
-	} else {
-		// otherwise, close the connection.
-		p.Unlock()
-		return client.Close()
+
+		return nil
 	}
-	return nil
+
+	p.Unlock()
+
+	// otherwise, close the connection.
+	return client.Close()
 }

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -24,9 +24,10 @@ func TestServeHTTP(t *testing.T) {
 		w.Write([]byte(body))
 	}))
 
+	network, address := parseAddress(listener.Addr().String())
 	handler := Handler{
 		Next:  nil,
-		Rules: []Rule{{Path: "/", Address: listener.Addr().String()}},
+		Rules: []Rule{{Path: "/", Address: listener.Addr().String(), dialer: basicDialer{network, address}}},
 	}
 	r, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
@@ -64,10 +65,10 @@ func TestRuleParseAddress(t *testing.T) {
 	}
 
 	for _, entry := range getClientTestTable {
-		if actualnetwork, _ := entry.rule.parseAddress(); actualnetwork != entry.expectednetwork {
+		if actualnetwork, _ := parseAddress(entry.rule.Address); actualnetwork != entry.expectednetwork {
 			t.Errorf("Unexpected network for address string %v. Got %v, expected %v", entry.rule.Address, actualnetwork, entry.expectednetwork)
 		}
-		if _, actualaddress := entry.rule.parseAddress(); actualaddress != entry.expectedaddress {
+		if _, actualaddress := parseAddress(entry.rule.Address); actualaddress != entry.expectedaddress {
 			t.Errorf("Unexpected parsed address for address string %v. Got %v, expected %v", entry.rule.Address, actualaddress, entry.expectedaddress)
 		}
 	}

--- a/caddyhttp/fastcgi/fcgiclient.go
+++ b/caddyhttp/fastcgi/fcgiclient.go
@@ -193,9 +193,9 @@ func Dial(network, address string) (fcgi *FCGIClient, err error) {
 	return DialWithDialer(network, address, net.Dialer{})
 }
 
-// Close closes fcgi connnection
-func (c *FCGIClient) Close() {
-	c.rwc.Close()
+// Close closes fcgi connnection.
+func (c *FCGIClient) Close() error {
+	return c.rwc.Close()
 }
 
 func (c *FCGIClient) writeRecord(recType uint8, content []byte) (err error) {
@@ -408,11 +408,11 @@ func (c *FCGIClient) Do(p map[string]string, req io.Reader) (r io.Reader, err er
 // clientCloser is a io.ReadCloser. It wraps a io.Reader with a Closer
 // that closes FCGIClient connection.
 type clientCloser struct {
-	*FCGIClient
+	f *FCGIClient
 	io.Reader
 }
 
-func (f clientCloser) Close() error { return f.rwc.Close() }
+func (c clientCloser) Close() error { return c.f.Close() }
 
 // Request returns a HTTP Response with Header and Body
 // from fcgi responder

--- a/caddyhttp/fastcgi/setup.go
+++ b/caddyhttp/fastcgi/setup.go
@@ -110,8 +110,14 @@ func fastcgiParse(c *caddy.Controller) ([]Rule, error) {
 				if !c.NextArg() {
 					return rules, c.ArgErr()
 				}
-				if pool, _ := strconv.Atoi(c.Val()); pool > 0 {
+				pool, err := strconv.Atoi(c.Val())
+				if err != nil {
+					return rules, err
+				}
+				if pool >= 0 {
 					rule.dialer = &persistentDialer{size: pool, network: network, address: address}
+				} else {
+					return rules, c.Errf("positive integer expected, found %d", pool)
 				}
 			}
 		}


### PR DESCRIPTION
This builds on https://github.com/mholt/caddy/pull/1087 and fixes https://github.com/mholt/caddy/issues/1123. Reconnects if required and allows a configurable number of connection to reuse in the pool.

This instructs fastcgi to attempt to persist and reuse up to 5 connections. 
```
fastcgi / 127.0.0.1:900 php {
    pool 5
}
```
It is disabled by default unless the configuration is added and `pool > 0`.

`pool 1` works fine from all my tests.

### Benchmark on linux container using [hey](https://github.com/rakyll/hey). 
#### Persistent Connection
Caddyfile
```
0.0.0.0
root /src
fastcgi / fpm:9000 php {
     pool 1
}
```
Result
```
❯ hey -n 1000 -c 20 http://localhost:2015
Summary:
  Total:	8.8103 secs
  Slowest:	0.3320 secs
  Fastest:	0.0379 secs
  Average:	0.1743 secs
  Requests/sec:	113.5040

Status code distribution:
  [200]	1000 responses

Response time histogram:
  0.038 [1]	|
  0.067 [4]	|∎
  0.097 [20]	|∎∎∎
  0.126 [69]	|∎∎∎∎∎∎∎∎∎
  0.156 [237]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.185 [293]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.214 [224]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.244 [99]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.273 [36]	|∎∎∎∎∎
  0.303 [14]	|∎∎
  0.332 [3]	|

Latency distribution:
  10% in 0.1281 secs
  25% in 0.1482 secs
  50% in 0.1717 secs
  75% in 0.1989 secs
  90% in 0.2263 secs
  95% in 0.2460 secs
  99% in 0.2856 secs
```
#### Non-Persistent Connection
Caddyfile
```
0.0.0.0
root /src
fastcgi / fpm:9000 php
```
Result
```
❯ hey -n 1000 -c 20 http://localhost:2016
Summary:
  Total:	10.2372 secs
  Slowest:	0.4034 secs
  Fastest:	0.0261 secs
  Average:	0.2017 secs
  Requests/sec:	97.6830

Status code distribution:
  [200]	1000 responses

Response time histogram:
  0.026 [1]	|
  0.064 [4]	|∎
  0.102 [25]	|∎∎∎
  0.139 [71]	|∎∎∎∎∎∎∎∎∎
  0.177 [227]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.215 [303]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.252 [210]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.290 [97]	|∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.328 [48]	|∎∎∎∎∎∎
  0.366 [8]	|∎
  0.403 [6]	|∎

Latency distribution:
  10% in 0.1388 secs
  25% in 0.1677 secs
  50% in 0.1988 secs
  75% in 0.2340 secs
  90% in 0.2727 secs
  95% in 0.2970 secs
  99% in 0.3450 secs
```
Not much difference in the benchmark results and persistent connection is a bit faster.