### PR TITLE
Add request placeholder support for querying request cookies.

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -199,7 +199,7 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 	}
 	// next check for cookies
-	if key[1] == '@' {
+	if key[1] == ':' {
 		name := key[2 : len(key)-1]
 		if cookie, err := r.request.Cookie(name); err == nil {
 			return cookie.Value

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -199,7 +199,7 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 	}
 	// next check for cookies
-	if key[1] == ':' {
+	if key[1] == '~' {
 		name := key[2 : len(key)-1]
 		if cookie, err := r.request.Cookie(name); err == nil {
 			return cookie.Value

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -198,6 +198,13 @@ func (r *replacer) getSubstitution(key string) string {
 			}
 		}
 	}
+	// next check for cookies
+	if key[1] == '@' {
+		name := key[2 : len(key)-1]
+		if cookie, err := r.request.Cookie(name); err == nil {
+			return cookie.Value
+		}
+	}
 
 	// search default replacements in the end
 	switch key {

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -82,8 +82,8 @@ func TestReplace(t *testing.T) {
 		{"Bad {>Custom placeholder", "Bad {>Custom placeholder"},
 		{"Bad {>Custom placeholder {>ShorterVal}", "Bad -"},
 		{"Bad {}", "Bad -"},
-		{"Cookies are {@taste}", "Cookies are delicious"},
-		{"Missing cookie is {@missing}", "Missing cookie is -"},
+		{"Cookies are {:taste}", "Cookies are delicious"},
+		{"Missing cookie is {:missing}", "Missing cookie is -"},
 	}
 
 	for _, c := range testCases {

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -47,6 +47,7 @@ func TestReplace(t *testing.T) {
 	repl := NewReplacer(request, recordRequest, "-")
 	// add some headers after creating replacer
 	request.Header.Set("CustomAdd", "caddy")
+	request.Header.Set("Cookie", "foo=bar; taste=delicious")
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -72,12 +73,17 @@ func TestReplace(t *testing.T) {
 		{"{when_iso}", "2006-01-02T15:04:12Z"},
 		{"The Custom header is {>Custom}.", "The Custom header is foobarbaz."},
 		{"The CustomAdd header is {>CustomAdd}.", "The CustomAdd header is caddy."},
-		{"The request is {request}.", "The request is POST / HTTP/1.1\\r\\nHost: localhost\\r\\nCustom: foobarbaz\\r\\nCustomadd: caddy\\r\\nShorterval: 1\\r\\n\\r\\n."},
+		{"The request is {request}.", "The request is POST / HTTP/1.1\\r\\nHost: localhost\\r\\n" +
+			"Cookie: foo=bar; taste=delicious\\r\\nCustom: foobarbaz\\r\\nCustomadd: caddy\\r\\n" +
+			"Shorterval: 1\\r\\n\\r\\n."},
 		{"The cUsToM header is {>cUsToM}...", "The cUsToM header is foobarbaz..."},
 		{"The Non-Existent header is {>Non-Existent}.", "The Non-Existent header is -."},
 		{"Bad {host placeholder...", "Bad {host placeholder..."},
 		{"Bad {>Custom placeholder", "Bad {>Custom placeholder"},
 		{"Bad {>Custom placeholder {>ShorterVal}", "Bad -"},
+		{"Bad {}", "Bad -"},
+		{"Cookies are {@taste}", "Cookies are delicious"},
+		{"Missing cookie is {@missing}", "Missing cookie is -"},
 	}
 
 	for _, c := range testCases {

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -82,8 +82,8 @@ func TestReplace(t *testing.T) {
 		{"Bad {>Custom placeholder", "Bad {>Custom placeholder"},
 		{"Bad {>Custom placeholder {>ShorterVal}", "Bad -"},
 		{"Bad {}", "Bad -"},
-		{"Cookies are {:taste}", "Cookies are delicious"},
-		{"Missing cookie is {:missing}", "Missing cookie is -"},
+		{"Cookies are {~taste}", "Cookies are delicious"},
+		{"Missing cookie is {~missing}", "Missing cookie is -"},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
This adds the ability to query the request cookies for placeholders
using the syntax "@cookiename".

For example, this would allow rewriting based on a cookie:
```
  rewrite {
    if {:version} is 'dev'
    to /dev/index.html
  }
```