### PR TITLE
trial fix for #1200 with log

### DIFF
--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -56,9 +56,7 @@ func TestReverseProxy(t *testing.T) {
 	// Make sure {upstream} placeholder is set
 	rr := httpserver.NewResponseRecorder(httptest.NewRecorder())
 	rr.Replacer = httpserver.NewReplacer(r, rr, "-")
-
 	p.ServeHTTP(rr, r)
-
 	if got, want := rr.Replacer.Replace("{upstream}"), backend.URL; got != want {
 		t.Errorf("Expected custom placeholder {upstream} to be set (%s), but it wasn't; got: %s", want, got)
 	}
@@ -816,6 +814,11 @@ func TestProxyDirectorURL(t *testing.T) {
 			requestURL: `http://localhost:2020/test/`,
 			targetURL:  `https://localhost:2021/t/`,
 			expectURL:  `https://localhost:2021/t/test/`,
+		},
+		{
+			requestURL: `http://localhost:2020/`,
+			targetURL:  `https://localhost:2021/t?foo%3dbar`,
+			expectURL:  `https://localhost:2021/t?foo%3dbar`,
 		},
 	} {
 		targetURL, err := url.Parse(c.targetURL)

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -98,9 +98,8 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 			}
 		}
 
-		//If Empty path dont join path to avoid additional /
-		//fix for 1200
-		if req.URL.Path == "/" {
+		// If Empty path dont join path to avoid additional "/" (issue 1200)
+		if req.URL.Path == "/" && target.Path != "" {
 			req.URL.Path = target.Path
 		} else {
 			hadTrailingSlash := strings.HasSuffix(req.URL.Path, "/")

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -129,7 +129,6 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
-		log.Printf("[INFO] Proxied Query:%s", req.URL)
 	}
 	rp := &ReverseProxy{Director: director, FlushInterval: 250 * time.Millisecond} // flushing good for streaming & server-sent events
 	if target.Scheme == "unix" {

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -14,7 +14,6 @@ package proxy
 import (
 	"crypto/tls"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
So I have fixed the immediate issue but need help with the next step.  The code submitted does as requested.

caddyfile

    localhost:8001
    proxy / localhost:4151/pub?topic=caddy

request `localhost:8001`  will now create a proxy url out to  `localhost:4151/pub?topic=caddy`

You can see this if you run `caddy -log` as you will get 

    [INFO] Proxied Query:localhost:4151/pub?topic=caddy

However the actual proxied url is 

    localhost:4151/pub/?topic=caddy

so more code somewhere else is adding the / in.  From investigations I would imagine the url is being split again and then joined which causes this extra / to be added. 

I do not know enough about `go` or `caddy` to be able to find the possible places this is happening.  Perhaps some pointers from @mholt  or others would help.

PS. If building and testing from this branch, I recommend using curl to test as the browser caches and makes it difficult to test.