### PR TITLE
Add StartupHooks to Plugins

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -70,14 +70,9 @@ func Run() {
 		})
 	}
 
-	err := caddy.StartupHooks(serverType)
-	if err != nil {
-		mustLogFatalf(err.Error())
-	}
-
 	// Check for one-time actions
 	if revoke != "" {
-		err = caddytls.Revoke(revoke)
+		err := caddytls.Revoke(revoke)
 		if err != nil {
 			mustLogFatalf(err.Error())
 		}
@@ -97,7 +92,13 @@ func Run() {
 	}
 
 	// Set CPU cap
-	err = setCPU(cpu)
+	err := setCPU(cpu)
+	if err != nil {
+		mustLogFatalf(err.Error())
+	}
+
+	// Execute Startup Hooks
+	err = caddy.StartupHooks(serverType)
 	if err != nil {
 		mustLogFatalf(err.Error())
 	}

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -70,9 +70,14 @@ func Run() {
 		})
 	}
 
+	err := caddy.StartupHooks(serverType)
+	if err != nil {
+		mustLogFatalf(err.Error())
+	}
+
 	// Check for one-time actions
 	if revoke != "" {
-		err := caddytls.Revoke(revoke)
+		err = caddytls.Revoke(revoke)
 		if err != nil {
 			mustLogFatalf(err.Error())
 		}
@@ -92,7 +97,7 @@ func Run() {
 	}
 
 	// Set CPU cap
-	err := setCPU(cpu)
+	err = setCPU(cpu)
 	if err != nil {
 		mustLogFatalf(err.Error())
 	}

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -97,10 +97,10 @@ func Run() {
 		mustLogFatalf(err.Error())
 	}
 
-	// Execute Startup Hooks
+	// Execute plugins that are registered to run as the process starts
 	err = caddy.StartupHooks(serverType)
 	if err != nil {
-		mustLogFatalf(err.Error())
+		mustLogFatalf("%v", err)
 	}
 
 	// Get Caddyfile input

--- a/plugins.go
+++ b/plugins.go
@@ -70,7 +70,7 @@ func DescribePlugins() string {
 }
 
 // StartupHooks executes the startup hooks defined when the
-// plugins where registred and returns the first error
+// plugins were registred and returns the first error
 // it encounters.
 func StartupHooks(serverType string) error {
 	for stype, stypePlugins := range plugins {

--- a/plugins.go
+++ b/plugins.go
@@ -69,7 +69,7 @@ func DescribePlugins() string {
 	return str
 }
 
-// StartupHooks executes the startup hooks defined when the 
+// StartupHooks executes the startup hooks defined when the
 // plugins where registred and returns the first error
 // it encounters.
 func StartupHooks(serverType string) error {

--- a/plugins.go
+++ b/plugins.go
@@ -69,6 +69,30 @@ func DescribePlugins() string {
 	return str
 }
 
+// StartupHooks executes the startup hooks defined when the 
+// plugins where registred and returns the first error
+// it encounters.
+func StartupHooks(serverType string) error {
+	for stype, stypePlugins := range plugins {
+		if stype != "" && stype != serverType {
+			continue
+		}
+
+		for name := range stypePlugins {
+			if stypePlugins[name].StartupHook == nil {
+				continue
+			}
+
+			err := stypePlugins[name].StartupHook()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidDirectives returns the list of all directives that are
 // recognized for the server type serverType. However, not all
 // directives may be installed. This makes it possible to give
@@ -176,6 +200,10 @@ type Plugin struct {
 	// Action is the plugin's setup function, if associated
 	// with a directive in the Caddyfile.
 	Action SetupFunc
+
+	// StartupHook is the plugin's function that is executed
+	// imediatelly after the flag parsing.
+	StartupHook func() error
 }
 
 // RegisterPlugin plugs in plugin. All plugins should register

--- a/plugins.go
+++ b/plugins.go
@@ -202,7 +202,7 @@ type Plugin struct {
 	Action SetupFunc
 
 	// StartupHook is the plugin's function that is executed
-	// imediatelly after the flag parsing.
+	// immediately after the flag parsing.
 	StartupHook func() error
 }
 

--- a/plugins.go
+++ b/plugins.go
@@ -70,7 +70,7 @@ func DescribePlugins() string {
 }
 
 // StartupHooks executes the startup hooks defined when the
-// plugins were registred and returns the first error
+// plugins were registered and returns the first error
 // it encounters.
 func StartupHooks(serverType string) error {
 	for stype, stypePlugins := range plugins {


### PR DESCRIPTION
StartupHook enables the developer to create plugins that are executed in the very beginning of the Caddy process, even before it has started running. It allows, among many other things, to use flags and take advantage of the fact that Caddy hasn't started running yet to configure and enable a variety of features. I think this hook will open a whole new range of plugins.

I've already talked with @mholt about this because I was having a problem while I wanted to develop a plugin and he suggested this.