### PR TITLE
Increase code coverage (caddy.go)

### DIFF
--- a/caddy_test.go
+++ b/caddy_test.go
@@ -85,10 +85,12 @@ func TestListenerAddrEqual(t *testing.T) {
 	}{
 		{ln1, ":1234", false},
 		{ln1, "0.0.0.0:1234", false},
+		{ln1, "0.0.0.0", false},
 		{ln1, ":" + ln1port + "", true},
 		{ln1, "0.0.0.0:" + ln1port + "", true},
-		{ln2, "127.0.0.1:1234", false},
 		{ln2, ":" + ln2port + "", false},
+		{ln2, "127.0.0.1:1234", false},
+		{ln2, "127.0.0.1", false},
 		{ln2, "127.0.0.1:" + ln2port + "", true},
 	} {
 		if got, want := listenerAddrEqual(test.ln, test.addr), test.expect; got != want {


### PR DESCRIPTION
This PR increases code coverage:

I cannot trigger (see below), as `ln, err := net.Listen("tcp", "[::]:0") == ln, err := net.Listen("tcp", "0.0.0.0:0")`!

```
if lnAddr == net.JoinHostPort("0.0.0.0", port) {  //covered
                return true // not covered
} //covered
```

Soon,

Eldin 😄 

P.S.: Sorry for the separate PR, you pushed my PR a little bit too fast (I was 😴 ) -- I guess it´s not a big problem? 