### PR TITLE
Add send_timeout property to fastcgi directive

### DIFF
--- a/caddyhttp/fastcgi/dialer.go
+++ b/caddyhttp/fastcgi/dialer.go
@@ -19,8 +19,11 @@ type basicDialer struct {
 	timeout time.Duration
 }
 
-func (b basicDialer) Dial() (Client, error) { return Dial(b.network, b.address, b.timeout) }
-func (b basicDialer) Close(c Client) error  { return c.Close() }
+func (b basicDialer) Dial() (Client, error) {
+	return DialTimeout(b.network, b.address, b.timeout)
+}
+
+func (b basicDialer) Close(c Client) error { return c.Close() }
 
 // persistentDialer keeps a pool of fcgi connections.
 // connections are not closed after use, rather added back to the pool for reuse.
@@ -47,7 +50,7 @@ func (p *persistentDialer) Dial() (Client, error) {
 	p.Unlock()
 
 	// no connection available, create new one
-	return Dial(p.network, p.address, p.timeout)
+	return DialTimeout(p.network, p.address, p.timeout)
 }
 
 func (p *persistentDialer) Close(client Client) error {

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -81,6 +81,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 			// Connect to FastCGI gateway
 			fcgiBackend, err := rule.dialer.Dial()
 			if err != nil {
+				if err, ok := err.(net.Error); ok && err.Timeout() {
+					return http.StatusGatewayTimeout, err
+				}
 				return http.StatusBadGateway, err
 			}
 			defer fcgiBackend.Close()

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -327,38 +327,124 @@ func TestBuildEnv(t *testing.T) {
 }
 
 func TestReadTimeout(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Unable to create listener for test: %v", err)
+	tests := []struct {
+		sleep       time.Duration
+		readTimeout time.Duration
+		shouldErr   bool
+	}{
+		{75 * time.Millisecond, 50 * time.Millisecond, true},
+		{0, -1 * time.Second, true},
+		{0, time.Minute, false},
 	}
-	defer listener.Close()
 
-	network, address := parseAddress(listener.Addr().String())
-	handler := Handler{
-		Next: nil,
-		Rules: []Rule{
-			{
-				Path:        "/",
-				Address:     listener.Addr().String(),
-				dialer:      basicDialer{network: network, address: address},
-				ReadTimeout: time.Millisecond * 100,
+	var wg sync.WaitGroup
+
+	for i, test := range tests {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("Test %d: Unable to create listener for test: %v", i, err)
+		}
+		defer listener.Close()
+
+		network, address := parseAddress(listener.Addr().String())
+		handler := Handler{
+			Next: nil,
+			Rules: []Rule{
+				{
+					Path:        "/",
+					Address:     listener.Addr().String(),
+					dialer:      basicDialer{network: network, address: address},
+					ReadTimeout: test.readTimeout,
+				},
 			},
-		},
-	}
-	r, err := http.NewRequest("GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Unable to create request: %v", err)
-	}
-	w := httptest.NewRecorder()
+		}
+		r, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fatalf("Test %d: Unable to create request: %v", i, err)
+		}
+		w := httptest.NewRecorder()
 
-	go fcgi.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(time.Millisecond * 130)
-	}))
+		wg.Add(1)
+		go fcgi.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(test.sleep)
+			w.WriteHeader(http.StatusOK)
+			wg.Done()
+		}))
 
-	_, err = handler.ServeHTTP(w, r)
-	if err == nil {
-		t.Error("Expected i/o timeout error but had none")
-	} else if err, ok := err.(net.Error); !ok || !err.Timeout() {
-		t.Errorf("Expected i/o timeout error, got: '%s'", err.Error())
+		got, err := handler.ServeHTTP(w, r)
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %d: Expected i/o timeout error but had none", i)
+			} else if err, ok := err.(net.Error); !ok || !err.Timeout() {
+				t.Errorf("Test %d: Expected i/o timeout error, got: '%s'", i, err.Error())
+			}
+
+			want := http.StatusGatewayTimeout
+			if got != want {
+				t.Errorf("Test %d: Expected returned status code to be %d, got: %d",
+					i, want, got)
+			}
+		} else if err != nil {
+			t.Errorf("Test %d: Expected nil error, got: %v", i, err)
+		}
+
+		wg.Wait()
+	}
+}
+
+func TestSendTimeout(t *testing.T) {
+	tests := []struct {
+		sendTimeout time.Duration
+		shouldErr   bool
+	}{
+		{-1 * time.Second, true},
+		{time.Minute, false},
+	}
+
+	for i, test := range tests {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("Test %d: Unable to create listener for test: %v", i, err)
+		}
+		defer listener.Close()
+
+		network, address := parseAddress(listener.Addr().String())
+		handler := Handler{
+			Next: nil,
+			Rules: []Rule{
+				{
+					Path:        "/",
+					Address:     listener.Addr().String(),
+					dialer:      basicDialer{network: network, address: address},
+					SendTimeout: test.sendTimeout,
+				},
+			},
+		}
+		r, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fatalf("Test %d: Unable to create request: %v", i, err)
+		}
+		w := httptest.NewRecorder()
+
+		go fcgi.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		got, err := handler.ServeHTTP(w, r)
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Test %d: Expected i/o timeout error but had none", i)
+			} else if err, ok := err.(net.Error); !ok || !err.Timeout() {
+				t.Errorf("Test %d: Expected i/o timeout error, got: '%s'", i, err.Error())
+			}
+
+			want := http.StatusGatewayTimeout
+			if got != want {
+				t.Errorf("Test %d: Expected returned status code to be %d, got: %d",
+					i, want, got)
+			}
+		} else if err != nil {
+			t.Errorf("Test %d: Expected nil error, got: %v", i, err)
+		}
 	}
 }

--- a/caddyhttp/fastcgi/fcgiclient_test.go
+++ b/caddyhttp/fastcgi/fcgiclient_test.go
@@ -103,7 +103,7 @@ func (s FastCGIServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 }
 
 func sendFcgi(reqType int, fcgiParams map[string]string, data []byte, posts map[string]string, files map[string]string) (content []byte) {
-	fcgi, err := Dial("tcp", ipPort, 0)
+	fcgi, err := DialTimeout("tcp", ipPort, 0)
 	if err != nil {
 		log.Println("err:", err)
 		return

--- a/caddyhttp/fastcgi/setup.go
+++ b/caddyhttp/fastcgi/setup.go
@@ -59,7 +59,7 @@ func fastcgiParse(c *caddy.Controller) ([]Rule, error) {
 			return rules, c.ArgErr()
 		}
 
-		rule := Rule{Path: args[0], ReadTimeout: 60 * time.Second}
+		rule := Rule{Path: args[0], ReadTimeout: 60 * time.Second, SendTimeout: 60 * time.Second}
 		upstreams := []string{args[1]}
 
 		if len(args) == 3 {
@@ -144,6 +144,15 @@ func fastcgiParse(c *caddy.Controller) ([]Rule, error) {
 					return rules, err
 				}
 				rule.ReadTimeout = readTimeout
+			case "send_timeout":
+				if !c.NextArg() {
+					return rules, c.ArgErr()
+				}
+				sendTimeout, err := time.ParseDuration(c.Val())
+				if err != nil {
+					return rules, err
+				}
+				rule.SendTimeout = sendTimeout
 			}
 		}
 


### PR DESCRIPTION
See #1094.

This update adds the send_timeout property to the fastcgi directive.

	fastcgi / 127.0.0.1:9000 {
		send_timeout 10s
	}

Like the connect_timeout and read_timeout properties, send_timeout has a default value of 60 seconds.

I added/refactored some tests along the way.
