### PR TITLE
Filter empty headers

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -273,7 +273,10 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) 
 	for ruleField, ruleValues := range rules {
 		if strings.HasPrefix(ruleField, "+") {
 			for _, ruleValue := range ruleValues {
-				headers.Add(strings.TrimPrefix(ruleField, "+"), repl.Replace(ruleValue))
+				var replacement = repl.Replace(ruleValue)
+				if len(replacement) > 0 {
+					headers.Add(strings.TrimPrefix(ruleField, "+"), replacement)
+				}
 			}
 		} else if strings.HasPrefix(ruleField, "-") {
 			headers.Del(strings.TrimPrefix(ruleField, "-"))

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -273,7 +273,7 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) 
 	for ruleField, ruleValues := range rules {
 		if strings.HasPrefix(ruleField, "+") {
 			for _, ruleValue := range ruleValues {
-				var replacement = repl.Replace(ruleValue)
+				replacement := repl.Replace(ruleValue)
 				if len(replacement) > 0 {
 					headers.Add(strings.TrimPrefix(ruleField, "+"), replacement)
 				}
@@ -281,7 +281,7 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) 
 		} else if strings.HasPrefix(ruleField, "-") {
 			headers.Del(strings.TrimPrefix(ruleField, "-"))
 		} else if len(ruleValues) > 0 {
-			var replacement = repl.Replace(ruleValues[len(ruleValues)-1])
+			replacement := repl.Replace(ruleValues[len(ruleValues)-1])
 			if len(replacement) > 0 {
 				headers.Set(ruleField, replacement)
 			}

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -278,7 +278,10 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) 
 		} else if strings.HasPrefix(ruleField, "-") {
 			headers.Del(strings.TrimPrefix(ruleField, "-"))
 		} else if len(ruleValues) > 0 {
-			headers.Set(ruleField, repl.Replace(ruleValues[len(ruleValues)-1]))
+			var replacement = repl.Replace(ruleValues[len(ruleValues)-1])
+			if len(replacement) > 0 {
+				headers.Set(ruleField, replacement)
+			}
 		}
 	}
 }

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -408,6 +408,7 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 		"+Add-Me":    {"Add-Value"},
 		"-Remove-Me": {""},
 		"Replace-Me": {"{hostname}"},
+		"Clear-Me":   {""},
 		"Host":       {"{>Host}"},
 	}
 	// set up proxy
@@ -458,6 +459,11 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 	if !reflect.DeepEqual(got, expect) {
 		t.Errorf("Request sent to upstream backend does not contain expected %v header: expect %v, but got %v",
 			headerKey, expect, got)
+	}
+
+	headerKey = "Clear-Me"
+	if _, ok := actualHeaders[headerKey]; ok {
+		t.Errorf("Request sent to upstream backend should not contain empty %v header", headerKey)
 	}
 
 	if actualHost != expectHost {

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -406,6 +406,7 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 		"Upgrade":    {"{>Upgrade}"},
 		"+Merge-Me":  {"Merge-Value"},
 		"+Add-Me":    {"Add-Value"},
+		"+Add-Empty": {"{}"},
 		"-Remove-Me": {""},
 		"Replace-Me": {"{hostname}"},
 		"Clear-Me":   {""},
@@ -446,6 +447,11 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 	if !reflect.DeepEqual(got, expect) {
 		t.Errorf("Request sent to upstream backend does not contain expected %v header: expect %v, but got %v",
 			headerKey, expect, got)
+	}
+
+	headerKey = "Add-Empty"
+	if _, ok := actualHeaders[headerKey]; ok {
+		t.Errorf("Request sent to upstream backend should not contain empty %v header", headerKey)
 	}
 
 	headerKey = "Remove-Me"


### PR DESCRIPTION
Some web servers (e.g. Jetty 9.3) don’t like HTTP headers with empty values. This commit filters header replacements with zero length.

Should fixes #1225 