### PR TITLE
proxy: fix TestReverseProxy failure on go tip

### DIFF
--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -78,7 +78,7 @@ func TestReverseProxy(t *testing.T) {
 	}
 
 	// create request and response recorder
-	r := httptest.NewRequest("GET", "/", nil)
+	r := httptest.NewRequest("GET", "/", strings.NewReader("test"))
 	w := httptest.NewRecorder()
 
 	r.ContentLength = -1 // force chunked encoding (required for trailers)
@@ -97,6 +97,7 @@ func TestReverseProxy(t *testing.T) {
 	verifyHeaders(res.Header, res.Trailer)
 
 	// Make sure {upstream} placeholder is set
+	r.Body = ioutil.NopCloser(strings.NewReader("test"))
 	rr := httpserver.NewResponseRecorder(httptest.NewRecorder())
 	rr.Replacer = httpserver.NewReplacer(r, rr, "-")
 


### PR DESCRIPTION
Because of [this commit](https://github.com/golang/go/commit/6e36811c37399d60cbce587b7c48e611009c5aec) on go tip,
it will probe the request's body to determine whether to use chunked transfer
encoding which trailers depend on it.
So we just offer a non empty body to make trailers work.

fix issue #1359

Signed-off-by: Tw <tw19881113@gmail.com>