### PR TITLE
launchd service file for Mac

### DIFF
--- a/dist/init/mac-launchd/README.md
+++ b/dist/init/mac-launchd/README.md
@@ -1,0 +1,12 @@
+launchd service for macOS
+=========================
+
+This is a sample file for a *launchd* service on Mac.
+Edit the paths and email in the plist file to match your info.
+
+Start and Stop the Caddy launchd service using the following commands:
+
+    $ launchctl load ~/Library/LaunchAgents/com.caddyserver.web.plist
+    $ launchctl unload ~/Library/LaunchAgents/com.caddyserver.web.plist
+
+More information can be found in this blogpost: [Running Caddy as a service on macOS X server](https://denbeke.be/blog/software/running-caddy-as-a-service-on-macos-os-x-server/)

--- a/dist/init/mac-launchd/com.caddyserver.web.plist
+++ b/dist/init/mac-launchd/com.caddyserver.web.plist
@@ -1,0 +1,31 @@
+<?xml version=”1.0" encoding=”UTF-8"?>
+<!DOCTYPE plist PUBLIC “-//Apple Computer//DTD PLIST 1.0//EN” “http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version=”1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.caddyserver.web</string>
+        <key>EnvironmentVariables</key>
+        <dict>
+            <key>HOME</key>
+            <string>/Users/mathias</string>
+        </dict>
+        <key>ProgramArguments</key>
+        <array>
+            <string>sh</string>
+            <string>-c</string>
+            <string>ulimit -n 8192; cd /Users/mathias/Sites; ./caddy -agree -email my_email@domain.com -conf=/Users/mathias/Sites/Caddyfile</string>
+        </array>
+        <key>UserName</key>
+        <string>www</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>/Users/mathias/Sites</string>
+        <key>StandardOutPath</key>
+        <string>/Users/mathias/Sites/caddy.log</string>
+        <key>StandardErrorPath</key>
+        <string>/Users/mathias/Sites/caddy_error.log</string>
+    </dict>
+</plist>


### PR DESCRIPTION
I added the *launchd* service file from my blogpost to the *init* folder.

It's not as good as the Linux ones because paths are not that fixed on Mac. So users can put Caddy wherever they want. But I figured out that adding a sample plist file would be useful.