### PR TITLE
Sort Browse listing by dir first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Caddyfile
 og_static/
 
 .vscode/
+
+caddyhttp/browse/temp*

--- a/caddyhttp/browse/browse.go
+++ b/caddyhttp/browse/browse.go
@@ -137,7 +137,14 @@ func (l byName) Swap(i, j int) { l.Items[i], l.Items[j] = l.Items[j], l.Items[i]
 
 // Treat upper and lower case equally
 func (l byName) Less(i, j int) bool {
-	return strings.ToLower(l.Items[i].Name) < strings.ToLower(l.Items[j].Name)
+
+	// if both are dir or file sort normally
+	if l.Items[i].IsDir == l.Items[j].IsDir {
+		return strings.ToLower(l.Items[i].Name) < strings.ToLower(l.Items[j].Name)
+	} else {
+		// always sort dir ahead of file
+		return l.Items[i].IsDir
+	}
 }
 
 // By Size

--- a/caddyhttp/browse/browse_test.go
+++ b/caddyhttp/browse/browse_test.go
@@ -181,9 +181,7 @@ func TestBrowseTemplate(t *testing.T) {
 
 <h1>/photos/</h1>
 
-<a href="./A%20Folder/">A Folder</a><br>
-
-<a href="./B%20Folder/">B Folder</a><br>
+<a href="./test1/">test1</a><br>
 
 <a href="./test.html">test.html</a><br>
 

--- a/caddyhttp/browse/browse_test.go
+++ b/caddyhttp/browse/browse_test.go
@@ -167,7 +167,7 @@ func TestBrowseTemplate(t *testing.T) {
 
 	code, _ := b.ServeHTTP(rec, req)
 	if code != http.StatusOK {
-		t.Fatalf("Wrong status, expected '%d', got '%d'", http.StatusOK, code)
+		t.Fatalf("Wrong status, expected %d, got %d", http.StatusOK, code)
 	}
 
 	respBody := rec.Body.String()

--- a/caddyhttp/browse/browse_test.go
+++ b/caddyhttp/browse/browse_test.go
@@ -167,7 +167,7 @@ func TestBrowseTemplate(t *testing.T) {
 
 	code, _ := b.ServeHTTP(rec, req)
 	if code != http.StatusOK {
-		t.Fatalf("Wrong status, expected %d, got %d", http.StatusOK, code)
+		t.Fatalf("Wrong status, expected '%d', got '%d'", http.StatusOK, code)
 	}
 
 	respBody := rec.Body.String()
@@ -181,6 +181,10 @@ func TestBrowseTemplate(t *testing.T) {
 
 <h1>/photos/</h1>
 
+<a href="./A%20Folder/">A Folder</a><br>
+
+<a href="./B%20Folder/">B Folder</a><br>
+
 <a href="./test.html">test.html</a><br>
 
 <a href="./test2.html">test2.html</a><br>
@@ -192,7 +196,7 @@ func TestBrowseTemplate(t *testing.T) {
 `
 
 	if respBody != expectedBody {
-		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+		t.Fatalf("Expected body: '%v' got: '%v'", expectedBody, respBody)
 	}
 
 }

--- a/caddyhttp/browse/testdata/photos/test1/test.html
+++ b/caddyhttp/browse/testdata/photos/test1/test.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Following [this discussion on the caddy forum](https://forum.caddyserver.com/t/browse-function-display-folders-first/1613) this PR changes default ordering of a directory listing to show Directories first in alphabetical order then files in alphabetical order.  

This is the standard ordering that people expect to see in any gui (web or desktop based) display of files and folders.  The change simply modifies the main name sort.  When sorting on modified date, I have left it the same so it sorts files and folders together as a list.

I modified the test and added a folder to the test directory to show that the sorting works.

