### PR TITLE
Fix 1592: Allow insecure CA URL on internal networks

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -777,9 +777,9 @@ func IsInternal(addr string) bool {
 
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		host = addr // happens if the addr is just a hostname
-		// if we encounter an error, the brackets need the be stripped
-		// because SplitHostPort didn't do it for us if there's no port
+		host = addr // happens if the addr is just a hostname, missing port
+		// if we encounter an error, the brackets need to be stripped
+		// because SplitHostPort didn't do it for us
 		host = strings.Trim(host, "[]")
 	}
 	ip := net.ParseIP(host)

--- a/caddy.go
+++ b/caddy.go
@@ -780,8 +780,7 @@ func IsInternal(addr string) bool {
 		host = addr // happens if the addr is just a hostname
 		// if we encounter an error, the brackets need the be stripped
 		// because SplitHostPort didn't do it for us if there's no port
-		host = strings.TrimLeft(host, "[")
-		host = strings.TrimRight(host, "]")
+		host = strings.Trim(host, "[]")
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {

--- a/caddy.go
+++ b/caddy.go
@@ -778,6 +778,10 @@ func IsInternal(addr string) bool {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr // happens if the addr is just a hostname
+		// if we encounter an error, the brackets need the be stripped
+		// because SplitHostPort didn't do it for us if there's no port
+		host = strings.TrimLeft(host, "[")
+		host = strings.TrimRight(host, "]")
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {

--- a/caddy_test.go
+++ b/caddy_test.go
@@ -94,6 +94,8 @@ func TestIsInternal(t *testing.T) {
 		{"fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", false},
 		{"fc00::", true},
 		{"fc00::1", true},
+		{"[fc00::1]", true},
+		{"[fc00::1]:8888", true},
 		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe", true},
 		{"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true},
 		{"fe00::", false},

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -61,7 +61,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 	if err != nil {
 		return nil, err
 	}
-	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsInternal(u.Host) {
+	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsInternal(u.Host) && !caddy.IsLoopback(u.Host) {
 		return nil, fmt.Errorf("%s: insecure CA URL (HTTPS required)", caURL)
 	}
 

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -61,7 +61,7 @@ var newACMEClient = func(config *Config, allowPrompts bool) (*ACMEClient, error)
 	if err != nil {
 		return nil, err
 	}
-	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsInternal(u.Host) && !caddy.IsLoopback(u.Host) {
+	if u.Scheme != "https" && !caddy.IsLoopback(u.Host) && !caddy.IsInternal(u.Host) {
 		return nil, fmt.Errorf("%s: insecure CA URL (HTTPS required)", caURL)
 	}
 


### PR DESCRIPTION
Followup to #1599 after #1592 was re-opened

If `net.SplitHostPort` returns an error (i.e. no port in the address), then we need to manually strip the square brackets so that it's a valid address for `net.ParseIP`, otherwise it returns `nil`.

I also added a couple tests to cover those cases.