### PR TITLE
Fix for #1388 starting with no Caddyfile

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -55,12 +55,10 @@ func init() {
 func hideCaddyfile(cctx caddy.Context) error {
 	ctx := cctx.(*httpContext)
 	for _, cfg := range ctx.siteConfigs {
-
 		// if no Caddyfile exists exit.
 		if cfg.originCaddyfile == "" {
 			return nil
 		}
-
 		absRoot, err := filepath.Abs(cfg.Root)
 		if err != nil {
 			return err

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -55,6 +55,12 @@ func init() {
 func hideCaddyfile(cctx caddy.Context) error {
 	ctx := cctx.(*httpContext)
 	for _, cfg := range ctx.siteConfigs {
+
+		// if no Caddyfile exists exit.
+		if cfg.originCaddyfile == "" {
+			return nil
+		}
+
 		absRoot, err := filepath.Abs(cfg.Root)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes #1388. 

Exit from hideCaddyfile function if no Caddyfile exists