### PR TITLE
Set session ticket keys properly (fixed in Go 1.8)

### DIFF
--- a/caddytls/crypto.go
+++ b/caddytls/crypto.go
@@ -271,7 +271,6 @@ func standaloneTLSTicketKeyRotation(c *tls.Config, ticker *time.Ticker, exitChan
 		c.SessionTicketsDisabled = true // bail if we don't have the entropy for the first one
 		return
 	}
-	c.SessionTicketKey = keys[0] // SetSessionTicketKeys doesn't set a 'tls.keysAlreadySet'
 	c.SetSessionTicketKeys(setSessionTicketKeysTestHook(keys))
 
 	for {


### PR DESCRIPTION
The reason this line was needed in the first place was due to https://github.com/golang/go/issues/15421.

This change should resolve the race in #1157 as well.