### PR TITLE
Added additional '-' to common log format #1398

### DIFF
--- a/caddyhttp/log/log.go
+++ b/caddyhttp/log/log.go
@@ -82,7 +82,7 @@ const (
 	// DefaultLogFilename is the default log filename.
 	DefaultLogFilename = "access.log"
 	// CommonLogFormat is the common log format.
-	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + ` [{when}] "{method} {uri} {proto}" {status} {size}`
+	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + " " + CommonLogEmptyValue + ` [{when}] "{method} {uri} {proto}" {status} {size}`
 	// CommonLogEmptyValue is the common empty log value.
 	CommonLogEmptyValue = "-"
 	// CombinedLogFormat is the combined log format.


### PR DESCRIPTION
A very simple fix for #1398 by simply adding a second '-' into the format for common log file.

In the future it may be desirable to add a placeholder for {>User} or {user} to "represent userid of the person requesting the document as determined by HTTP authentication" , however my personal opinion may be that in 2016 HTTP authentication even with HTTPS is not sufficiently 'common'.

This simple fix makes the caddy common file format compatible with the generally accepted 'common' file format, even if it will never provide the 'user' in the log.