### PR TITLE
Allow replacement params in log filename

### DIFF
--- a/caddyhttp/log/setup.go
+++ b/caddyhttp/log/setup.go
@@ -127,7 +127,6 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 				fileMu:     new(sync.RWMutex),
 			})
 		} else if len(args) == 1 {
-			log.Println("%v", args[0])
 			// Only an output file specified
 			rules = appendEntry(rules, "/", &Entry{
 				OutputFile: args[0],
@@ -137,8 +136,6 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 			})
 		} else {
 			// Path scope, output file, and maybe a format specified
-			log.Println("%v", args[1])
-
 			format := DefaultLogFormat
 
 			if len(args) > 2 {


### PR DESCRIPTION
I have the start of a PR for this issue #1396 

@mholt There are some comments inline if you have time to take a look.

Essentially I call replacer on the path for the log file.

If the logfile returned is differnt to the currently open one, I close it and open the new log file? I have questions around

- Am I closing the existing logfile correctly?
- Would a better approach be to leave a file open for each different log file opened rather than closing and reopening?
- Is this desired behaviour are we happy that this Issue is to be implemented?
- Is #1404 relevant to this at all?

This is not ready to merge yet, I need to add tests and tidy up some code but need some feedback on direction.