### PR TITLE
add separate upstart scripts for centos 6 and ubuntu 12.04

### DIFF
--- a/dist/init/linux-upstart/README.md
+++ b/dist/init/linux-upstart/README.md
@@ -8,7 +8,7 @@ Usage in this blogpost: [Running Caddy Server as a service with Upstart](https:/
 Short recap:
 
 * Download Caddy in `/usr/local/bin/caddy` and execute `sudo setcap cap_net_bind_service=+ep /usr/local/bin/caddy`.
-* Save the upstart config file in `/etc/init/caddy.conf`.
+* Save the appropriate upstart config file in `/etc/init/caddy.conf`.
 * Ensure that the folder `/etc/caddy` exists and that the subfolder .caddy is owned by `www-data`.
 * Create a Caddyfile in `/etc/caddy/Caddyfile`.
 * Now you can use `sudo service caddy start|stop|restart`.

--- a/dist/init/linux-upstart/caddy.conf.centos-6
+++ b/dist/init/linux-upstart/caddy.conf.centos-6
@@ -1,0 +1,28 @@
+description "Caddy HTTP/2 web server"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+# centos 6 upstart version does not support console
+console log
+
+# centos 6 upstart version does not support setuid/setgid
+setuid www-data
+setgid www-data
+
+respawn
+respawn limit 10 5
+
+# centos 6 upstart version does not support reload
+reload signal SIGUSR1
+
+# Let's Encrypt certificates will be written to this directory.
+env HOME=/etc/caddy
+
+limit nofile 1048576 1048576
+
+script
+        cd /etc/caddy
+        rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
+        exec /usr/local/bin/caddy -agree -log=stdout -conf=/etc/caddy/Caddyfile -root=$rootdir
+end script

--- a/dist/init/linux-upstart/caddy.conf.ubuntu-12.04
+++ b/dist/init/linux-upstart/caddy.conf.ubuntu-12.04
@@ -1,0 +1,26 @@
+description "Caddy HTTP/2 web server"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+console log
+
+setuid www-data
+setgid www-data
+
+respawn
+respawn limit 10 5
+
+# 12.04 upstart version does not support reload
+#reload signal SIGUSR1
+
+# Let's Encrypt certificates will be written to this directory.
+env HOME=/etc/caddy
+
+limit nofile 1048576 1048576
+
+script
+        cd /etc/caddy
+        rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
+        exec /usr/local/bin/caddy -agree -log=stdout -conf=/etc/caddy/Caddyfile -root=$rootdir
+end script


### PR DESCRIPTION
The upstart versions of centos 6 and ubuntu 12.04 are missing features that are configured in the current upstart file. This PR adds separate files for these OSes.