### PR TITLE
Support internationalized domain name (IDN) in Caddyfile

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -345,11 +345,10 @@ func standardizeAddress(str string) (Address, error) {
 
 	// convert non-ascii (IDNA) host to Punycode
 	if isIDN(host) {
-		asciiHost, err := idna.ToASCII(host)
+		host, err = idna.ToASCII(host)
 		if err != nil {
-			return Address{}, fmt.Errorf("Failed to convert IDN to ASCII: %s", input)
+			return Address{}, fmt.Errorf("failed to convert IDN to ASCII: %s", input)
 		}
-		host = asciiHost
 	}
 
 	// see if we can set port based off scheme


### PR DESCRIPTION
 ### 1. What does this change do, exactly?
It adds support for using an IDN as a site address in Caddyfiles. Instead of writing `xn--bcher-kva.ch`. it's now possible to write `bücher.ch`.

Ref: https://www.wikiwand.com/en/Internationalized_domain_name

### 2. Please link to the relevant issues.
N/A

### 3. Which documentation changes (if any) need to be made because of this PR?
Could add a note [in site address section](https://caddyserver.com/docs/http-caddyfile#addresses)

### 4. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later