### PR TITLE
Fix lint warning by renaming MaxBytesExceededErr -> ErrMaxBytesExceeded

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -302,7 +302,7 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 		_, err := ioutil.ReadAll(r.request.Body)
 		if err != nil {
-			if err == MaxBytesExceededErr {
+			if err == ErrMaxBytesExceeded {
 				return r.emptyValue
 			}
 		}

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -478,9 +478,9 @@ func (ln tcpKeepAliveListener) File() (*os.File, error) {
 	return ln.TCPListener.File()
 }
 
-// MaxBytesExceeded is the error returned by MaxBytesReader
+// ErrMaxBytesExceeded is the error returned by MaxBytesReader
 // when the request body exceeds the limit imposed
-var MaxBytesExceededErr = errors.New("http: request body too large")
+var ErrMaxBytesExceeded = errors.New("http: request body too large")
 
 // DefaultErrorFunc responds to an HTTP request with a simple description
 // of the specified HTTP status code.

--- a/caddyhttp/limits/handler.go
+++ b/caddyhttp/limits/handler.go
@@ -31,7 +31,7 @@ func (l Limit) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 
 // MaxBytesReader and its associated methods are borrowed from the
 // Go Standard library (comments intact). The only difference is that
-// it returns a MaxBytesExceeded error instead of a generic error message
+// it returns a ErrMaxBytesExceeded error instead of a generic error message
 // when the request body has exceeded the requested limit
 func MaxBytesReader(w http.ResponseWriter, r io.ReadCloser, n int64) io.ReadCloser {
 	return &maxBytesReader{w: w, r: r, n: n}
@@ -81,7 +81,7 @@ func (l *maxBytesReader) Read(p []byte) (n int, err error) {
 	if res, ok := l.w.(requestTooLarger); ok {
 		res.requestTooLarge()
 	}
-	l.err = httpserver.MaxBytesExceededErr
+	l.err = httpserver.ErrMaxBytesExceeded
 	return n, l.err
 }
 

--- a/caddyhttp/limits/handler_test.go
+++ b/caddyhttp/limits/handler_test.go
@@ -29,7 +29,7 @@ func TestBodySizeLimit(t *testing.T) {
 	if got := string(gotContent); got != expectContent {
 		t.Errorf("expected content[%s], got[%s]", expectContent, got)
 	}
-	if gotError != httpserver.MaxBytesExceededErr {
-		t.Errorf("expect error %v, got %v", httpserver.MaxBytesExceededErr, gotError)
+	if gotError != httpserver.ErrMaxBytesExceeded {
+		t.Errorf("expect error %v, got %v", httpserver.ErrMaxBytesExceeded, gotError)
 	}
 }

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -228,7 +228,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			return 0, nil
 		}
 
-		if backendErr == httpserver.MaxBytesExceededErr {
+		if backendErr == httpserver.ErrMaxBytesExceeded {
 			return http.StatusRequestEntityTooLarge, backendErr
 		}
 


### PR DESCRIPTION
### 1. What does this change do, exactly?
Renames MaxBytesExceededErr to ErrMaxBytesExceeded and make golint happier :)

Ref: https://ci.appveyor.com/project/mholt/caddy/build/2811#L87

### 2. Please link to the relevant issues.
N/A

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
