### PR TITLE
Init switch from HOME to Caddy

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -12,7 +12,7 @@ User=www-data
 Group=www-data
 
 ; Letsencrypt-issued certificates will be written to this directory.
-Environment=HOME=/etc/ssl/caddy
+Environment=CADDYPATH=/etc/ssl/caddy
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
 ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp

--- a/dist/init/linux-upstart/caddy.conf
+++ b/dist/init/linux-upstart/caddy.conf
@@ -14,7 +14,7 @@ respawn limit 10 5
 reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env HOME=/etc/caddy
+env CADDYPATH =/etc/caddy
 
 limit nofile 1048576 1048576
 

--- a/dist/init/linux-upstart/caddy.conf.centos-6
+++ b/dist/init/linux-upstart/caddy.conf.centos-6
@@ -17,7 +17,7 @@ respawn limit 10 5
 reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env HOME=/etc/caddy
+env CADDYPATH=/etc/caddy
 
 limit nofile 1048576 1048576
 

--- a/dist/init/linux-upstart/caddy.conf.ubuntu-12.04
+++ b/dist/init/linux-upstart/caddy.conf.ubuntu-12.04
@@ -15,7 +15,7 @@ respawn limit 10 5
 #reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env HOME=/etc/caddy
+env CADDYPATH=/etc/caddy
 
 limit nofile 1048576 1048576
 


### PR DESCRIPTION
Maybe make the path also equal, i found:
- `/etc/ssl/caddy`
- `/etc/caddy`
- `/etc/caddy/ssl`

And for MAC, i do not know :sweat_smile:

