### PR TITLE
Add connect_timeout and read_timeout to fastcgi.

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
@@ -81,6 +82,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 			if err != nil {
 				return http.StatusBadGateway, err
 			}
+			fcgiBackend.ReadTimeout = rule.ReadTimeout
 
 			var resp *http.Response
 			contentLength, _ := strconv.Atoi(r.Header.Get("Content-Length"))
@@ -300,6 +302,9 @@ type Rule struct {
 
 	// Ignored paths
 	IgnoredSubPaths []string
+
+	// The duration used to set a deadline when reading from the FastCGI server.
+	ReadTimeout time.Duration
 
 	// FCGI dialer
 	dialer dialer

--- a/caddyhttp/fastcgi/fcgiclient_test.go
+++ b/caddyhttp/fastcgi/fcgiclient_test.go
@@ -103,7 +103,7 @@ func (s FastCGIServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 }
 
 func sendFcgi(reqType int, fcgiParams map[string]string, data []byte, posts map[string]string, files map[string]string) (content []byte) {
-	fcgi, err := Dial("tcp", ipPort)
+	fcgi, err := Dial("tcp", ipPort, 0)
 	if err != nil {
 		log.Println("err:", err)
 		return

--- a/caddyhttp/fastcgi/setup_test.go
+++ b/caddyhttp/fastcgi/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -135,6 +136,29 @@ func TestFastcgiParse(t *testing.T) {
 				SplitPath:  ".php",
 				dialer:     basicDialer{network: network, address: address},
 				IndexFiles: []string{},
+			}}},
+		{`fastcgi / ` + defaultAddress + ` {
+	              connect_timeout 5s
+	              }`,
+			false, []Rule{{
+				Path:       "/",
+				Address:    defaultAddress,
+				Ext:        "",
+				SplitPath:  "",
+				dialer:     basicDialer{network: network, address: address, timeout: 5 * time.Second},
+				IndexFiles: []string{},
+			}}},
+		{`fastcgi / ` + defaultAddress + ` {
+	              read_timeout 5s
+	              }`,
+			false, []Rule{{
+				Path:        "/",
+				Address:     defaultAddress,
+				Ext:         "",
+				SplitPath:   "",
+				dialer:      basicDialer{network: network, address: address},
+				IndexFiles:  []string{},
+				ReadTimeout: 5 * time.Second,
 			}}},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
Hi,

Here's a summary of the changes for #1094 , as well as some questions/concerns.

### Connect Timeout

I added a new connect_timeout property to the fastcgi directive, e.g.:

	fastcgi / 127.0.0.1:9000 {
		connect_timeout 10s
	}

I can test the new property using docker-compose: use iptables on the proxy 
and drop packets that are outbound to the FastCGI service.

I'm having a hard time writing a test for it. I combed through the net
package to find some way to generate a i/o timeout but found nothing. Some
[tests](https://golang.org/src/net/timeout_test.go) in the net package use
internal packages-those appear to be the ones with which the connection can be
impeded.

Any suggestions on how to test this while continuing to use net.Dialer?

### Read Timeout

Similarly, here's the new read_timeout property:

	fastcgi / 127.0.0.1:9000 {
		read_timeout 10s
	}

I ended up assigning a deadline in streamReader.Read(), but had to use a
type assertion in order to assign the value. I *think* this is the right place,
or close, but I'm not so sure about the type assertion.

At any rate, feedback appreciated!