### PR TITLE
Replace use of Header to store Original URI for rewrite to Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ access.log
 Caddyfile
 
 og_static/
+
+.vscode/

--- a/caddy.go
+++ b/caddy.go
@@ -877,4 +877,7 @@ type CtxKey string
 // context.WithValue to access the original request URI that accompanied the
 // server request. The associated value will be of type string.
 const URLPathCtxKey CtxKey = "url_path"
+
+// URIxRewriteCtxKey is a context key used to store origional unrewritten
+// URI in context.WithValue
 const URIxRewriteCtxKey CtxKey = "caddy_rewrite_original_uri"

--- a/caddy.go
+++ b/caddy.go
@@ -878,6 +878,6 @@ type CtxKey string
 // server request. The associated value will be of type string.
 const URLPathCtxKey CtxKey = "url_path"
 
-// URIxRewriteCtxKey is a context key used to store origional unrewritten
+// URIxRewriteCtxKey is a context key used to store original unrewritten
 // URI in context.WithValue
 const URIxRewriteCtxKey CtxKey = "caddy_rewrite_original_uri"

--- a/caddy.go
+++ b/caddy.go
@@ -877,3 +877,4 @@ type CtxKey string
 // context.WithValue to access the original request URI that accompanied the
 // server request. The associated value will be of type string.
 const URLPathCtxKey CtxKey = "url_path"
+const URIxRewriteCtxKey CtxKey = "caddy_rewrite_original_uri"

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -33,11 +33,6 @@ type Handler struct {
 	ServerPort      string
 }
 
