### PR TITLE
Add check for maximum number of arguments to log directive

### DIFF
--- a/caddyhttp/log/setup.go
+++ b/caddyhttp/log/setup.go
@@ -72,7 +72,7 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 				format = strings.Replace(format, "{combined}", CombinedLogFormat, -1)
 			}
 		default:
-			// Maxiumum number of args in log directive is 3.
+			// Maximum number of args in log directive is 3.
 			return nil, c.ArgErr()
 		}
 

--- a/caddyhttp/log/setup.go
+++ b/caddyhttp/log/setup.go
@@ -71,6 +71,9 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 				},
 				Format: DefaultLogFormat,
 			})
+		} else if len(args) > 3 {
+			// Maxiumum number of args in log directive is 3.
+			return nil, c.ArgErr()
 		} else {
 			// Path scope, output file, and maybe a format specified
 

--- a/caddyhttp/log/setup.go
+++ b/caddyhttp/log/setup.go
@@ -53,57 +53,36 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 			}
 		}
 
+		path := "/"
+		format := DefaultLogFormat
+		output := DefaultLogFilename
+
 		switch len(args) {
 		case 0:
-			// Nothing specified; use defaults
-			rules = appendEntry(rules, "/", &Entry{
-				Log: &httpserver.Logger{
-					Output: DefaultLogFilename,
-					Roller: logRoller,
-				},
-				Format: DefaultLogFormat,
-			})
+			// nothing to change
 		case 1:
 			// Only an output file specified
-			rules = appendEntry(rules, "/", &Entry{
-				Log: &httpserver.Logger{
-					Output: args[0],
-					Roller: logRoller,
-				},
-				Format: DefaultLogFormat,
-			})
-		case 2:
-			// Path scope, output file
-			format := DefaultLogFormat
-
+			output = args[0]
+		case 2, 3:
+			// Path scope, output file, and maybe a format specified
+			path = args[0]
+			output = args[1]
 			if len(args) > 2 {
 				format = strings.Replace(args[2], "{common}", CommonLogFormat, -1)
 				format = strings.Replace(format, "{combined}", CombinedLogFormat, -1)
 			}
-
-			rules = appendEntry(rules, args[0], &Entry{
-				Log: &httpserver.Logger{
-					Output: args[1],
-					Roller: logRoller,
-				},
-				Format: format,
-			})
-		case 3:
-			// Path scope, output file, and format specified
-			format := strings.Replace(args[2], "{common}", CommonLogFormat, -1)
-			format = strings.Replace(format, "{combined}", CombinedLogFormat, -1)
-
-			rules = appendEntry(rules, args[0], &Entry{
-				Log: &httpserver.Logger{
-					Output: args[1],
-					Roller: logRoller,
-				},
-				Format: format,
-			})
 		default:
 			// Maxiumum number of args in log directive is 3.
 			return nil, c.ArgErr()
 		}
+
+		rules = appendEntry(rules, path, &Entry{
+			Log: &httpserver.Logger{
+				Output: output,
+				Roller: logRoller,
+			},
+			Format: format,
+		})
 	}
 
 	return rules, nil

--- a/caddyhttp/log/setup_test.go
+++ b/caddyhttp/log/setup_test.go
@@ -227,6 +227,7 @@ func TestLogParse(t *testing.T) {
 		}}},
 		{`log access.log { rotate_size }`, true, nil},
 		{`log access.log { invalid_option 1 }`, true, nil},
+		{`log / acccess.log "{remote} - [{when}] "{method} {port}" {scheme} {mitm} "`, true, nil},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("http", test.inputLogRules)


### PR DESCRIPTION
### 1. What does this change do, exactly?
This will add a check for maximum number of arguments to the log directive. If len(args) > 3 it will return an error. This can happen when having unmatched number of quotes.

### 2. Please link to the relevant issues.
#1668

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
