### PR TITLE
Remove the eager check in the browse middleware

### DIFF
--- a/caddyhttp/browse/setup.go
+++ b/caddyhttp/browse/setup.go
@@ -62,15 +62,6 @@ func browseParse(c *caddy.Controller) ([]Config, error) {
 			bc.PathScope = "/"
 		}
 		bc.Root = http.Dir(cfg.Root)
-		theRoot, err := bc.Root.Open("/") // catch a missing path early
-		if err != nil {
-			return configs, err
-		}
-		defer theRoot.Close()
-		_, err = theRoot.Readdir(-1)
-		if err != nil {
-			return configs, err
-		}
 
 		// Second argument would be the template file to use
 		var tplText string

--- a/caddyhttp/browse/setup_test.go
+++ b/caddyhttp/browse/setup_test.go
@@ -66,4 +66,16 @@ func TestSetup(t *testing.T) {
 			}
 		}
 	}
+
+	// test case #6 tests startup with missing root directory in combination with default browse settings
+	controller := caddy.NewTestController("http", "browse")
+	cfg := httpserver.GetConfig(controller)
+
+	//Manipulate the root to a nonexistent directory, must be done, cause the default test root exists
+	cfg.Root = nonExistantDirPath
+	err = setup(controller)
+
+	if err != nil {
+		t.Errorf("Test case #%d received an error of %v", 6, err)
+	}
 }

--- a/caddyhttp/browse/setup_test.go
+++ b/caddyhttp/browse/setup_test.go
@@ -18,7 +18,7 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BeforeTest: Failed to find an existing directory for testing! Error was: %v", err)
 	}
-	nonExistantDirPath := filepath.Join(tempDirPath, strconv.Itoa(int(time.Now().UnixNano())))
+	nonExistentDirPath := filepath.Join(tempDirPath, strconv.Itoa(int(time.Now().UnixNano())))
 
 	tempTemplate, err := ioutil.TempFile(".", "tempTemplate")
 	if err != nil {
@@ -43,7 +43,7 @@ func TestSetup(t *testing.T) {
 		{"browse . " + tempTemplatePath, []string{"."}, false},
 
 		// test case #3 tests detection of non-existent template
-		{"browse . " + nonExistantDirPath, nil, true},
+		{"browse . " + nonExistentDirPath, nil, true},
 
 		// test case #4 tests detection of duplicate pathscopes
 		{"browse " + tempDirPath + "\n browse " + tempDirPath, nil, true},
@@ -71,11 +71,11 @@ func TestSetup(t *testing.T) {
 	controller := caddy.NewTestController("http", "browse")
 	cfg := httpserver.GetConfig(controller)
 
-	//Manipulate the root to a nonexistent directory, must be done, cause the default test root exists
-	cfg.Root = nonExistantDirPath
+	// Make sure non-existent root path doesn't return error
+	cfg.Root = nonExistentDirPath
 	err = setup(controller)
 
 	if err != nil {
-		t.Errorf("Test case #%d received an error of %v", 6, err)
+		t.Errorf("Test for non-existent browse path received an error, but shouldn't have: %v", err)
 	}
 }


### PR DESCRIPTION
Hello,

it is just the removing of the eager check in the browse middleware as stated in https://github.com/mholt/caddy/issues/1085

Caddy will start and throw a 404-error until the directory will be created.

Hopes that helps you ;)