### PR TITLE
Very simple fix for #1153

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -245,6 +245,7 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env["PATH_TRANSLATED"] = filepath.Join(h.AbsRoot, pathInfo) // Info: http://www.oreilly.com/openbook/cgi/ch02_04.html
 	}
 
+		
 	// Some web apps rely on knowing HTTPS or not
 	if r.TLS != nil {
 		env["HTTPS"] = "on"
@@ -257,12 +258,18 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env[envVar[0]] = replacer.Replace(envVar[1])
 	}
 
-	// Add all HTTP headers to env variables
+	// Add all HTTP headers (except Caddy-Rewrite-Original-URI ) to env variables
 	for field, val := range r.Header {
-		header := strings.ToUpper(field)
-		header = headerNameReplacer.Replace(header)
-		env["HTTP_"+header] = strings.Join(val, ", ")
+		
+		if strings.ToUpper(field) != strings.ToUpper(internalRewriteFieldName) {
+		   header := strings.ToUpper(field)
+		   header = headerNameReplacer.Replace(header)
+		   env["HTTP_"+header] = strings.Join(val, ", ")
+		} 
+
 	}
+
+	
 
 	return env, nil
 }

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -245,7 +245,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env["PATH_TRANSLATED"] = filepath.Join(h.AbsRoot, pathInfo) // Info: http://www.oreilly.com/openbook/cgi/ch02_04.html
 	}
 
-		
 	// Some web apps rely on knowing HTTPS or not
 	if r.TLS != nil {
 		env["HTTPS"] = "on"
@@ -260,16 +259,15 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 
 	// Add all HTTP headers (except Caddy-Rewrite-Original-URI ) to env variables
 	for field, val := range r.Header {
-		
-		if strings.ToUpper(field) != strings.ToUpper(internalRewriteFieldName) {
-		   header := strings.ToUpper(field)
-		   header = headerNameReplacer.Replace(header)
-		   env["HTTP_"+header] = strings.Join(val, ", ")
-		} 
+
+		if strings.ToLower(field) == strings.ToLower(internalRewriteFieldName) {
+			continue
+		}
+		header := strings.ToUpper(field)
+		header = headerNameReplacer.Replace(header)
+		env["HTTP_"+header] = strings.Join(val, ", ")
 
 	}
-
-	
 
 	return env, nil
 }

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -205,7 +205,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 	reqURI := r.URL.RequestURI()
 	if origURI := r.Header.Get(internalRewriteFieldName); origURI != "" {
 		reqURI = origURI
-		r.Header.Del(internalRewriteFieldName)
 	}
 
 	// Some variables are unused but cleared explicitly to prevent

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -259,7 +259,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 
 	// Add all HTTP headers (except Caddy-Rewrite-Original-URI ) to env variables
 	for field, val := range r.Header {
-
 		if strings.ToLower(field) == strings.ToLower(internalRewriteFieldName) {
 			continue
 		}
@@ -268,7 +267,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env["HTTP_"+header] = strings.Join(val, ", ")
 
 	}
-
 	return env, nil
 }
 

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -31,6 +31,11 @@ type Handler struct {
 	ServerPort      string
 }
 
