### PR TITLE
proxy: Improve failover logic and retries

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -80,10 +80,6 @@ func (uh *UpstreamHost) Available() bool {
 	return !uh.Down() && !uh.Full()
 }
 
-// tryDuration is how long to try upstream hosts; failures result in
-// immediate retries until this duration ends or we get a nil host.
-var tryDuration = 60 * time.Second
-
 // ServeHTTP satisfies the httpserver.Handler interface.
 func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	// start by selecting most specific matching upstream config

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -100,7 +100,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	start := time.Now()
 	keepRetrying := func() bool {
 		// if we've tried long enough, break
-		if time.Now().Sub(start) >= upstream.GetTryDuration() {
+		if time.Since(start) >= upstream.GetTryDuration() {
 			return false
 		}
 		// otherwise, wait and try the next available host

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -766,9 +766,9 @@ func (u *fakeUpstream) Select(r *http.Request) *UpstreamHost {
 	return u.host
 }
 
-func (u *fakeUpstream) AllowedPath(requestPath string) bool {
-	return true
-}
+func (u *fakeUpstream) AllowedPath(requestPath string) bool { return true }
+func (u *fakeUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
+func (u *fakeUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 
 // newWebSocketTestProxy returns a test proxy that will
 // redirect to the specified backendAddr. The function
@@ -808,9 +808,9 @@ func (u *fakeWsUpstream) Select(r *http.Request) *UpstreamHost {
 	}
 }
 
-func (u *fakeWsUpstream) AllowedPath(requestPath string) bool {
-	return true
-}
+func (u *fakeWsUpstream) AllowedPath(requestPath string) bool { return true }
+func (u *fakeWsUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
+func (u *fakeWsUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 
 // recorderHijacker is a ResponseRecorder that can
 // be hijacked.

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -24,10 +24,6 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-func init() {
-	tryDuration = 50 * time.Millisecond // prevent tests from hanging
-}
-
 func TestReverseProxy(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -31,6 +31,8 @@ type staticUpstream struct {
 
 	FailTimeout time.Duration
 	MaxFails    int32
+	TryDuration time.Duration
+	TryInterval time.Duration
 	MaxConns    int64
 	HealthCheck struct {
 		Client   http.Client
@@ -53,8 +55,8 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 			downstreamHeaders: make(http.Header),
 			Hosts:             nil,
 			Policy:            &Random{},
-			FailTimeout:       10 * time.Second,
 			MaxFails:          1,
+			TryInterval:       1 * time.Second,
 			MaxConns:          0,
 			KeepAlive:         http.DefaultMaxIdleConnsPerHost,
 		}
@@ -114,11 +116,6 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 	return upstreams, nil
 }
 
-// RegisterPolicy adds a custom policy to the proxy.
-func RegisterPolicy(name string, policy func() Policy) {
-	supportedPolicies[name] = policy
-}
-
 func (u *staticUpstream) From() string {
 	return u.from
 }
@@ -141,8 +138,7 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 				if uh.Unhealthy {
 					return true
 				}
-				if uh.Fails >= u.MaxFails &&
-					u.MaxFails != 0 {
+				if uh.Fails >= u.MaxFails {
 					return true
 				}
 				return false
@@ -237,7 +233,28 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		if err != nil {
 			return err
 		}
+		if n < 1 {
+			return c.Err("max_fails must be at least 1")
+		}
 		u.MaxFails = int32(n)
+	case "try_duration":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		dur, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		u.TryDuration = dur
+	case "try_interval":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		interval, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		u.TryInterval = interval
 	case "max_conns":
 		if !c.NextArg() {
 			return c.ArgErr()
@@ -396,4 +413,19 @@ func (u *staticUpstream) AllowedPath(requestPath string) bool {
 		}
 	}
 	return true
+}
+
+// GetTryDuration returns u.TryDuration.
+func (u *staticUpstream) GetTryDuration() time.Duration {
+	return u.TryDuration
+}
+
+// GetTryInterval returns u.TryInterval.
+func (u *staticUpstream) GetTryInterval() time.Duration {
+	return u.TryInterval
+}
+
+// RegisterPolicy adds a custom policy to the proxy.
+func RegisterPolicy(name string, policy func() Policy) {
+	supportedPolicies[name] = policy
 }

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -56,7 +56,7 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 			Hosts:             nil,
 			Policy:            &Random{},
 			MaxFails:          1,
-			TryInterval:       1 * time.Second,
+			TryInterval:       250 * time.Millisecond,
 			MaxConns:          0,
 			KeepAlive:         http.DefaultMaxIdleConnsPerHost,
 		}


### PR DESCRIPTION
This PR should fix #1069 and resolve a few other outstanding irritants in proxy behavior for backends that are less-than-robust. In summary:

- Proxy no longer retries by default when a request fails, because `tryDuration` (now a configurable value on the Upstream itself) defaults to 0. This means that, by default, the downstream client must retry their request when a host initially goes down or no hosts are available.

- New configuration subdirectives: `try_duration` and `try_interval`. try_duration specifies how long to try selecting hosts (used to be 60s) until one succeeds. The introduction of try_interval (with a default of 1s) is there to prevent tight loops that spin the CPU in case all the requests fail gloriously fast; this also operates under the assumption that hosts won't likely come back up within a fraction of a second and that a client can wait 1s when an upstream host initially goes down.

- fail_timeout now defaults to 0, which means that request failure counting is disabled. In other words, a failed request does not count against the upstream host's availability. Since max_fails defaults to 1 (which is sensible), a single request failure could mark the upstream host down for every client for 10 seconds. This is still the case, but now the user has to opt-in to this behavior.

- max_fails can no longer be < 1. People used to set this to 0 to work around the sporadic failures or "long-lived" downtime (of 10 seconds) even if the actual downtime may have been a fluke or a second or two. This resulted in the CPU spinning in a loop and 10s of "502 Bad Gateway" even though the host came up 9 seconds earlier. Anyway, this value is now irrelevant if fail_timeout is 0. The user has to explicitly enable fail_timeout in order to count request failures.

- We report the actual backend error rather than "unreachable backend".

I have also [updated the proxy docs](https://github.com/caddyserver/caddyserver.com/commit/06f46e3875a347efabd34bb8b839c4e467497861) in an attempt to be clearer in what these parameters do.

@nemothekid: Would love to have your review/approval on this! :smile: