### PR TITLE
Don't return tls.Config if client does not support SNI

### DIFF
--- a/caddytls/handshake.go
+++ b/caddytls/handshake.go
@@ -70,6 +70,11 @@ func (cg ConfigGroup) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Cer
 // This method is safe for use as a tls.Config.GetConfigForClient callback.
 func (cg ConfigGroup) GetConfigForClient(clientHello *tls.ClientHelloInfo) (*tls.Config, error) {
 
+	// Client does not support SNI
+	if clientHello.ServerName == "" {
+		return nil, errors.New("Clients without SNI are not supported")
+	}
+
 	config := cg.getConfig(clientHello.ServerName)
 
 	if config != nil {

--- a/caddytls/handshake_test.go
+++ b/caddytls/handshake_test.go
@@ -55,12 +55,11 @@ func TestGetCertificate(t *testing.T) {
 	}
 }
 
-
 func TestGetConfigForClientWithoutSNI(t *testing.T) {
 
 	cg := make(ConfigGroup)
 
-	if _, err := cg.GetConfigForClient(&tls.ClientHelloInfo{ServerName:""}); err == nil {
+	if _, err := cg.GetConfigForClient(&tls.ClientHelloInfo{ServerName: ""}); err == nil {
 		t.Error("Expected GetConfigForClient to fail is ServerName is not provided in ClientHelloInfo")
 	}
 }

--- a/caddytls/handshake_test.go
+++ b/caddytls/handshake_test.go
@@ -54,3 +54,13 @@ func TestGetCertificate(t *testing.T) {
 		t.Errorf("Expected default cert with no matches, got: %v", cert)
 	}
 }
+
+
+func TestGetConfigForClientWithoutSNI(t *testing.T) {
+
+	cg := make(ConfigGroup)
+
+	if _, err := cg.GetConfigForClient(&tls.ClientHelloInfo{ServerName:""}); err == nil {
+		t.Error("Expected GetConfigForClient to fail is ServerName is not provided in ClientHelloInfo")
+	}
+}


### PR DESCRIPTION
Clients without SNI support are very rare (http://caniuse.com/#search=SNI). 

Calling Caddy without SNI support ends with connection being established via TLS 1.0 and bad certificate (first in the list of domains). It should not be supported given the fact that 98.18% clients support it (lowering security for unsecured devices is not really a good idea).