-// When a rewrite is performed, a header field of this name
-// is added to the request
-// It contains the original request URI before the rewrite.
-const internalRewriteFieldName = "Caddy-Rewrite-Original-URI"
-
 // ServeHTTP satisfies the httpserver.Handler interface.
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, rule := range h.Rules {
@@ -212,12 +207,12 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 	// Strip PATH_INFO from SCRIPT_NAME
 	scriptName = strings.TrimSuffix(scriptName, pathInfo)
 
-	// Get the request URI. The request URI might be as it came in over the wire,
+	// Get the request URI from context. The request URI might be as it came in over the wire,
 	// or it might have been rewritten internally by the rewrite middleware (see issue #256).
-	// If it was rewritten, there will be a header indicating the original URL,
+	// If it was rewritten, there will be a context value with the original URL,
 	// which is needed to get the correct RequestURI value for PHP apps.
 	reqURI := r.URL.RequestURI()
-	if origURI := r.Header.Get(internalRewriteFieldName); origURI != "" {
+	if origURI, _ := r.Context().Value(caddy.URIxRewriteCtxKey).(string); origURI != "" {
 		reqURI = origURI
 	}
 
@@ -275,11 +270,8 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env[envVar[0]] = replacer.Replace(envVar[1])
 	}
 
-	// Add all HTTP headers (except Caddy-Rewrite-Original-URI ) to env variables
+	// Add all HTTP headers to env variables
 	for field, val := range r.Header {
-		if strings.ToLower(field) == strings.ToLower(internalRewriteFieldName) {
-			continue
-		}
 		header := strings.ToUpper(field)
 		header = headerNameReplacer.Replace(header)
 		env["HTTP_"+header] = strings.Join(val, ", ")

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -304,25 +303,6 @@ func TestBuildEnv(t *testing.T) {
 	envExpected["CUSTOM_URI"] = "custom_uri/fgci_test.php?test=blabla"
 	envExpected["CUSTOM_QUERY"] = "custom=true&test=blabla"
 	testBuildEnv(r, rule, fpath, envExpected)
-
-	// 6. Test Caddy-Rewrite-Original-URI header is not removed
-	r = newReq()
-	rule.EnvVars = [][2]string{
-		{"HTTP_HOST", "{host}"},
-		{"CUSTOM_URI", "custom_uri{uri}"},
-		{"CUSTOM_QUERY", "custom=true&{query}"},
-	}
-	envExpected = newEnv()
-	envExpected["HTTP_HOST"] = "localhost:2015"
-	envExpected["CUSTOM_URI"] = "custom_uri/fgci_test.php?test=blabla"
-	envExpected["CUSTOM_QUERY"] = "custom=true&test=blabla"
-	httpFieldName := strings.ToUpper(internalRewriteFieldName)
-	envExpected["HTTP_"+httpFieldName] = ""
-	r.Header.Add(internalRewriteFieldName, "/apath/torewrite/index.php")
-	testBuildEnv(r, rule, fpath, envExpected)
-	if r.Header.Get(internalRewriteFieldName) == "" {
-		t.Errorf("Error: Header Expected %v", internalRewriteFieldName)
-	}
 
 }
 

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -240,13 +240,15 @@ func (r *replacer) getSubstitution(key string) string {
 	case "{path}":
 		// if a rewrite has happened, the original URI should be used as the path
 		// rather than the rewritten URI
-		path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
+		path, _ := r.request.Context().Value(caddy.URIxRewriteCtxKey).(string)
+		//path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
 		if path == "" {
 			path = r.request.URL.Path
 		}
 		return path
 	case "{path_escaped}":
-		path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
+		path, _ := r.request.Context().Value(caddy.URIxRewriteCtxKey).(string)
+		//path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
 		if path == "" {
 			path = r.request.URL.Path
 		}

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -241,14 +241,12 @@ func (r *replacer) getSubstitution(key string) string {
 		// if a rewrite has happened, the original URI should be used as the path
 		// rather than the rewritten URI
 		path, _ := r.request.Context().Value(caddy.URIxRewriteCtxKey).(string)
-		//path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
 		if path == "" {
 			path = r.request.URL.Path
 		}
 		return path
 	case "{path_escaped}":
 		path, _ := r.request.Context().Value(caddy.URIxRewriteCtxKey).(string)
-		//path := r.request.Header.Get("Caddy-Rewrite-Original-URI")
 		if path == "" {
 			path = r.request.URL.Path
 		}

--- a/caddyhttp/rewrite/rewrite.go
+++ b/caddyhttp/rewrite/rewrite.go
@@ -234,8 +234,3 @@ func (r *ComplexRule) regexpMatches(rPath string) []string {
 func newReplacer(r *http.Request) httpserver.Replacer {
 	return httpserver.NewReplacer(r, nil, "")
 }
-
-// When a rewrite is performed, this header is added to the request
-// and is for internal use only, specifically the fastcgi middleware.
-// It contains the original request URI before the rewrite.
-const headerFieldName = "Caddy-Rewrite-Original-URI"

--- a/caddyhttp/rewrite/rewrite.go
+++ b/caddyhttp/rewrite/rewrite.go
@@ -65,9 +65,6 @@ func (s SimpleRule) Match(r *http.Request) bool { return s.From == r.URL.Path }
 
 // Rewrite rewrites the internal location of the current request.
 func (s SimpleRule) Rewrite(fs http.FileSystem, r *http.Request) Result {
-	// take note of this rewrite for internal use by fastcgi
-	// all we need is the URI, not full URL
-	//r.Header.Set(headerFieldName, r.URL.RequestURI())
 
 	// attempt rewrite
 	return To(fs, r, s.To, newReplacer(r))

--- a/caddyhttp/rewrite/rewrite.go
+++ b/caddyhttp/rewrite/rewrite.go
@@ -67,7 +67,7 @@ func (s SimpleRule) Match(r *http.Request) bool { return s.From == r.URL.Path }
 func (s SimpleRule) Rewrite(fs http.FileSystem, r *http.Request) Result {
 	// take note of this rewrite for internal use by fastcgi
 	// all we need is the URI, not full URL
-	r.Header.Set(headerFieldName, r.URL.RequestURI())
+	//r.Header.Set(headerFieldName, r.URL.RequestURI())
 
 	// attempt rewrite
 	return To(fs, r, s.To, newReplacer(r))

--- a/caddyhttp/rewrite/to.go
+++ b/caddyhttp/rewrite/to.go
@@ -1,12 +1,14 @@
 package rewrite
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
@@ -49,7 +51,9 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 
 	// take note of this rewrite for internal use by fastcgi
 	// all we need is the URI, not full URL
-	r.Header.Set(headerFieldName, r.URL.RequestURI())
+	//r.Header.Set(headerFieldName, r.URL.RequestURI())
+
+	*r = *r.WithContext(context.WithValue(r.Context(), caddy.URIxRewriteCtxKey, r.URL.RequestURI()))
 
 	// perform rewrite
 	r.URL.Path = u.Path

--- a/caddyhttp/rewrite/to.go
+++ b/caddyhttp/rewrite/to.go
@@ -51,8 +51,6 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 
 	// take note of this rewrite for internal use by fastcgi
 	// all we need is the URI, not full URL
-	//r.Header.Set(headerFieldName, r.URL.RequestURI())
-
 	*r = *r.WithContext(context.WithValue(r.Context(), caddy.URIxRewriteCtxKey, r.URL.RequestURI()))
 
 	// perform rewrite


### PR DESCRIPTION
This PR replaces the use of an internal request header

> Caddy-Rewrite-Original-URI

with `context`.  This should be merged before #1481 which will be updated to use this new code.

I'm not sure where to put a test if any.