### PR TITLE
Feature Request: #1117

### DIFF
--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -105,6 +105,14 @@ func setupTLS(c *caddy.Controller) error {
 					}
 					config.Ciphers = append(config.Ciphers, value)
 				}
+			case "curves":
+				for c.NextArg() {
+					value, ok := supportedCurvesMap[strings.ToUpper(c.Val())]
+					if !ok {
+						return c.Errf("Wrong curve name or curve not supported: '%s'", c.Val())
+					}
+					config.CurvePreferences = append(config.CurvePreferences, value)
+				}
 			case "clients":
 				clientCertList := c.RemainingArgs()
 				if len(clientCertList) == 0 {

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -179,6 +179,18 @@ func TestSetupParseWithWrongOptionalParams(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected errors, but no error returned")
 	}
+
+	// Test curves wrong params
+	params = `tls {
+			curves ab123, cd456, ef789
+		}`
+	cfg = new(Config)
+	RegisterConfigGetter("", func(c *caddy.Controller) *Config { return cfg })
+	c = caddy.NewTestController("", params)
+	err = setupTLS(c)
+	if err == nil {
+		t.Errorf("Expected errors, but no error returned")
+	}
 }
 
 func TestSetupParseWithClientAuth(t *testing.T) {
@@ -266,6 +278,24 @@ func TestSetupParseWithKeyType(t *testing.T) {
 
 	if cfg.KeyType != acme.EC384 {
 		t.Errorf("Expected 'P384' as KeyType, got %#v", cfg.KeyType)
+	}
+}
+
+func TestSetupParseWithCurves(t *testing.T) {
+	params := `tls {
+            curves p256 p384 p521
+        }`
+	cfg := new(Config)
+	RegisterConfigGetter("", func(c *caddy.Controller) *Config { return cfg })
+	c := caddy.NewTestController("", params)
+
+	err := setupTLS(c)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
+
+	if len(cfg.CurvePreferences) != 3 {
+		t.Errorf("Expected 3 curves, got %v", len(cfg.CurvePreferences))
 	}
 }
 

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -297,6 +297,13 @@ func TestSetupParseWithCurves(t *testing.T) {
 	if len(cfg.CurvePreferences) != 3 {
 		t.Errorf("Expected 3 curves, got %v", len(cfg.CurvePreferences))
 	}
+
+	expectedCurveOrder := []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521}
+	for i := range cfg.CurvePreferences {
+		if cfg.CurvePreferences[i] != expectedCurveOrder[i] {
+			t.Errorf("Expected %v as curve, got %v", expectedCurveOrder[i], cfg.CurvePreferences[i])
+		}
+	}
 }
 
 func TestSetupParseWithOneTLSProtocol(t *testing.T) {


### PR DESCRIPTION
This PR implements the feature request #1117 😄 

Caddyfile:

````
domain.com {
   tls {
      curves ab123, cd456, ef789
   }
}
```

Supported Curves (https://golang.org/pkg/crypto/tls/#CurveID):

```
p256 
p384 
p521 
```