### PR TITLE
Fix [1152]? Fix unexpected behavior in redir

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -245,9 +245,9 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 		return port
 	case "{uri}":
-		return r.request.URL.RequestURI()
+		return strings.TrimLeft(r.request.URL.RequestURI(), "/")
 	case "{uri_escaped}":
-		return url.QueryEscape(r.request.URL.RequestURI())
+		return url.QueryEscape(strings.TrimLeft(r.request.URL.RequestURI(), "/"))
 	case "{when}":
 		return time.Now().Format(timeFormat)
 	case "{file}":

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -245,9 +245,9 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 		return port
 	case "{uri}":
-		return strings.TrimLeft(r.request.URL.RequestURI(), "/")
+		return r.request.URL.RequestURI()
 	case "{uri_escaped}":
-		return url.QueryEscape(strings.TrimLeft(r.request.URL.RequestURI(), "/"))
+		return url.QueryEscape(r.request.URL.RequestURI())
 	case "{when}":
 		return time.Now().Format(timeFormat)
 	case "{file}":

--- a/caddyhttp/redirect/redirect.go
+++ b/caddyhttp/redirect/redirect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"strings"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
@@ -20,6 +21,9 @@ type Redirect struct {
 func (rd Redirect) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, rule := range rd.Rules {
 		if (rule.FromPath == "/" || r.URL.Path == rule.FromPath) && schemeMatches(rule, r) && rule.Match(r) {
+			if rule.To == "{uri}" {
+				rule.To = strings.TrimLeft(rule.To, "/")
+			}
 			to := httpserver.NewReplacer(r, nil, "").Replace(rule.To)
 			if rule.Meta {
 				safeTo := html.EscapeString(to)

--- a/caddyhttp/redirect/redirect.go
+++ b/caddyhttp/redirect/redirect.go
@@ -21,7 +21,7 @@ type Redirect struct {
 func (rd Redirect) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, rule := range rd.Rules {
 		if (rule.FromPath == "/" || r.URL.Path == rule.FromPath) && schemeMatches(rule, r) && rule.Match(r) {
-			if rule.To == "{uri}" {
+			if rule.To == "{host}{uri}" {
 				rule.To = strings.TrimLeft(rule.To, "/")
 			}
 			to := httpserver.NewReplacer(r, nil, "").Replace(rule.To)


### PR DESCRIPTION
Hello,

Caddyfile:

```
www.domain.com {
   redir https://domain.com{uri}
}
domain.com {
  ...
}
```

http://www.domain.com/abc/def redirects to https://domain.com//abc/def

This PR fixes this behavior => http://www.domain.com/abc/def redirects to https://domain.com/abc/def