### PR TITLE
Added directive "filter" to whitelist for support of caddy-filter plugin

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -437,6 +437,7 @@ var directives = []string{
 	"hugo",        // github.com/hacdias/caddy-hugo
 	"mailout",     // github.com/SchumacherFM/mailout
 	"awslambda",   // github.com/coopernurse/caddy-awslambda
+	"filter",      // github.com/echocat/caddy-filter
 }
 
 const (


### PR DESCRIPTION
All required pull request to enable full support of github.com/echocat/caddy-filter plugin:
* https://github.com/mholt/caddy/pull/1167
* https://github.com/caddyserver/buildsrv/pull/33
* https://github.com/caddyserver/caddyserver.com/pull/84