### PR TITLE
Context: add Push action

### DIFF
--- a/caddyhttp/httpserver/context.go
+++ b/caddyhttp/httpserver/context.go
@@ -29,6 +29,20 @@ type Context struct {
 	Req  *http.Request
 	URL  *url.URL
 	Args []interface{} // defined by arguments to .Include
+
+	// just used for adding preload links for server push
+	responseHeader http.Header
+}
+
+// NewContextWithHeader creates a context with given response header.
+//
+// To plugin developer:
+// The returned context's exported fileds remain empty,
+// you should then initialize them if you want.
+func NewContextWithHeader(rh http.Header) Context {
+	return Context{
+		responseHeader: rh,
+	}
 }
 
 // Include returns the contents of filename relative to the site root.
@@ -408,6 +422,15 @@ func (c Context) RandomString(minLen, maxLen int) string {
 	}
 
 	return string(result)
+}
+
+// Push adds a preload link in response header for server push
+func (c Context) Push(link string) string {
+	if c.responseHeader == nil {
+		return ""
+	}
+	c.responseHeader.Add("Link", "<"+link+">; rel=preload")
+	return ""
 }
 
 // buffer pool for .Include context actions

--- a/caddyhttp/markdown/markdown.go
+++ b/caddyhttp/markdown/markdown.go
@@ -133,11 +133,10 @@ func (md Markdown) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 	}
 	lastModTime = latest(lastModTime, fs.ModTime())
 
-	ctx := httpserver.Context{
-		Root: md.FileSys,
-		Req:  r,
-		URL:  r.URL,
-	}
+	ctx := httpserver.NewContextWithHeader(w.Header())
+	ctx.Root = md.FileSys
+	ctx.Req = r
+	ctx.URL = r.URL
 	html, err := cfg.Markdown(title(fpath), f, dirents, ctx)
 	if err != nil {
 		return http.StatusInternalServerError, err

--- a/caddyhttp/templates/templates.go
+++ b/caddyhttp/templates/templates.go
@@ -34,7 +34,10 @@ func (t Templates) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		for _, ext := range rule.Extensions {
 			if reqExt == ext {
 				// Create execution context
-				ctx := httpserver.Context{Root: t.FileSys, Req: r, URL: r.URL}
+				ctx := httpserver.NewContextWithHeader(w.Header())
+				ctx.Root = t.FileSys
+				ctx.Req = r
+				ctx.URL = r.URL
 
 				// New template
 				templateName := filepath.Base(fpath)


### PR DESCRIPTION
During writing [my blog caddy plugin](https://github.com/tw4452852/caddy-totorow), I find that there is no way to add push links in template files. I think this is very useful to indicate server push in templates when combining with `push`.
For example, something in `index.html` looks like: 

```
...
<script src="/public/js/jquery.js" type="text/javascript" charset="utf-8"></script>
<link rel="stylesheet" type="text/css" href="/public/css/style.css" />
{{.AddLink /public/js/jquery.js}}
{{.AddLink /public/css/style.css}}
...
```

Client will receive server push for `/public/js/jquery.js` `/public/css/style.css`