+// When a rewrite is performed, a header field of this name
+// is added to the request
+// It contains the original request URI before the rewrite.
+const internalRewriteFieldName = "Caddy-Rewrite-Original-URI"
+
 // ServeHTTP satisfies the httpserver.Handler interface.
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, rule := range h.Rules {
@@ -201,7 +206,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 	// or it might have been rewritten internally by the rewrite middleware (see issue #256).
 	// If it was rewritten, there will be a header indicating the original URL,
 	// which is needed to get the correct RequestURI value for PHP apps.
-	const internalRewriteFieldName = "Caddy-Rewrite-Original-URI"
 	reqURI := r.URL.RequestURI()
 	if origURI := r.Header.Get(internalRewriteFieldName); origURI != "" {
 		reqURI = origURI
@@ -265,7 +269,6 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		header := strings.ToUpper(field)
 		header = headerNameReplacer.Replace(header)
 		env["HTTP_"+header] = strings.Join(val, ", ")
-
 	}
 	return env, nil
 }

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -298,7 +299,6 @@ func TestBuildEnv(t *testing.T) {
 	testBuildEnv(r, rule, fpath, envExpected)
 
 	// 6. Test Caddy-Rewrite-Original-URI header is not removed
-	const internalRewriteFieldName = "Caddy-Rewrite-Original-URI"
 	r = newReq()
 	rule.EnvVars = [][2]string{
 		{"HTTP_HOST", "{host}"},
@@ -309,7 +309,8 @@ func TestBuildEnv(t *testing.T) {
 	envExpected["HTTP_HOST"] = "localhost:2015"
 	envExpected["CUSTOM_URI"] = "custom_uri/fgci_test.php?test=blabla"
 	envExpected["CUSTOM_QUERY"] = "custom=true&test=blabla"
-	envExpected["HTTP_CADDY_REWRITE_ORIGINAL_URI"] = ""
+	httpFieldName := strings.ToUpper(internalRewriteFieldName)
+	envExpected["HTTP_"+httpFieldName] = ""
 	r.Header.Add(internalRewriteFieldName, "/apath/torewrite/index.php")
 	testBuildEnv(r, rule, fpath, envExpected)
 	if r.Header.Get(internalRewriteFieldName) == "" {

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -297,7 +297,7 @@ func TestBuildEnv(t *testing.T) {
 	envExpected["CUSTOM_QUERY"] = "custom=true&test=blabla"
 	testBuildEnv(r, rule, fpath, envExpected)
 
-	// 6. {>Caddy-Rewrite-Original-URI}
+	// 6. Test Caddy-Rewrite-Original-URI header is not removed
 	const internalRewriteFieldName = "Caddy-Rewrite-Original-URI"
 	r = newReq()
 	rule.EnvVars = [][2]string{

--- a/caddyhttp/fastcgi/setup_test.go
+++ b/caddyhttp/fastcgi/setup_test.go
@@ -125,6 +125,17 @@ func TestFastcgiParse(t *testing.T) {
 				dialer:     &persistentDialer{size: 5, network: network, address: address},
 				IndexFiles: []string{},
 			}}},
+		{`fastcgi / ` + defaultAddress + ` {
+	              split .php
+	              }`,
+			false, []Rule{{
+				Path:       "/",
+				Address:    defaultAddress,
+				Ext:        "",
+				SplitPath:  ".php",
+				dialer:     basicDialer{network: network, address: address},
+				IndexFiles: []string{},
+			}}},
 	}
 	for i, test := range tests {
 		actualFastcgiConfigs, err := fastcgiParse(caddy.NewTestController("http", test.inputFastcgiConfig))

--- a/caddyhttp/markdown/summary/render.go
+++ b/caddyhttp/markdown/summary/render.go
@@ -24,7 +24,7 @@ func (r renderer) BlockCode(out *bytes.Buffer, text []byte, land string) {}
 func (r renderer) BlockQuote(out *bytes.Buffer, text []byte) {}
 
 // BlockHtml is the HTML tag callback.
-func (r renderer) BlockHtml(out *bytes.Buffer, text []byte) {}
+func (r renderer) BlockHTML(out *bytes.Buffer, text []byte) {}
 
 // Header is the header tag callback.
 func (r renderer) Header(out *bytes.Buffer, text func() bool, level int, id string) {}
@@ -115,7 +115,7 @@ func (r renderer) Link(out *bytes.Buffer, link []byte, title []byte, content []b
 }
 
 // RawHtmlTag is the raw HTML tag callback.
-func (r renderer) RawHtmlTag(out *bytes.Buffer, tag []byte) {}
+func (r renderer) RawHTMLTag(out *bytes.Buffer, tag []byte) {}
 
 // TripleEmphasis is the triple emphasis tag callback.  Outputs a simple plain-text
 // version of the input.

--- a/caddyhttp/markdown/summary/render.go
+++ b/caddyhttp/markdown/summary/render.go
@@ -24,7 +24,7 @@ func (r renderer) BlockCode(out *bytes.Buffer, text []byte, land string) {}
 func (r renderer) BlockQuote(out *bytes.Buffer, text []byte) {}
 
 // BlockHtml is the HTML tag callback.
-func (r renderer) BlockHTML(out *bytes.Buffer, text []byte) {}
+func (r renderer) BlockHtml(out *bytes.Buffer, text []byte) {}
 
 // Header is the header tag callback.
 func (r renderer) Header(out *bytes.Buffer, text func() bool, level int, id string) {}
@@ -115,7 +115,7 @@ func (r renderer) Link(out *bytes.Buffer, link []byte, title []byte, content []b
 }
 
 // RawHtmlTag is the raw HTML tag callback.
-func (r renderer) RawHTMLTag(out *bytes.Buffer, tag []byte) {}
+func (r renderer) RawHtmlTag(out *bytes.Buffer, tag []byte) {}
 
 // TripleEmphasis is the triple emphasis tag callback.  Outputs a simple plain-text
 // version of the input.


### PR DESCRIPTION
Preventing the deletion of  `Caddy-Rewrite-Original-URI` from header allows php fastcgi apps to correctly log the url requested.

With my basic testing seems to fix #1153 

I do not have enough knowledge to know if the other lines in the if statement are relevant or should also be removed.