### PR TITLE
Fix issue #1258

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -232,13 +232,16 @@ func HasListenerWithAddress(addr string) bool {
 func listenerAddrEqual(ln net.Listener, addr string) bool {
 	lnAddr := ln.Addr().String()
 	hostname, port, err := net.SplitHostPort(addr)
-	if err != nil || hostname != "" {
+	if err != nil {
 		return lnAddr == addr
 	}
 	if lnAddr == net.JoinHostPort("::", port) {
 		return true
 	}
 	if lnAddr == net.JoinHostPort("0.0.0.0", port) {
+		return true
+	}
+	if hostname != "" && lnAddr == addr {
 		return true
 	}
 	return false

--- a/caddy.go
+++ b/caddy.go
@@ -241,10 +241,7 @@ func listenerAddrEqual(ln net.Listener, addr string) bool {
 	if lnAddr == net.JoinHostPort("0.0.0.0", port) {
 		return true
 	}
-	if hostname != "" && lnAddr == addr {
-		return true
-	}
-	return false
+	return hostname != "" && lnAddr == addr
 }
 
 // TCPServer is a type that can listen and serve connections.

--- a/caddy_test.go
+++ b/caddy_test.go
@@ -1,6 +1,9 @@
 package caddy
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 /*
 // TODO
@@ -55,4 +58,39 @@ func TestIsLoopback(t *testing.T) {
 			t.Errorf("Test %d (%s): expected %v but was %v", i, test.input, want, got)
 		}
 	}
+}
+
+func TestListenerAddrEqual(t *testing.T) {
+	ln1, err := newLocalListener("[::]:2016")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln1.Close()
+
+	ln2, err := newLocalListener("[::]:2017")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln2.Close()
+
+	for i, test := range []struct {
+		ln     net.Listener
+		addr   string
+		expect bool
+	}{
+		{ln1, "0.0.0.0:2016", true},
+		{ln2, "0.0.0.0:2018", false},
+	} {
+		if got, want := listenerAddrEqual(test.ln, test.addr), test.expect; got != want {
+			t.Errorf("Test %d (%v == %v): expected %v but was %v", i, test.addr, test.ln.Addr().String(), want, got)
+		}
+	}
+}
+
+func newLocalListener(addr string) (net.Listener, error) {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return ln, nil
 }

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -113,7 +113,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 
 		// See if HTTP challenge needs to be proxied
 		useHTTPPort := "" // empty port value will use challenge default
-		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, HTTPChallengePort)) {
+		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, HTTPChallengePort)) || config.OnDemand {
 			useHTTPPort = config.AltHTTPPort
 			if useHTTPPort == "" {
 				useHTTPPort = DefaultHTTPAlternatePort
@@ -134,7 +134,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 		}
 
 		// See if TLS challenge needs to be handled by our own facilities
-		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, TLSSNIChallengePort)) {
+		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, TLSSNIChallengePort)) || config.OnDemand {
 			c.acmeClient.SetChallengeProvider(acme.TLSSNI01, tlsSniSolver{})
 		}
 	} else {

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -113,7 +113,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 
 		// See if HTTP challenge needs to be proxied
 		useHTTPPort := "" // empty port value will use challenge default
-		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, HTTPChallengePort)) || config.OnDemand {
+		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, HTTPChallengePort)) {
 			useHTTPPort = config.AltHTTPPort
 			if useHTTPPort == "" {
 				useHTTPPort = DefaultHTTPAlternatePort
@@ -134,7 +134,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 		}
 
 		// See if TLS challenge needs to be handled by our own facilities
-		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, TLSSNIChallengePort)) || config.OnDemand {
+		if caddy.HasListenerWithAddress(net.JoinHostPort(config.ListenHost, TLSSNIChallengePort)) {
 			c.acmeClient.SetChallengeProvider(acme.TLSSNI01, tlsSniSolver{})
 		}
 	} else {


### PR DESCRIPTION
Hello @mholt ,

this PR should fix issue #1258:

```
2016/11/24 16:10:41 [INFO] Obtaining new certificate for 1.caddy.domain.com
2016/11/24 16:10:42 [INFO] acme: Registering account for
2016/11/24 16:10:42 [INFO][1.caddy.domain.com] acme: Obtaining bundled SAN certificate
2016/11/24 16:10:43 [INFO][1.caddy.domain.com] acme: Trying to solve TLS-SNI-01
2016/11/24 16:10:45 [INFO][1.caddy.domain.com] The server validated our request
2016/11/24 16:10:45 [INFO][1.caddy.domain.com] acme: Validations succeeded; requesting certificates
2016/11/24 16:10:46 [INFO] acme: Requesting issuer cert from https://acme-staging.api.letsencrypt.org/acme/issuer-cert
2016/11/24 16:10:46 [INFO][1.caddy.domain.com] Server responded with a certificate.
2016/11/24 16:10:46 [WARNING] Stapling OCSP: no OCSP stapling for [1.caddy.domain.com]: ocsp: error from server: unauthorized
2016/11/24 16:10:53 [INFO] Obtaining new certificate for 2.caddy.domain.com
2016/11/24 16:10:53 [INFO][2.caddy.domain.com] acme: Obtaining bundled SAN certificate
2016/11/24 16:10:53 [INFO][2.caddy.domain.com] acme: Could not find solver for: dns-01
2016/11/24 16:10:53 [INFO][2.caddy.domain.com] acme: Trying to solve HTTP-01
2016/11/24 16:10:54 [INFO][2.caddy.domain.com] Served key authentication
2016/11/24 16:10:55 [INFO][2.caddy.domain.com] The server validated our request
2016/11/24 16:10:55 [INFO][2.caddy.domain.com] acme: Validations succeeded; requesting certificates
2016/11/24 16:10:56 [INFO] acme: Requesting issuer cert from https://acme-staging.api.letsencrypt.org/acme/issuer-cert
2016/11/24 16:10:56 [INFO][2.caddy.domain.com] Server responded with a certificate.
2016/11/24 16:10:56 [WARNING] Stapling OCSP: no OCSP stapling for [2.caddy.domain.com]: ocsp: error from server: unauthorized
2016/11/24 16:11:04 [INFO] Obtaining new certificate for 3.caddy.domain.com
2016/11/24 16:11:04 [INFO][3.caddy.domain.com] acme: Obtaining bundled SAN certificate
2016/11/24 16:11:04 [INFO][3.caddy.domain.com] acme: Trying to solve TLS-SNI-01
2016/11/24 16:11:06 [INFO][3.caddy.domain.com] The server validated our request
2016/11/24 16:11:06 [INFO][3.caddy.domain.com] acme: Validations succeeded; requesting certificates
2016/11/24 16:11:07 [INFO] acme: Requesting issuer cert from https://acme-staging.api.letsencrypt.org/acme/issuer-cert
2016/11/24 16:11:07 [INFO][3.caddy.domain.com] Server responded with a certificate.
2016/11/24 16:11:07 [WARNING] Stapling OCSP: no OCSP stapling for [3.caddy.domain.com]: ocsp: error from server: unauthorized
2016/11/24 16:11:40 [INFO] Obtaining new certificate for 4.caddy.domain.com
2016/11/24 16:11:40 [INFO][4.caddy.domain.com] acme: Obtaining bundled SAN certificate
2016/11/24 16:11:40 [INFO][4.caddy.domain.com] acme: Trying to solve HTTP-01
2016/11/24 16:11:41 [INFO][4.caddy.domain.com] Served key authentication
2016/11/24 16:11:42 [INFO][4.caddy.domain.com] The server validated our request
2016/11/24 16:11:42 [INFO][4.caddy.domain.com] acme: Validations succeeded; requesting certificates
2016/11/24 16:11:42 [INFO] acme: Requesting issuer cert from https://acme-staging.api.letsencrypt.org/acme/issuer-cert
2016/11/24 16:11:42 [INFO][4.caddy.domain.com] Server responded with a certificate.
```