### PR TITLE
Sort the resulting slice before the comparison.

### DIFF
--- a/caddyhttp/httpserver/context_test.go
+++ b/caddyhttp/httpserver/context_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -766,9 +767,12 @@ func TestFiles(t *testing.T) {
 			if numFiles == 0 && len(actual) != 0 {
 				t.Errorf(testPrefix+"Expected files %v, got: %v",
 					test.fileNames, actual)
-			} else if numFiles > 0 && !reflect.DeepEqual(test.fileNames, actual) {
-				t.Errorf(testPrefix+"Expected files %v, got: %v",
-					test.fileNames, actual)
+			} else {
+				sort.Strings(actual)
+				if numFiles > 0 && !reflect.DeepEqual(test.fileNames, actual) {
+					t.Errorf(testPrefix+"Expected files %v, got: %v",
+						test.fileNames, actual)
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a minor fix for an intermittent failure by TestFiles:

	--- FAIL: TestFiles (0.00s)
		context_test.go:771: Test [1]: Expected files [file1 file2], got: [file2 file1]
	FAIL
	FAIL	github.com/mholt/caddy/caddyhttp/httpserver	0.050s

Since Files() does not guarantee the order of the files returned, the test sorts the resulting slice before comparing to the expected one.