### PR TITLE
Starting possible fix for #1200

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -98,11 +98,17 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 			}
 		}
 
-		hadTrailingSlash := strings.HasSuffix(req.URL.Path, "/")
-		req.URL.Path = path.Join(target.Path, req.URL.Path)
-		// path.Join will strip off the last /, so put it back if it was there.
-		if hadTrailingSlash && !strings.HasSuffix(req.URL.Path, "/") {
-			req.URL.Path = req.URL.Path + "/"
+		//If there is no query, there is no ? so proxy destination is the begining of a path.
+		//Otherwise simply proxy to address and discard additional path information.
+		if target.RawQuery == "" {
+			hadTrailingSlash := strings.HasSuffix(req.URL.Path, "/")
+			req.URL.Path = path.Join(target.Path, req.URL.Path)
+			// path.Join will strip off the last /, so put it back if it was there.
+			if hadTrailingSlash && !strings.HasSuffix(req.URL.Path, "/") {
+				req.URL.Path = req.URL.Path + "/"
+			}
+		} else {
+			req.URL.Path = target.Path
 		}
 
 		// Trims the path of the socket from the URL path.


### PR DESCRIPTION
I wanted to see if we were happy with the direction of this fix for #1200

If the proxy address has a query on the end ?some=value then discard any additional path information .
eg

```
localhost:8001
proxy / localhost:4151/pub?topic=caddy
```

then the url `localhost:8001/big/long/url/index.php?other=value`

would proxy to `localhost:4151/pub?topic=caddy&other=value`

the information contained in `big/long/url/index.php` is discarded.

Is this the desired behaviour?

ps. I know I will need to add test before submitting.
