### PR TITLE
Support template arguments for Markdown.

### DIFF
--- a/caddyhttp/markdown/template.go
+++ b/caddyhttp/markdown/template.go
@@ -22,7 +22,8 @@ type Data struct {
 // Include "overrides" the embedded httpserver.Context's Include()
 // method so that included files have access to d's fields.
 // Note: using {{template 'template-name' .}} instead might be better.
-func (d Data) Include(filename string) (string, error) {
+func (d Data) Include(filename string, args ...interface{}) (string, error) {
+	d.Args = args
 	return httpserver.ContextInclude(filename, d, d.Root)
 }
 


### PR DESCRIPTION
### 1. What does this change do, exactly?

Adds the second `args ...interface{}` parameter to the version of `Include` used with the Markdown plugin. This allows arguments to included templates when using that plugin.

### 2. Please link to the relevant issues.


### 3. Which documentation changes (if any) need to be made because of this PR?

I don't think this will require any changes. The documentation already implies that passing arguments to included templates should be possible.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change - the file is untested at the moment and the change is pretty trivial, I can write tests if necessary, though.
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
