### PR TITLE
Implementing custom PathClean function to allow masking, closes #1298

### DIFF
--- a/caddyhttp/httpserver/pathcleaner.go
+++ b/caddyhttp/httpserver/pathcleaner.go
@@ -18,7 +18,7 @@ import (
 // (e.g., /api/endpoint/http://example.com).
 // This is a common pattern in many applications to allow passing URIs as path argument
 func CleanMaskedPath(p string, mask ...string) string {
-	t := ""
+	var t string
 	maskMap := make(map[string]string)
 
 	// Iterate over supplied masks and create temporary replacement strings

--- a/caddyhttp/httpserver/pathcleaner.go
+++ b/caddyhttp/httpserver/pathcleaner.go
@@ -49,7 +49,7 @@ func CleanPath(reqPath string) string {
 
 // An efficient and fast method for random string generation.
 // Inspired by http://stackoverflow.com/a/31832326.
-const randomStringLenght = 4
+const randomStringLength = 4
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const (
 	letterIdxBits = 6
@@ -60,8 +60,8 @@ const (
 var src = rand.NewSource(time.Now().UnixNano())
 
 func generateRandomString() string {
-	b := make([]byte, randomStringLenght)
-	for i, cache, remain := randomStringLenght-1, src.Int63(), letterIdxMax; i >= 0; {
+	b := make([]byte, randomStringLength)
+	for i, cache, remain := randomStringLength-1, src.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
 			cache, remain = src.Int63(), letterIdxMax
 		}

--- a/caddyhttp/httpserver/pathcleaner.go
+++ b/caddyhttp/httpserver/pathcleaner.go
@@ -1,0 +1,75 @@
+package httpserver
+
+import (
+	"math/rand"
+	"path"
+	"strings"
+	"time"
+)
+
+// A proxy function to prevent one or more of the path cleanup operations:
+//   - collapse multiple slashes into one
+//   - eliminate "/." (current directory)
+//   - eliminate "<parent_directory>/.."
+// by masking certain patterns in the path with a temporary random string.
+// This could be helpful when certain patterns in the path are desired
+// that would otherwise be changed in the path clean up process.
+// One such use case is the presence of the double slashes as protocol separator
+// (e.g., /api/endpoint/http://example.com).
+// This is a common pattern in many applications to allow passing URIs as path argument
+func CleanMaskedPath(p string, mask ...string) string {
+	t := ""
+	maskMap := make(map[string]string)
+
+	// Iterate over supplied masks and create temporary replacement strings
+	// only for the masks that are present in the path, then replace all occurrences
+	for _, m := range mask {
+		if strings.Index(p, m) >= 0 {
+			t = "/_caddy" + generateRandomString() + "__"
+			maskMap[m] = t
+			p = strings.Replace(p, m, t, -1)
+		}
+	}
+
+	p = path.Clean(p)
+
+	// Revert the replaced masks after path cleanup
+	for m, t := range maskMap {
+		p = strings.Replace(p, t, m, -1)
+	}
+	return p
+}
+
+func CleanPath(p string) string {
+	// Apply the default mask to preserve double slashes of protocols
+	// such as "http://", "https://", and "ftp://" etc.
+	return CleanMaskedPath(p, "://")
+}
+
+// The most efficient method for random string generation.
+// Inspired by http://stackoverflow.com/a/31832326.
+const randomStringLenght = 10
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6
+	letterIdxMask = 1<<letterIdxBits - 1
+	letterIdxMax  = 63 / letterIdxBits
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+func generateRandomString() string {
+	b := make([]byte, randomStringLenght)
+	for i, cache, remain := randomStringLenght-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return string(b)
+}

--- a/caddyhttp/httpserver/pathcleaner.go
+++ b/caddyhttp/httpserver/pathcleaner.go
@@ -43,8 +43,8 @@ func CleanMaskedPath(reqPath string, masks ...string) string {
 // CleanPath calls CleanMaskedPath() with the default mask of "://"
 // to preserve double slashes of protocols
 // such as "http://", "https://", and "ftp://" etc.
-func CleanPath(p string) string {
-	return CleanMaskedPath(p, "://")
+func CleanPath(reqPath string) string {
+	return CleanMaskedPath(reqPath, "://")
 }
 
 // An efficient and fast method for random string generation.

--- a/caddyhttp/httpserver/pathcleaner_test.go
+++ b/caddyhttp/httpserver/pathcleaner_test.go
@@ -1,0 +1,76 @@
+package httpserver
+
+import (
+	"path"
+	"testing"
+)
+
+var paths = map[string]map[string]string{
+	"/../a/b/../././/c": {
+		"preserve_all": "/../a/b/../././/c",
+		"preserve_protocol": "/a/c",
+		"preserve_slashes": "/a//c",
+		"preserve_dots": "/../a/b/../././c",
+		"clean_all": "/a/c",
+	},
+	"/path/https://www.google.com": {
+		"preserve_all": "/path/https://www.google.com",
+		"preserve_protocol": "/path/https://www.google.com",
+		"preserve_slashes": "/path/https://www.google.com",
+		"preserve_dots": "/path/https:/www.google.com",
+		"clean_all": "/path/https:/www.google.com",
+	},
+	"/a/b/../././/c/http://example.com/foo//bar/../blah": {
+		"preserve_all": "/a/b/../././/c/http://example.com/foo//bar/../blah",
+		"preserve_protocol": "/a/c/http://example.com/foo/blah",
+		"preserve_slashes": "/a//c/http://example.com/foo/blah",
+		"preserve_dots": "/a/b/../././c/http:/example.com/foo/bar/../blah",
+		"clean_all": "/a/c/http:/example.com/foo/blah",
+	},
+}
+
+func assertEqual(t *testing.T, exp, rcv string) {
+	if exp != rcv {
+		t.Errorf("\tExpected: %s\n\t\t\tRecieved: %s", exp, rcv)
+	}
+}
+
+func maskedTestRunner(t *testing.T, variation string, mask ...string) {
+	for p, v := range paths {
+		assertEqual(t, v[variation], CleanMaskedPath(p, mask...))
+	}
+}
+
+// No need to test the built-in `path.Clean()` function.
+// However, it is useful to cross-examine the test dataset.
+func TestPathClean(t *testing.T) {
+	for p, v := range paths {
+		assertEqual(t, v["clean_all"], path.Clean(p))
+	}
+}
+
+func TestCleanAll(t *testing.T) {
+	maskedTestRunner(t, "clean_all")
+}
+
+func TestPreserveAll(t *testing.T) {
+	maskedTestRunner(t, "preserve_all", "//", "/..", "/.")
+}
+
+func TestPreserveProtocol(t *testing.T) {
+	maskedTestRunner(t, "preserve_protocol", "://")
+}
+
+func TestPreserveSlashes(t *testing.T) {
+	maskedTestRunner(t, "preserve_slashes", "//")
+}
+
+func TestPreserveDots(t *testing.T) {
+	maskedTestRunner(t, "preserve_dots", "/..", "/.")
+}
+
+func TestDefaultMask(t *testing.T) {
+	for p, v := range paths {
+		assertEqual(t, v["preserve_protocol"], CleanPath(p))
+	}
+}

--- a/caddyhttp/httpserver/pathcleaner_test.go
+++ b/caddyhttp/httpserver/pathcleaner_test.go
@@ -7,25 +7,25 @@ import (
 
 var paths = map[string]map[string]string{
 	"/../a/b/../././/c": {
-		"preserve_all": "/../a/b/../././/c",
+		"preserve_all":      "/../a/b/../././/c",
 		"preserve_protocol": "/a/c",
-		"preserve_slashes": "/a//c",
-		"preserve_dots": "/../a/b/../././c",
-		"clean_all": "/a/c",
+		"preserve_slashes":  "/a//c",
+		"preserve_dots":     "/../a/b/../././c",
+		"clean_all":         "/a/c",
 	},
 	"/path/https://www.google.com": {
-		"preserve_all": "/path/https://www.google.com",
+		"preserve_all":      "/path/https://www.google.com",
 		"preserve_protocol": "/path/https://www.google.com",
-		"preserve_slashes": "/path/https://www.google.com",
-		"preserve_dots": "/path/https:/www.google.com",
-		"clean_all": "/path/https:/www.google.com",
+		"preserve_slashes":  "/path/https://www.google.com",
+		"preserve_dots":     "/path/https:/www.google.com",
+		"clean_all":         "/path/https:/www.google.com",
 	},
 	"/a/b/../././/c/http://example.com/foo//bar/../blah": {
-		"preserve_all": "/a/b/../././/c/http://example.com/foo//bar/../blah",
+		"preserve_all":      "/a/b/../././/c/http://example.com/foo//bar/../blah",
 		"preserve_protocol": "/a/c/http://example.com/foo/blah",
-		"preserve_slashes": "/a//c/http://example.com/foo/blah",
-		"preserve_dots": "/a/b/../././c/http:/example.com/foo/bar/../blah",
-		"clean_all": "/a/c/http:/example.com/foo/blah",
+		"preserve_slashes":  "/a//c/http://example.com/foo/blah",
+		"preserve_dots":     "/a/b/../././c/http:/example.com/foo/bar/../blah",
+		"clean_all":         "/a/c/http:/example.com/foo/blah",
 	},
 }
 

--- a/caddyhttp/httpserver/pathcleaner_test.go
+++ b/caddyhttp/httpserver/pathcleaner_test.go
@@ -77,7 +77,7 @@ func TestDefaultMask(t *testing.T) {
 
 func maskedBenchmarkRunner(b *testing.B, masks ...string) {
 	for n := 0; n < b.N; n++ {
-		for reqPath, _ := range paths {
+		for reqPath := range paths {
 			CleanMaskedPath(reqPath, masks...)
 		}
 	}
@@ -85,7 +85,7 @@ func maskedBenchmarkRunner(b *testing.B, masks ...string) {
 
 func BenchmarkPathClean(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		for reqPath, _ := range paths {
+		for reqPath := range paths {
 			path.Clean(reqPath)
 		}
 	}
@@ -113,7 +113,7 @@ func BenchmarkPreserveDots(b *testing.B) {
 
 func BenchmarkDefaultMask(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		for reqPath, _ := range paths {
+		for reqPath := range paths {
 			CleanPath(reqPath)
 		}
 	}

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"runtime"
 	"strings"
 	"sync"
@@ -351,7 +350,7 @@ func sanitizePath(r *http.Request) {
 	if r.URL.Path == "/" {
 		return
 	}
-	cleanedPath := path.Clean(r.URL.Path)
+	cleanedPath := CleanPath(r.URL.Path)
 	if cleanedPath == "." {
 		r.URL.Path = "/"
 	} else {


### PR DESCRIPTION
* A generic function is implemented to allow masking of certain patterns before calling the built-in `path.Clean()` function.
* Added default mask to preserve double slashes of protocol separator (e.g., `http://`, `https://`, or `ftp://`).
* Unit tests for the new functionality.

Note: This PR implements the functionality discussed in #1298.