### PR TITLE
Log certificate location

### DIFF
--- a/caddytls/filestorage.go
+++ b/caddytls/filestorage.go
@@ -3,6 +3,7 @@ package caddytls
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -188,6 +189,7 @@ func (s *FileStorage) StoreSite(domain string, data *SiteData) error {
 	if err != nil {
 		return fmt.Errorf("writing cert meta file: %v", err)
 	}
+	log.Printf("[INFO][%v] Certificate written to disk: %v", domain, s.siteCertFile(domain))
 	return nil
 }
 


### PR DESCRIPTION
If of interest this implements issue #1394 by logging certificate location when first written to disk.

> 2017/03/06 21:53:10 [INFO][sitecert3.example.com] Certificate written to disk: C:\Users\admin\.caddy\acme\acme-v01.api.letsencrypt.org\sites\sitecert3.example.com\sitecert3.example.com.crt

