### PR TITLE
caddy 'login' plugin

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -468,6 +468,7 @@ var directives = []string{
 	"status",
 	"cors", // github.com/captncraig/cors/caddy
 	"mime",
+	"login",     // github.com/tarent/loginsrv/caddy
 	"jwt",       // github.com/BTBurke/caddy-jwt
 	"jsonp",     // github.com/pschlump/caddy-jsonp
 	"upload",    // blitznote.com/src/caddy.upload


### PR DESCRIPTION

I would like to add my login plugin as an official 3rd party plugin.
It allows the login using multiple backends and plays nicely together with the existing caddy-jwt plugin. 

See the README's for more details: 
  https://github.com/tarent/loginsrv
  https://github.com/tarent/loginsrv/tree/master/caddy