### PR TITLE
rename Push action for more general use

### DIFF
--- a/caddyhttp/httpserver/tplcontext.go
+++ b/caddyhttp/httpserver/tplcontext.go
@@ -424,12 +424,13 @@ func (c Context) RandomString(minLen, maxLen int) string {
 	return string(result)
 }
 
-// Push adds a preload link in response header for server push
-func (c Context) Push(link string) string {
+// AddLink adds a link header in response
+// see https://www.w3.org/wiki/LinkHeader
+func (c Context) AddLink(link string) string {
 	if c.responseHeader == nil {
 		return ""
 	}
-	c.responseHeader.Add("Link", "<"+link+">; rel=preload")
+	c.responseHeader.Add("Link", link)
 	return ""
 }
 

--- a/caddyhttp/httpserver/tplcontext_test.go
+++ b/caddyhttp/httpserver/tplcontext_test.go
@@ -877,18 +877,18 @@ func TestFiles(t *testing.T) {
 	}
 }
 
-func TestPush(t *testing.T) {
+func TestAddLink(t *testing.T) {
 	for name, c := range map[string]struct {
 		input       string
 		expectLinks []string
 	}{
 		"oneLink": {
-			input:       `{{.Push "/test.css"}}`,
+			input:       `{{.AddLink "</test.css>; rel=preload"}}`,
 			expectLinks: []string{"</test.css>; rel=preload"},
 		},
 		"multipleLinks": {
-			input:       `{{.Push "/test1.css"}} {{.Push "/test2.css"}}`,
-			expectLinks: []string{"</test1.css>; rel=preload", "</test2.css>; rel=preload"},
+			input:       `{{.AddLink "</test1.css>; rel=preload"}} {{.AddLink "</test2.css>; rel=meta"}}`,
+			expectLinks: []string{"</test1.css>; rel=preload", "</test2.css>; rel=meta"},
 		},
 	} {
 		c := c


### PR DESCRIPTION
I have just read the `LinkHeader` [spec](https://www.w3.org/wiki/LinkHeader), found that we should support it more generally, like `Apache` and `Nginx` do.


(Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.)

### 1. What does this change do, exactly?

rename context's `Push` action to `AddLink` for more general use case.

### 2. Please link to the relevant issues.

N/A.

### 3. Which documentation changes (if any) need to be made because of this PR?

Add a new template action for `AddLink`.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
