### PR TITLE
caddytls: Prefer ChaCha20 if AES-NI instruction set is unavailable

### DIFF
--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -58,21 +58,7 @@ func TestSetupParseBasic(t *testing.T) {
 	}
 
 	// Cipher checks
-	expectedCiphers := []uint16{
-		tls.TLS_FALLBACK_SCSV,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-	}
+	expectedCiphers := append([]uint16{tls.TLS_FALLBACK_SCSV}, getPreferredDefaultCiphers()...)
 
 	// Ensure count is correct (plus one for TLS_FALLBACK_SCSV)
 	if len(cfg.Ciphers) != len(expectedCiphers) {


### PR DESCRIPTION
### 1. What does this change do, exactly?

This PR allows Caddy to automatically detect the presence of absence of the AES-NI instruction set. If it is present, Caddy's normal cipher suites will be used. If AES-NI is not supported, ChaCha20 suites will be preferred over the slow, possibly not constant-time AES support that the Go runtime will use instead.

### 2. Please link to the relevant issues.

#1674

### 3. Which documentation changes (if any) need to be made because of this PR?

None required.
### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
