### PR TITLE
lint fixes

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -768,7 +768,7 @@ func IsLoopback(addr string) bool {
 // be an IP or an IP:port combination.
 // Loopback addresses are considered false.
 func IsInternal(addr string) bool {
-	private_networks := []string{
+	privateNetworks := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
@@ -786,8 +786,8 @@ func IsInternal(addr string) bool {
 	if ip == nil {
 		return false
 	}
-	for _, private_network := range private_networks {
-		_, ipnet, _ := net.ParseCIDR(private_network)
+	for _, privateNetwork := range privateNetworks {
+		_, ipnet, _ := net.ParseCIDR(privateNetwork)
 		if ipnet.Contains(ip) {
 			return true
 		}

--- a/caddyhttp/browse/browse.go
+++ b/caddyhttp/browse/browse.go
@@ -156,10 +156,10 @@ func (l byNameDirFirst) Less(i, j int) bool {
 	// if both are dir or file sort normally
 	if l.Items[i].IsDir == l.Items[j].IsDir {
 		return strings.ToLower(l.Items[i].Name) < strings.ToLower(l.Items[j].Name)
-	} else {
-		// always sort dir ahead of file
-		return l.Items[i].IsDir
 	}
+
+	// always sort dir ahead of file
+	return l.Items[i].IsDir
 }
 
 // By Size

--- a/caddyhttp/httpserver/mitm.go
+++ b/caddyhttp/httpserver/mitm.go
@@ -161,11 +161,11 @@ func parseRawClientHello(data []byte) (info rawHelloInfo) {
 	if len(data) < 42 {
 		return
 	}
-	sessionIdLen := int(data[38])
-	if sessionIdLen > 32 || len(data) < 39+sessionIdLen {
+	sessionIDLen := int(data[38])
+	if sessionIDLen > 32 || len(data) < 39+sessionIDLen {
 		return
 	}
-	data = data[39+sessionIdLen:]
+	data = data[39+sessionIDLen:]
 	if len(data) < 2 {
 		return
 	}
@@ -598,6 +598,7 @@ var greaseCiphers = map[uint16]struct{}{
 	0xFAFA: {},
 }
 
+// Define variables used for TLS communication
 const (
 	extensionOCSPStatusRequest = 5
 	extensionSupportedCurves   = 10 // also called "SupportedGroups"

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -330,9 +330,9 @@ func (r *replacer) getSubstitution(key string) string {
 		if val, ok := r.request.Context().Value(caddy.CtxKey("mitm")).(bool); ok {
 			if val {
 				return "likely"
-			} else {
-				return "unlikely"
 			}
+
+			return "unlikely"
 		}
 		return "unknown"
 	case "{status}":

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -232,8 +232,8 @@ func (c *Config) StorageFor(caURL string) (Storage, error) {
 // buildStandardTLSConfig converts cfg (*caddytls.Config) to a *tls.Config
 // and stores it in cfg so it can be used in servers. If TLS is disabled,
 // no tls.Config is created.
-func (cfg *Config) buildStandardTLSConfig() error {
-	if !cfg.Enabled {
+func (c *Config) buildStandardTLSConfig() error {
+	if !c.Enabled {
 		return nil
 	}
 
@@ -243,35 +243,35 @@ func (cfg *Config) buildStandardTLSConfig() error {
 	curvesAdded := make(map[tls.CurveID]struct{})
 
 	// add cipher suites
-	for _, ciph := range cfg.Ciphers {
+	for _, ciph := range c.Ciphers {
 		if _, ok := ciphersAdded[ciph]; !ok {
 			ciphersAdded[ciph] = struct{}{}
 			config.CipherSuites = append(config.CipherSuites, ciph)
 		}
 	}
 
-	config.PreferServerCipherSuites = cfg.PreferServerCipherSuites
+	config.PreferServerCipherSuites = c.PreferServerCipherSuites
 
 	// add curve preferences
-	for _, curv := range cfg.CurvePreferences {
+	for _, curv := range c.CurvePreferences {
 		if _, ok := curvesAdded[curv]; !ok {
 			curvesAdded[curv] = struct{}{}
 			config.CurvePreferences = append(config.CurvePreferences, curv)
 		}
 	}
 
-	config.MinVersion = cfg.ProtocolMinVersion
-	config.MaxVersion = cfg.ProtocolMaxVersion
-	config.ClientAuth = cfg.ClientAuth
-	config.NextProtos = cfg.ALPN
-	config.GetCertificate = cfg.GetCertificate
+	config.MinVersion = c.ProtocolMinVersion
+	config.MaxVersion = c.ProtocolMaxVersion
+	config.ClientAuth = c.ClientAuth
+	config.NextProtos = c.ALPN
+	config.GetCertificate = c.GetCertificate
 
 	// set up client authentication if enabled
 	if config.ClientAuth != tls.NoClientCert {
 		pool := x509.NewCertPool()
 		clientCertsAdded := make(map[string]struct{})
 
-		for _, caFile := range cfg.ClientCerts {
+		for _, caFile := range c.ClientCerts {
 			// don't add cert to pool more than once
 			if _, ok := clientCertsAdded[caFile]; ok {
 				continue
@@ -303,7 +303,7 @@ func (cfg *Config) buildStandardTLSConfig() error {
 	}
 
 	// store the resulting new tls.Config
-	cfg.tlsConfig = config
+	c.tlsConfig = config
 
 	return nil
 }

--- a/plugins.go
+++ b/plugins.go
@@ -217,6 +217,7 @@ func RegisterPlugin(name string, plugin Plugin) {
 // EventName represents the name of an event used with event hooks.
 type EventName string
 
+// Define the event names for the startup and shutdown events
 const (
 	StartupEvent  EventName = "startup"
 	ShutdownEvent EventName = "shutdown"


### PR DESCRIPTION
### 1. What does this change do, exactly?
Fixed most of the warning presented by running `golint ./...`

### 2. Please link to the relevant issues.
None.

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- ✅  I have written tests and verified that they fail without my change
- ✅ I have squashed any insignificant commits
- ✅ This change has comments for package types, values, functions, and non-obvious lines of code
- ✅ I am willing to help maintain this change if there are issues with it later

### 5. Other Notes
There is still some remaining warning, but I'm not sure I agree with them:
```
caddyhttp/httpserver/mitm.go:612:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:613:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:614:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:615:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:616:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:617:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:618:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/httpserver/mitm.go:619:2: don't use ALL_CAPS in Go names; use CamelCase
caddyhttp/markdown/summary/render.go:27:19: method BlockHtml should be BlockHTML
caddyhttp/markdown/summary/render.go:118:19: method RawHtmlTag should be RawHTMLTag
```
The using `ALL_CAPS` warnings in `caddyhttp/httpserver/mitm.go` is for the cipher suite list, and it is done the same way that the `crypto/tls` package does it. Any thoughts on this?

And `BlockHtml` and `RawHtmlTag` are methods to implement the `russross/blackfriday` package.