### PR TITLE
Defer websocket body close

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -232,7 +232,7 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, 
 	}
 
 	if isWebsocket {
-		res.Body.Close()
+		defer res.Body.Close()
 		hj, ok := rw.(http.Hijacker)
 		if !ok {
 			panic(httpserver.NonHijackerError{Underlying: rw})


### PR DESCRIPTION
This defers the body close until the entire copy is complete.

I was having a problem with the websocket created by the Home Assistant (home-assistant.io) frontend getting proxied through Caddy. When I looked at the Wireshark capture the server was sending data but Caddy wasn't forwarding it. Eventually, I was able to isolate that Caddy was stopped at the `Close` call. Deferring this call allowed the data to pass and all work as expected.

I'm not entirely sure what the cause of the problem was (I'm not well-versed in the details of websockets). I suspect it has something to do with a comment I found in Caddy about the de-chunking which might be occurring