### PR TITLE
internal: inherit original ResponseWriter's interfaces

### DIFF
--- a/caddyhttp/internalsrv/internal.go
+++ b/caddyhttp/internalsrv/internal.go
@@ -7,6 +7,8 @@
 package internalsrv
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -94,3 +96,51 @@ func (w internalResponseWriter) Write(b []byte) (int, error) {
 	}
 	return w.ResponseWriter.Write(b)
 }
+
+// Hijack implements http.Hijacker. It simply wraps the underlying
+// ResponseWriter's Hijack method if there is one, or returns an error.
+func (w internalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, httpserver.NonHijackerError{Underlying: w.ResponseWriter}
+}
+
+// Flush implements http.Flusher. It simply wraps the underlying
+// ResponseWriter's Flush method if there is one, or panics.
+func (w internalResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	} else {
+		panic(httpserver.NonFlusherError{Underlying: w.ResponseWriter})
+	}
+}
+
+// CloseNotify implements http.CloseNotifier.
+// It just inherits the underlying ResponseWriter's CloseNotify method.
+// It panics if the underlying ResponseWriter is not a CloseNotifier.
+func (w internalResponseWriter) CloseNotify() <-chan bool {
+	if cn, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return cn.CloseNotify()
+	}
+	panic(httpserver.NonCloseNotifierError{Underlying: w.ResponseWriter})
+}
+
+// Push implements http.Pusher.
+// It just inherits the underlying ResponseWriter's Push method.
+// It panics if the underlying ResponseWriter is not a Pusher.
+func (w internalResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, hasPusher := w.ResponseWriter.(http.Pusher); hasPusher {
+		return pusher.Push(target, opts)
+	}
+
+	return httpserver.NonPusherError{Underlying: w.ResponseWriter}
+}
+
+// Interface guards
+var (
+	_ http.Pusher        = internalResponseWriter{}
+	_ http.Flusher       = internalResponseWriter{}
+	_ http.CloseNotifier = internalResponseWriter{}
+	_ http.Hijacker      = internalResponseWriter{}
+)


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>

(Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.)

### 1. What does this change do, exactly?

make `internalResponseWriter` inherit original ResponseWriter's interfaces.

### 2. Please link to the relevant issues.

N/A.

### 3. Which documentation changes (if any) need to be made because of this PR?

No.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
