### PR TITLE
systemd README: set mode of caddy.service to 644 instead of 744

### DIFF
--- a/dist/init/linux-systemd/README.md
+++ b/dist/init/linux-systemd/README.md
@@ -94,7 +94,7 @@ and start caddy:
 ```bash
 sudo cp caddy.service /etc/systemd/system/
 sudo chown root:root /etc/systemd/system/caddy.service
-sudo chmod 744 /etc/systemd/system/caddy.service
+sudo chmod 644 /etc/systemd/system/caddy.service
 sudo systemctl daemon-reload
 sudo systemctl start caddy.service
 ```


### PR DESCRIPTION
It makes no sense to set the executable bit on a systemd unit config file. Most likely a typo.