### PR TITLE
Do not lowercase path in httpContext

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -103,13 +103,17 @@ func (h *httpContext) InspectServerBlocks(sourceFile string, serverBlocks []cadd
 	// For each address in each server block, make a new config
 	for _, sb := range serverBlocks {
 		for _, key := range sb.Keys {
-			// Lowercase entire address except path (assume path is at end).
-			var path string
-			addrTemp, err := standardizeAddress(key)
-			if err == nil {
-				path = addrTemp.Path
+			if CaseSensitivePath {
+				// Lowercase entire address except path (assume path is at end).
+				var path string
+				addrTemp, err := standardizeAddress(key)
+				if err == nil {
+					path = addrTemp.Path
+				}
+				key = strings.ToLower(key)[:len(key)-len(path)] + path
+			} else {
+				key = strings.ToLower(key)
 			}
-			key = strings.ToLower(key)[:len(key)-len(path)] + path
 			if _, dup := h.keysToSiteConfigs[key]; dup {
 				return serverBlocks, fmt.Errorf("duplicate site address: %s", key)
 			}
@@ -221,13 +225,18 @@ func (h *httpContext) MakeServers() ([]caddy.Server, error) {
 func GetConfig(c *caddy.Controller) *SiteConfig {
 	ctx := c.Context().(*httpContext)
 
-	// Lowercase entire address except path (assume path is at end).
-	var path string
-	addr, err := standardizeAddress(c.Key)
-	if err == nil {
-		path = addr.Path
+	var key string
+	if CaseSensitivePath {
+		// Lowercase entire address except path (assume path is at end).
+		var path string
+		addr, err := standardizeAddress(c.Key)
+		if err == nil {
+			path = addr.Path
+		}
+		key = strings.ToLower(c.Key)[:len(c.Key)-len(path)] + path
+	} else {
+		key = strings.ToLower(c.Key)
 	}
-	key := strings.ToLower(c.Key)[:len(c.Key)-len(path)] + path
 
 	if cfg, ok := ctx.keysToSiteConfigs[key]; ok {
 		return cfg

--- a/caddyhttp/httpserver/plugin_test.go
+++ b/caddyhttp/httpserver/plugin_test.go
@@ -153,6 +153,26 @@ func TestInspectServerBlocksCaseInsensitiveKey(t *testing.T) {
 	}
 }
 
+func TestInspectServerBlocksPathCaseSensitivity(t *testing.T) {
+	filename := "Testfile"
+	ctx := newContext().(*httpContext)
+	input := strings.NewReader("/path {\n}\n/PATH {\n}")
+	sblocks, err := caddyfile.Parse(filename, input, nil)
+	if err != nil {
+		t.Fatalf("Expected no error setting up test, got: %v", err)
+	}
+	CaseSensitivePath = true
+	_, err = ctx.InspectServerBlocks(filename, sblocks)
+	if err != nil {
+		t.Error("Expected no error with matching, differently-cased paths with CaseSensitivePath == true, but got error")
+	}
+	CaseSensitivePath = false
+	_, err = ctx.InspectServerBlocks(filename, sblocks)
+	if err == nil {
+		t.Error("Expected error with matching, differently-cased paths with CaseSensitivePath == false, but got error")
+	}
+}
+
 func TestGetConfig(t *testing.T) {
 	// case insensitivity for key
 	con := caddy.NewTestController("http", "")

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -344,7 +344,15 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	// the URL path, so a request to example.com/foo/blog on the site
 	// defined as example.com/foo appears as /blog instead of /foo/blog.
 	if pathPrefix != "/" {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, pathPrefix)
+		if CaseSensitivePath {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, pathPrefix)
+		} else {
+			// The following is essentially a case-insensitive implementation
+			// of strings.TrimPrefix
+			if strings.HasPrefix(strings.ToLower(r.URL.Path), strings.ToLower(pathPrefix)) {
+				r.URL.Path = r.URL.Path[len(pathPrefix):]
+			}
+		}
 		if !strings.HasPrefix(r.URL.Path, "/") {
 			r.URL.Path = "/" + r.URL.Path
 		}

--- a/caddyhttp/httpserver/vhosttrie.go
+++ b/caddyhttp/httpserver/vhosttrie.go
@@ -33,6 +33,10 @@ func (t *vhostTrie) Insert(key string, site *SiteConfig) {
 // insertPath expects t to be a host node (not a root node),
 // and inserts site into the t according to remainingPath.
 func (t *vhostTrie) insertPath(remainingPath, originalPath string, site *SiteConfig) {
+	if !CaseSensitivePath {
+		remainingPath = strings.ToLower(remainingPath)
+		originalPath = strings.ToLower(originalPath)
+	}
 	if remainingPath == "" {
 		t.site = site
 		t.path = originalPath
@@ -103,6 +107,9 @@ func (t *vhostTrie) matchHost(host string) *vhostTrie {
 // remainingPath, and returns its node.
 func (t *vhostTrie) matchPath(remainingPath string) *vhostTrie {
 	var longestMatch *vhostTrie
+	if !CaseSensitivePath {
+		remainingPath = strings.ToLower(remainingPath)
+	}
 	for len(remainingPath) > 0 {
 		ch := string(remainingPath[0])
 		next, ok := t.edges[ch]

--- a/caddyhttp/httpserver/vhosttrie_test.go
+++ b/caddyhttp/httpserver/vhosttrie_test.go
@@ -16,6 +16,7 @@ func TestVHostTrie(t *testing.T) {
 		"example.com/foo/bar",
 		"*.example.com/test",
 	})
+	CaseSensitivePath = true
 	assertTestTrie(t, trie, []vhostTrieTest{
 		{"not-in-trie.com", false, "", "/"},
 		{"example", true, "example", "/"},
@@ -79,6 +80,19 @@ func TestVHostTriePort(t *testing.T) {
 	assertTestTrie(t, trie, []vhostTrieTest{
 		{"example.com/foo", true, "example.com:1234", "/"},
 	}, true)
+}
+
+func TestVHostTrieCaseSensitivePath(t *testing.T) {
+	trie := newVHostTrie()
+	populateTestTrie(trie, []string{
+		"example.com/PATH",
+		"example.com/path",
+	})
+	CaseSensitivePath = true
+	assertTestTrie(t, trie, []vhostTrieTest{
+		{"example.com/path", true, "example.com/path", "/path"},
+		{"example.com/PATH", true, "example.com/PATH", "/PATH"},
+	}, false)
 }
 
 func populateTestTrie(trie *vhostTrie, keys []string) {


### PR DESCRIPTION
Closes #1517 

`httpContext` assumed that the entire address string could be case-insensitive and therefore lowercased it in order to detect duplicate entries. However, an address' path _is_ case-sensitive (e.g. `http://localhost:80/foo` and `http://localhost:80/Foo` are unique). This pull request modifies the lowercasing behavior to exclude the path.