### PR TITLE
Cleanly shutdown proxy healthchecks on restart

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -43,9 +43,8 @@ type Upstream interface {
 	// Gets the number of upstream hosts.
 	GetHostCount() int
 
-	// Gets the upstream's shutdown function for shutting
-	// down connections cleanly.
-	GetShutdownFunc() func() error
+	// Stops the upstream from proxying requests to shutdown goroutines cleanly.
+	Stop() error
 }
 
 // UpstreamHostDownFunc can be used to customize how Down behaves.

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -42,6 +42,10 @@ type Upstream interface {
 
 	// Gets the number of upstream hosts.
 	GetHostCount() int
+
+	// Gets the upstream's shutdown function for shutting
+	// down connections cleanly.
+	GetShutdownFunc() func() error
 }
 
 // UpstreamHostDownFunc can be used to customize how Down behaves.

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -1216,6 +1216,7 @@ func (u *fakeUpstream) AllowedPath(requestPath string) bool { return true }
 func (u *fakeUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeUpstream) GetHostCount() int                   { return 1 }
+func (u *fakeUpstream) GetShutdownFunc() func() error       { return func() error { return nil } }
 
 // newWebSocketTestProxy returns a test proxy that will
 // redirect to the specified backendAddr. The function
@@ -1268,6 +1269,7 @@ func (u *fakeWsUpstream) AllowedPath(requestPath string) bool { return true }
 func (u *fakeWsUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeWsUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeWsUpstream) GetHostCount() int                   { return 1 }
+func (u *fakeWsUpstream) GetShutdownFunc() func() error       { return func() error { return nil } }
 
 // recorderHijacker is a ResponseRecorder that can
 // be hijacked.

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -1216,7 +1216,7 @@ func (u *fakeUpstream) AllowedPath(requestPath string) bool { return true }
 func (u *fakeUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeUpstream) GetHostCount() int                   { return 1 }
-func (u *fakeUpstream) GetShutdownFunc() func() error       { return func() error { return nil } }
+func (u *fakeUpstream) Stop() error                         { return nil }
 
 // newWebSocketTestProxy returns a test proxy that will
 // redirect to the specified backendAddr. The function
@@ -1269,7 +1269,7 @@ func (u *fakeWsUpstream) AllowedPath(requestPath string) bool { return true }
 func (u *fakeWsUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeWsUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeWsUpstream) GetHostCount() int                   { return 1 }
-func (u *fakeWsUpstream) GetShutdownFunc() func() error       { return func() error { return nil } }
+func (u *fakeWsUpstream) Stop() error                         { return nil }
 
 // recorderHijacker is a ResponseRecorder that can
 // be hijacked.

--- a/caddyhttp/proxy/setup.go
+++ b/caddyhttp/proxy/setup.go
@@ -21,5 +21,10 @@ func setup(c *caddy.Controller) error {
 	httpserver.GetConfig(c).AddMiddleware(func(next httpserver.Handler) httpserver.Handler {
 		return Proxy{Next: next, Upstreams: upstreams}
 	})
+
+	for _, upstream := range upstreams {
+		c.OnRestart(upstream.GetShutdownFunc())
+	}
+
 	return nil
 }

--- a/caddyhttp/proxy/setup.go
+++ b/caddyhttp/proxy/setup.go
@@ -22,8 +22,10 @@ func setup(c *caddy.Controller) error {
 		return Proxy{Next: next, Upstreams: upstreams}
 	})
 
+	// Register shutdown and restart handlers.
 	for _, upstream := range upstreams {
-		c.OnRestart(upstream.GetShutdownFunc())
+		c.OnRestart(upstream.Stop)
+		c.OnShutdown(upstream.Stop)
 	}
 
 	return nil

--- a/caddyhttp/proxy/setup.go
+++ b/caddyhttp/proxy/setup.go
@@ -22,9 +22,8 @@ func setup(c *caddy.Controller) error {
 		return Proxy{Next: next, Upstreams: upstreams}
 	})
 
-	// Register shutdown and restart handlers.
+	// Register shutdown handlers.
 	for _, upstream := range upstreams {
-		c.OnRestart(upstream.Stop)
 		c.OnShutdown(upstream.Stop)
 	}
 

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -113,8 +113,8 @@ func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
 			upstream.HealthCheck.Client = http.Client{
 				Timeout: upstream.HealthCheck.Timeout,
 			}
