### PR TITLE
proxy: add root_ca parameter to configure upstream root CAs

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -14,6 +14,7 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"io"
 	"net"
 	"net/http"
@@ -189,12 +190,8 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 		// if keepalive is equal to the default,
 		// just use default transport, to avoid creating
 		// a brand new transport
-		transport := &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			Dial:                  defaultDialer.Dial,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
+		transport := createTransport()
+		transport.ExpectContinueTimeout = 1 * time.Second
 		if keepalive == 0 {
 			transport.DisableKeepAlives = true
 		} else {
@@ -213,25 +210,33 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 // since this transport skips verification.
 func (rp *ReverseProxy) UseInsecureTransport() {
 	if rp.Transport == nil {
-		transport := &http.Transport{
-			Proxy:               http.ProxyFromEnvironment,
-			Dial:                defaultDialer.Dial,
-			TLSHandshakeTimeout: 10 * time.Second,
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
-		}
+		transport := createTransport();
 		if httpserver.HTTP2 {
 			http2.ConfigureTransport(transport)
 		}
 		rp.Transport = transport
-	} else if transport, ok := rp.Transport.(*http.Transport); ok {
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{}
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = true
-		// No http2.ConfigureTransport() here.
-		// For now this is only added in places where
-		// an http.Transport is actually created.
 	}
+	rp.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+}
+
+func (rp *ReverseProxy) SetTransportCARoots(certPool *x509.CertPool) {
+	if rp.Transport == nil {
+		transport := createTransport();
+		if httpserver.HTTP2 {
+			http2.ConfigureTransport(transport)
+		}
+		rp.Transport = transport
+	}
+	rp.Transport.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: certPool}
+}
+
+func createTransport() *http.Transport {
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		Dial:                defaultDialer.Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return transport
 }
 
 // ServeHTTP serves the proxied request to the upstream by performing a roundtrip.

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -41,6 +42,8 @@ type staticUpstream struct {
 	IgnoredSubPaths    []string
 	insecureSkipVerify bool
 	MaxFails           int32
+	rootCAPath         string
+	rootCertPool       *x509.CertPool
 }
 
 // NewStaticUpstreams parses the configuration input and sets up
@@ -93,6 +96,18 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 
 		if len(to) == 0 {
 			return upstreams, c.ArgErr()
+		}
+
+		if upstream.rootCAPath != "" {
+			certPool := x509.NewCertPool()
+			certBytes, err := ioutil.ReadFile(upstream.rootCAPath)
+			if err != nil {
+				return upstreams, c.Errf("Unable to load root CAs PEM file: %v", err)
+			}
+			if !certPool.AppendCertsFromPEM(certBytes) {
+				return upstreams, c.Errf("Unable to load root CAs PEM file %s", upstream.rootCAPath)
+			}
+			upstream.rootCertPool = certPool
 		}
 
 		upstream.Hosts = make([]*UpstreamHost, len(to))
@@ -155,6 +170,9 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix, u.KeepAlive)
 	if u.insecureSkipVerify {
 		uh.ReverseProxy.UseInsecureTransport()
+	}
+	if u.rootCertPool != nil {
+		uh.ReverseProxy.SetTransportCARoots(u.rootCertPool)
 	}
 
 	return uh, nil
@@ -335,6 +353,11 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		u.IgnoredSubPaths = ignoredPaths
 	case "insecure_skip_verify":
 		u.insecureSkipVerify = true
+	case "root_ca":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		u.rootCAPath = c.Val()
 	case "keepalive":
 		if !c.NextArg() {
 			return c.ArgErr()

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -46,6 +46,9 @@ func TestNewHost(t *testing.T) {
 	if !uh.CheckDown(uh) {
 		t.Error("Expected failed host to be down.")
 	}
+	if uh.ReverseProxy.Transport.(*http.Transport).TLSClientConfig.RootCAs != upstream.rootCertPool {
+		t.Error("Expected the RootsssCAs to be set")
+	}
 }
 
 func TestHealthCheck(t *testing.T) {


### PR DESCRIPTION
This adds the `root_ca` parameter to the proxy module to configure upstream root CAs.

Some of the example use cases might be to use internal roots for internal usage or to trim down roots when connecting to a service.

If the idea seems right, I can add docs to document this.