### PR TITLE
markdown: backup title should use TrimSuffix not TrimRight

### DIFF
--- a/caddyhttp/markdown/markdown.go
+++ b/caddyhttp/markdown/markdown.go
@@ -167,5 +167,5 @@ func latest(t ...time.Time) time.Time {
 
 // title gives a backup generated title for a page
 func title(p string) string {
-	return strings.TrimRight(path.Base(p), path.Ext(p))
+	return strings.TrimSuffix(path.Base(p), path.Ext(p))
 }


### PR DESCRIPTION
Ref: [caddyhttp/markdown/markdown.go](https://github.com/mholt/caddy/blob/master/caddyhttp/markdown/markdown.go#L168)

Func [strings.TrimRight](https://golang.org/pkg/strings/#TrimRight) (`TrimLeft` and `Trim`) removes *cutset* or a set of characters of type `string`, multiple times if possible:

```go
fmt.Println(strings.TrimRight("foo.md", ".md")) // ok: foo
fmt.Println(strings.TrimRight("md.md", ".md"))  // bad: <blank>

fmt.Println(strings.TrimSuffix("foo.md", ".md")) // good: foo
fmt.Println(strings.TrimSuffix("md.md", ".md"))  // good: md
```

Also see [the Go Playground](https://play.golang.org/p/TBKx3T4btT).

In order to generate the correct HTML page title from the filename, function `strings.TrimSuffix` should be used.

Searched the code base:

<https://github.com/mholt/caddy/search?p=1&q=trim&utf8=%E2%9C%93>

This is the only place affected. The other place [caddyhttp/header/header.go](https://github.com/mholt/caddy/blob/master/caddyhttp/header/header.go#L36) uses a single character
 as a cutset, which is good.