### PR TITLE
Fixed #1484

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -224,7 +224,10 @@ func (rp *ReverseProxy) UseInsecureTransport() {
 		}
 		rp.Transport = transport
 	} else if transport, ok := rp.Transport.(*http.Transport); ok {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
 		// No http2.ConfigureTransport() here.
 		// For now this is only added in places where
 		// an http.Transport is actually created.

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -441,7 +441,7 @@ func newConnHijackerTransport(base http.RoundTripper) *connHijackerTransport {
 	}
 	if b, _ := base.(*http.Transport); b != nil {
 		tlsClientConfig := b.TLSClientConfig
-		if tlsClientConfig.NextProtos != nil {
+		if tlsClientConfig != nil && tlsClientConfig.NextProtos != nil {
 			tlsClientConfig = tlsClientConfig.Clone()
 			tlsClientConfig.NextProtos = nil
 		}


### PR DESCRIPTION
#1484. The fix is luckily very simple (it's literally only `tlsClientConfig != nil &&`). It can currently be tested by setting the default value of `httpserver.HTTP2` to `false` in `caddyhttp/httpserver/plugin.go` and then running `go test -run=TestWebSocketReverseProxyFromWSClient` (which I did).

@passcod If you know how and if you have the time it'd be really cool if you could test this PR by building caddy from source. 🙂

P.S.: This PR sadly does not contain a real testcase for 4e31a26. Reason being that we currently run all of our tests with `httpserver.HTTP2` set to `true`, which causes `TLSClientConfig` to be set and thus this error to never appear. Adding another testcase just for this very simple bug does not seem particularly helpful to me. Instead we should probably rather finally rewrite all the proxy tests to be more modular. Currently the entire `proxy_test.go` file is >1000 lines of largely redundant code. If it were more modular we could then easily run the same test e.g. twice: Once with `httpserver.HTTP2` set to `true` and once while it's set to `false`. But this should probably rather happen in a seperate PR.