+			upstream.wg.Add(1)
 			go func() {
-				upstream.wg.Add(1)
 				defer upstream.wg.Done()
 				upstream.HealthCheckWorker(upstream.stop)
 			}()

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -223,7 +223,7 @@ func TestStop(t *testing.T) {
 			var counter int64 = 0
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				r.Body.Close()
-				counter = atomic.AddInt64(&counter, 1)
+				atomic.AddInt64(&counter, 1)
 			}))
 
 			defer backend.Close()

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -220,7 +220,7 @@ func TestStop(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			// Set up proxy.
-			var counter int64 = 0
+			var counter int64
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				r.Body.Close()
 				atomic.AddInt64(&counter, 1)

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -1,8 +1,11 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -186,6 +189,74 @@ func TestParseBlockHealthCheck(t *testing.T) {
 				test.timeout,
 			)
 		}
+	}
+}
+
+func TestStop(t *testing.T) {
+	config := "proxy / %s {\n health_check /healthcheck \nhealth_check_interval %dms \n}"
+	tests := []struct {
+		name                    string
+		intervalInMilliseconds  int
+		numHealthcheckIntervals int
+	}{
+		{
+			"No Healthchecks After Stop - 5ms, 1 intervals",
+			5,
+			1,
+		},
+		{
+			"No Healthchecks After Stop - 5ms, 2 intervals",
+			5,
+			2,
+		},
+		{
+			"No Healthchecks After Stop - 5ms, 3 intervals",
+			5,
+			3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Set up proxy.
+			var counter int64 = 0
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				r.Body.Close()
+				counter = atomic.AddInt64(&counter, 1)
+			}))
+
+			defer backend.Close()
+
+			upstreams, err := NewStaticUpstreams(caddyfile.NewDispenser("Testfile", strings.NewReader(fmt.Sprintf(config, backend.URL, test.intervalInMilliseconds))))
+			if err != nil {
+				t.Error("Expected no error. Got:", err.Error())
+			}
+
+			// Give some time for healthchecks to hit the server.
+			time.Sleep(time.Duration(test.intervalInMilliseconds*test.numHealthcheckIntervals) * time.Millisecond)
+
+			for _, upstream := range upstreams {
+				if err := upstream.Stop(); err != nil {
+					t.Error("Expected no error stopping upstream. Got: ", err.Error())
+				}
+			}
+
+			counterValueAfterShutdown := counter
+
+			// Give some time to see if healthchecks are still hitting the server.
+			time.Sleep(time.Duration(test.intervalInMilliseconds*test.numHealthcheckIntervals) * time.Millisecond)
+
+			if counterValueAfterShutdown == 0 {
+				t.Error("Expected healthchecks to hit test server. Got no healthchecks.")
+			}
+
+			if counter != counterValueAfterShutdown {
+				t.Errorf("Expected no more healthchecks after shutdown. Got: %d healthchecks after shutdown", counter-counterValueAfterShutdown)
+			}
+
+		})
+
 	}
 }
 

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -242,7 +242,7 @@ func TestStop(t *testing.T) {
 				}
 			}
 
-			counterValueAfterShutdown := counter
+			counterValueAfterShutdown := atomic.LoadInt64(&counter)
 
 			// Give some time to see if healthchecks are still hitting the server.
 			time.Sleep(time.Duration(test.intervalInMilliseconds*test.numHealthcheckIntervals) * time.Millisecond)
@@ -251,8 +251,9 @@ func TestStop(t *testing.T) {
 				t.Error("Expected healthchecks to hit test server. Got no healthchecks.")
 			}
 
-			if counter != counterValueAfterShutdown {
-				t.Errorf("Expected no more healthchecks after shutdown. Got: %d healthchecks after shutdown", counter-counterValueAfterShutdown)
+			counterValueAfterWaiting := atomic.LoadInt64(&counter)
+			if counterValueAfterWaiting != counterValueAfterShutdown {
+				t.Errorf("Expected no more healthchecks after shutdown. Got: %d healthchecks after shutdown", counterValueAfterWaiting-counterValueAfterShutdown)
 			}
 
 		})


### PR DESCRIPTION
Closes #1503. 

This pull request adds a Stop method to the Upstream interface for safely shutting down the running goroutines.
The Stop function is registered with the Caddy controller's OnShutdown handler during setup so that the kill signal is propagated to all consumers.

I added some tests to check that healthchecks don't get sent after upstreams receive their kill signals.