### PR TITLE
Allow setting directive tls to "no_email"

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -95,9 +95,11 @@ type Config struct {
 	DNSProvider string
 
 	// The email address to use when creating or
-	// using an ACME account (fun fact: if this
-	// is set to "off" then this config will not
-	// qualify for managed TLS)
+	// using an ACME account. If this is set to
+	// "off" then this config will not qualify
+	// for managed TLS. If it is set to "no_email"
+	// registration will be done with an empty
+	// email address.
 	ACMEEmail string
 
 	// The type of key to use when generating

--- a/caddytls/user.go
+++ b/caddytls/user.go
@@ -25,7 +25,11 @@ type User struct {
 
 // GetEmail gets u's email.
 func (u User) GetEmail() string {
-	return u.Email
+	if (u.Email == "no_email") {
+		return ""
+	} else {
+		return u.Email
+	}
 }
 
 // GetRegistration gets u's registration resource.

--- a/caddytls/user_test.go
+++ b/caddytls/user_test.go
@@ -40,6 +40,18 @@ func TestUser(t *testing.T) {
 	}
 }
 
+func TestUserNoEmail(t *testing.T) {
+	u := User{
+		Email:        "no_email",
+		Registration: nil,
+		key:          nil,
+	}
+
+	if expected, actual := "", u.GetEmail(); actual != expected {
+		t.Errorf("Expected email '%s' but got '%s'", expected, actual)
+	}
+}
+
 func TestNewUser(t *testing.T) {
 	email := "me@foobar.com"
 	user, err := newUser(email)


### PR DESCRIPTION
This allows to suppress the prompt while still registering with LE without an email address.

I kept the string "no_email" in `caddytls.Config.ACMEEmail` all the way down and implemented the mangling to an empty string only in the `GetEmail()` receiver function that implements the `github.com/xenolf/lego/acme.User` interface. This seemed reasonable because the string is also used to identify the user when his credentials are saved to disk.