### PR TITLE
Add Sec-Websocket-Protocol header to websocket preset.

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -323,6 +323,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 	case "websocket":
 		u.upstreamHeaders.Add("Connection", "{>Connection}")
 		u.upstreamHeaders.Add("Upgrade", "{>Upgrade}")
+		u.upstreamHeaders.Add("Sec-Websocket-Protocol", "{>Sec-Websocket-Protocol}")
 	case "without":
 		if !c.NextArg() {
 			return c.ArgErr()


### PR DESCRIPTION
As requested in #1170, this change adds the Sec-Websocket-Protocol header to the proxy directive's "websocket" preset. It also refactors the test.