### PR TITLE
Log Site start to -log. Fix for #1205

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -363,6 +363,8 @@ func (s *Server) OnStartupComplete() {
 			output += " (only accessible on this machine)"
 		}
 		fmt.Println(output)
+		//Also print to -log.
+		log.Println(output)
 	}
 }
 

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -363,7 +363,6 @@ func (s *Server) OnStartupComplete() {
 			output += " (only accessible on this machine)"
 		}
 		fmt.Println(output)
-		//Also print to -log.
 		log.Println(output)
 	}
 }


### PR DESCRIPTION
This is a 1 line fix for #1205. 

Details of each site started will be written to Log as well as stdout.

I dont think this needs a test case. 