### PR TITLE
Fix data race for max connection limiting in proxy directive.

### DIFF
--- a/caddyhttp/proxy/policy_test.go
+++ b/caddyhttp/proxy/policy_test.go
@@ -60,13 +60,13 @@ func TestRoundRobinPolicy(t *testing.T) {
 		t.Error("Expected third round robin host to be first host in the pool.")
 	}
 	// mark host as down
-	pool[1].Unhealthy = true
+	pool[1].Unhealthy = 1
 	h = rrPolicy.Select(pool, request)
 	if h != pool[2] {
 		t.Error("Expected to skip down host.")
 	}
 	// mark host as up
-	pool[1].Unhealthy = false
+	pool[1].Unhealthy = 0
 
 	h = rrPolicy.Select(pool, request)
 	if h == pool[2] {
@@ -161,7 +161,7 @@ func TestIPHashPolicy(t *testing.T) {
 	// we should get a healthy host if the original host is unhealthy and a
 	// healthy host is available
 	request.RemoteAddr = "172.0.0.1"
-	pool[1].Unhealthy = true
+	pool[1].Unhealthy = 1
 	h = ipHash.Select(pool, request)
 	if h != pool[2] {
 		t.Error("Expected ip hash policy host to be the third host.")
@@ -172,10 +172,10 @@ func TestIPHashPolicy(t *testing.T) {
 	if h != pool[2] {
 		t.Error("Expected ip hash policy host to be the third host.")
 	}
-	pool[1].Unhealthy = false
+	pool[1].Unhealthy = 0
 
 	request.RemoteAddr = "172.0.0.3"
-	pool[2].Unhealthy = true
+	pool[2].Unhealthy = 1
 	h = ipHash.Select(pool, request)
 	if h != pool[0] {
 		t.Error("Expected ip hash policy host to be the first host.")
@@ -219,8 +219,8 @@ func TestIPHashPolicy(t *testing.T) {
 	}
 
 	// We should get nil when there are no healthy hosts
-	pool[0].Unhealthy = true
-	pool[1].Unhealthy = true
+	pool[0].Unhealthy = 1
+	pool[1].Unhealthy = 1
 	h = ipHash.Select(pool, request)
 	if h != nil {
 		t.Error("Expected ip hash policy host to be nil.")

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -174,8 +174,6 @@ func TestReverseProxyMaxConnLimit(t *testing.T) {
 		Upstreams: su,
 	}
 
-	// testComplete := make(chan bool)
-	// go func() {
 	var jobs sync.WaitGroup
 
 	for i := 0; i < MaxTestConns; i++ {
@@ -210,15 +208,8 @@ func TestReverseProxyMaxConnLimit(t *testing.T) {
 	// Now let all the requests complete and verify the status codes for those:
 	close(connContinue)
 
+	// Wait for the initial requests to finish and check their results.
 	jobs.Wait()
-	// 	testComplete <- true
-	// }()
-
-	// select {
-	// case <-testComplete:
-	// case <-time.After(time.Second):
-	// 	t.Fatal("Timed out")
-	// }
 }
 
 func TestWebSocketReverseProxyNonHijackerPanic(t *testing.T) {

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -141,6 +142,83 @@ func TestReverseProxyInsecureSkipVerify(t *testing.T) {
 	if !requestWasHTTP2 {
 		t.Error("Even with insecure HTTPS, expected proxy to use HTTP/2")
 	}
+}
+
+// This test will fail when using the race detector without atomic reads &
+// writes of UpstreamHost.Conns and UpstreamHost.Unhealthy.
+func TestReverseProxyMaxConnLimit(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	const MaxTestConns = 2
+	connReceived := make(chan bool, MaxTestConns)
+	connContinue := make(chan bool)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connReceived <- true
+		<-connContinue
+	}))
+	defer backend.Close()
+
+	su, err := NewStaticUpstreams(caddyfile.NewDispenser("Testfile", strings.NewReader(`
+		proxy / `+backend.URL+` {
+			max_conns `+fmt.Sprint(MaxTestConns)+`
+		}
+	`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set up proxy
+	p := &Proxy{
+		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
+		Upstreams: su,
+	}
+
+	// testComplete := make(chan bool)
+	// go func() {
+	var jobs sync.WaitGroup
+
+	for i := 0; i < MaxTestConns; i++ {
+		jobs.Add(1)
+		go func(i int) {
+			defer jobs.Done()
+			w := httptest.NewRecorder()
+			code, err := p.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+			if err != nil {
+				t.Errorf("Request %d failed: %v", i, err)
+			} else if code != 0 {
+				t.Errorf("Bad return code for request %d: %d", i, code)
+			} else if w.Code != 200 {
+				t.Errorf("Bad statuc code for request %d: %d", i, w.Code)
+			}
+		}(i)
+	}
+	// Wait for all the requests to hit the backend.
+	for i := 0; i < MaxTestConns; i++ {
+		<-connReceived
+	}
+
+	// Now we should have MaxTestConns requests connected and sitting on the backend
+	// server.  Verify that the next request is rejected.
+	w := httptest.NewRecorder()
+	code, err := p.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	if code != http.StatusBadGateway {
+		t.Errorf("Expected request to be rejected, but got: %d [%v]\nStatus code: %d",
+			code, err, w.Code)
+	}
+
+	// Now let all the requests complete and verify the status codes for those:
+	close(connContinue)
+
+	jobs.Wait()
+	// 	testComplete <- true
+	// }()
+
+	// select {
+	// case <-testComplete:
+	// case <-time.After(time.Second):
+	// 	t.Fatal("Timed out")
+	// }
 }
 
 func TestWebSocketReverseProxyNonHijackerPanic(t *testing.T) {

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -36,12 +36,12 @@ func TestNewHost(t *testing.T) {
 		t.Error("Expected new host not to be down.")
 	}
 	// mark Unhealthy
-	uh.Unhealthy = true
+	uh.Unhealthy = 1
 	if !uh.CheckDown(uh) {
 		t.Error("Expected unhealthy host to be down.")
 	}
 	// mark with Fails
-	uh.Unhealthy = false
+	uh.Unhealthy = 0
 	uh.Fails = 1
 	if !uh.CheckDown(uh) {
 		t.Error("Expected failed host to be down.")
@@ -74,13 +74,13 @@ func TestSelect(t *testing.T) {
 		MaxFails:    1,
 	}
 	r, _ := http.NewRequest("GET", "/", nil)
-	upstream.Hosts[0].Unhealthy = true
-	upstream.Hosts[1].Unhealthy = true
-	upstream.Hosts[2].Unhealthy = true
+	upstream.Hosts[0].Unhealthy = 1
+	upstream.Hosts[1].Unhealthy = 1
+	upstream.Hosts[2].Unhealthy = 1
 	if h := upstream.Select(r); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].Unhealthy = false
+	upstream.Hosts[2].Unhealthy = 0
 	if h := upstream.Select(r); h == nil {
 		t.Error("Expected select to not return nil")
 	}


### PR DESCRIPTION
The Conns and Unhealthy fields are updated concurrently across all active
requests.  Because of this, they must use atomic operations for reads and
writes.

Prior to this change, Conns was incremented atomically, but read unsafely.
Unhealthly was updated & read unsafely.  The new test
TestReverseProxyMaxConnLimit exposes this race when run with -race.

Switching to atomic operations makes the race detector happy.