### PR TITLE
Disable warning for insecure CA if located on private network.

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -763,6 +763,34 @@ func IsLoopback(addr string) bool {
 		strings.HasPrefix(host, "127.")
 }
 
+// IsPrivateNetwork returns true if the IP of addr
+// belongs to a private network IP range. addr must only
+// be an IP or an IP:port combination.
+func IsPrivateNetwork(addr string) bool {
+	private_networks := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"fc00::/7",
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr // happens if the addr is just a hostname
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, private_network := range private_networks {
+		_, ipnet, _ := net.ParseCIDR(private_network)
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // Upgrade re-launches the process, preserving the listeners
 // for a graceful restart. It does NOT load new configuration;
 // it only starts the process anew with a fresh binary.

--- a/caddy.go
+++ b/caddy.go
@@ -763,10 +763,11 @@ func IsLoopback(addr string) bool {
 		strings.HasPrefix(host, "127.")
 }
 
-// IsPrivateNetwork returns true if the IP of addr
+// IsInternal returns true if the IP of addr
 // belongs to a private network IP range. addr must only
 // be an IP or an IP:port combination.
-func IsPrivateNetwork(addr string) bool {
+// Loopback addresses are considered false.
+func IsInternal(addr string) bool {
 	private_networks := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",

--- a/caddy_test.go
+++ b/caddy_test.go
@@ -61,6 +61,48 @@ func TestIsLoopback(t *testing.T) {
 	}
 }
 
+func TestIsPrivateNetwork(t *testing.T) {
+	for i, test := range []struct {
+		input  string
+		expect bool
+	}{
+		{"10.0.0.0", true},
+		{"10.0.0.5", true},
+		{"10.255.255.255", true},
+		{"10.0.0.5:1234", true},
+		{"172.16.0.0", true},
+		{"172.19.1.1", true},
+		{"172.31.255.255", true},
+		{"192.168.0.0", true},
+		{"192.168.1.12", true},
+		{"192.168.255.255", true},
+		{"fc00::1", true},
+		{"fd12:3456:789a:1::1", true},
+		{"fd12:3456:789a:1::1:1234", true},
+		{"fd3e:00c3:62a6:e2b3::", true},
+		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true},
+		{"example.com", false},
+		{"localhost", false},
+		{"localhost:1234", false},
+		{"localhost:", false},
+		{"127.0.0.1", false},
+		{"127.0.0.1:443", false},
+		{"127.0.1.5", false},
+		{"12.7.0.1", false},
+		{"[::1]", false},
+		{"[::1]:1234", false},
+		{"::1", false},
+		{"::", false},
+		{"[::]", false},
+		{"local", false},
+		{"cc85:e78:948c:2ad6:5959:102d:10cb:31c4", false},
+	} {
+		if got, want := IsPrivateNetwork(test.input), test.expect; got != want {
+			t.Errorf("Test %d (%s): expected %v but was %v", i, test.input, want, got)
+		}
+	}
+}
+
 func TestListenerAddrEqual(t *testing.T) {
 	ln1, err := net.Listen("tcp", "[::]:0")
 	if err != nil {

--- a/caddy_test.go
+++ b/caddy_test.go
@@ -61,7 +61,7 @@ func TestIsLoopback(t *testing.T) {
 	}
 }
 
-func TestIsPrivateNetwork(t *testing.T) {
+func TestIsInternal(t *testing.T) {
 	for i, test := range []struct {
 		input  string
 		expect bool
@@ -114,7 +114,7 @@ func TestIsPrivateNetwork(t *testing.T) {
 		{"[::]", false},
 		{"local", false},
 	} {
-		if got, want := IsPrivateNetwork(test.input), test.expect; got != want {
+		if got, want := IsInternal(test.input), test.expect; got != want {
 			t.Errorf("Test %d (%s): expected %v but was %v", i, test.input, want, got)
 		}
 	}

--- a/caddy_test.go
+++ b/caddy_test.go
@@ -66,21 +66,39 @@ func TestIsPrivateNetwork(t *testing.T) {
 		input  string
 		expect bool
 	}{
+		{"9.255.255.255", false},
 		{"10.0.0.0", true},
-		{"10.0.0.5", true},
+		{"10.0.0.1", true},
+		{"10.255.255.254", true},
 		{"10.255.255.255", true},
+		{"11.0.0.0", false},
 		{"10.0.0.5:1234", true},
+		{"11.0.0.5:1234", false},
+
+		{"172.15.255.255", false},
 		{"172.16.0.0", true},
-		{"172.19.1.1", true},
+		{"172.16.0.1", true},
+		{"172.31.255.254", true},
 		{"172.31.255.255", true},
+		{"172.32.0.0", false},
+		{"172.16.0.1:1234", true},
+
+		{"192.167.255.255", false},
 		{"192.168.0.0", true},
-		{"192.168.1.12", true},
+		{"192.168.0.1", true},
+		{"192.168.255.254", true},
 		{"192.168.255.255", true},
+		{"192.169.0.0", false},
+		{"192.168.0.1:1234", true},
+
+		{"fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false},
+		{"fc00::", true},
 		{"fc00::1", true},
-		{"fd12:3456:789a:1::1", true},
-		{"fd12:3456:789a:1::1:1234", true},
-		{"fd3e:00c3:62a6:e2b3::", true},
+		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe", true},
 		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true},
+		{"fe00::", false},
+		{"fd12:3456:789a:1::1:1234", true},
+
 		{"example.com", false},
 		{"localhost", false},
 		{"localhost:1234", false},
@@ -95,7 +113,6 @@ func TestIsPrivateNetwork(t *testing.T) {
 		{"::", false},
 		{"[::]", false},
 		{"local", false},
-		{"cc85:e78:948c:2ad6:5959:102d:10cb:31c4", false},
 	} {
 		if got, want := IsPrivateNetwork(test.input), test.expect; got != want {
 			t.Errorf("Test %d (%s): expected %v but was %v", i, test.input, want, got)

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -61,7 +61,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 	if err != nil {
 		return nil, err
 	}
-	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsPrivateNetwork(u.Host) {
+	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsInternal(u.Host) {
 		return nil, fmt.Errorf("%s: insecure CA URL (HTTPS required)", caURL)
 	}
 

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -61,7 +61,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 	if err != nil {
 		return nil, err
 	}
-	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !strings.HasPrefix(u.Host, "10.") {
+	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsPrivateNetwork(u.Host) {
 		return nil, fmt.Errorf("%s: insecure CA URL (HTTPS required)", caURL)
 	}
 


### PR DESCRIPTION
My first Caddy PR :)

Fix for #1592. It doesn't handle hostnames that resolves to private IPs.