### PR TITLE
markdown: reload template on each request and fix fake tests

### DIFF
--- a/caddyhttp/markdown/markdown.go
+++ b/caddyhttp/markdown/markdown.go
@@ -53,6 +53,9 @@ type Config struct {
 
 	// Template(s) to render with
 	Template *template.Template
+
+	// a pair of template's name and its underlying file path
+	TemplateFiles map[string]string
 }
 
 // ServeHTTP implements the http.Handler interface.

--- a/caddyhttp/markdown/markdown_test.go
+++ b/caddyhttp/markdown/markdown_test.go
@@ -1,16 +1,12 @@
 package markdown
 
 import (
-	"bufio"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"text/template"
-	"time"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"github.com/russross/blackfriday"
@@ -79,19 +75,23 @@ func TestMarkdown(t *testing.T) {
 		}),
 	}
 
-	req, err := http.NewRequest("GET", "/blog/test.md", nil)
-	if err != nil {
-		t.Fatalf("Could not create HTTP request: %v", err)
+	get := func(url string) string {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			t.Fatalf("Could not create HTTP request: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		code, err := md.ServeHTTP(rec, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if code != http.StatusOK {
+			t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, code)
+		}
+		return rec.Body.String()
 	}
 
-	rec := httptest.NewRecorder()
-
-	md.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
-	}
-
-	respBody := rec.Body.String()
+	respBody := get("/blog/test.md")
 	expectedBody := `<!DOCTYPE html>
 <html>
 <head>
@@ -99,7 +99,6 @@ func TestMarkdown(t *testing.T) {
 </head>
 <body>
 <h1>Header for: Markdown test 1</h1>
-
 Welcome to A Caddy website!
 <h2>Welcome on the blog</h2>
 
@@ -113,46 +112,22 @@ Welcome to A Caddy website!
 </body>
 </html>
 `
-	if !equalStrings(respBody, expectedBody) {
-		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
-	}
-
-	req, err = http.NewRequest("GET", "/docflags/test.md", nil)
-	if err != nil {
-		t.Fatalf("Could not create HTTP request: %v", err)
-	}
-	rec = httptest.NewRecorder()
-
-	md.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
-	}
-	respBody = rec.Body.String()
+	respBody = get("/docflags/test.md")
 	expectedBody = `Doc.var_string hello
-Doc.var_bool <no value>
-DocFlags.var_string <no value>
-DocFlags.var_bool true`
+Doc.var_bool true
+`
 
-	if !equalStrings(respBody, expectedBody) {
-		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	if respBody != expectedBody {
+		t.Fatalf("Expected body:\n%q\ngot:\n%q", expectedBody, respBody)
 	}
 
-	req, err = http.NewRequest("GET", "/log/test.md", nil)
-	if err != nil {
-		t.Fatalf("Could not create HTTP request: %v", err)
-	}
-	rec = httptest.NewRecorder()
-
-	md.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
-	}
-	respBody = rec.Body.String()
+	respBody = get("/log/test.md")
 	expectedBody = `<!DOCTYPE html>
 <html>
 	<head>
 		<title>Markdown test 2</title>
 		<meta charset="utf-8">
+
 		<link rel="stylesheet" href="/resources/css/log.css">
 		<link rel="stylesheet" href="/resources/css/default.css">
 		<script src="/resources/js/log.js"></script>
@@ -171,26 +146,11 @@ DocFlags.var_bool true`
 	</body>
 </html>`
 
-	if !equalStrings(respBody, expectedBody) {
-		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	if respBody != expectedBody {
+		t.Fatalf("Expected body:\n%q\ngot:\n%q", expectedBody, respBody)
 	}
 
-	req, err = http.NewRequest("GET", "/og/first.md", nil)
-	if err != nil {
-		t.Fatalf("Could not create HTTP request: %v", err)
-	}
-	rec = httptest.NewRecorder()
-	currenttime := time.Now().Local().Add(-time.Second)
-	_ = os.Chtimes("testdata/og/first.md", currenttime, currenttime)
-	currenttime = time.Now().Local()
-	_ = os.Chtimes("testdata/og_static/og/first.md/index.html", currenttime, currenttime)
-	time.Sleep(time.Millisecond * 200)
-
-	md.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, rec.Code)
-	}
-	respBody = rec.Body.String()
+	respBody = get("/og/first.md")
 	expectedBody = `<!DOCTYPE html>
 <html>
 <head>
@@ -198,30 +158,16 @@ DocFlags.var_bool true`
 </head>
 <body>
 <h1>Header for: first_post</h1>
-
 Welcome to title!
 <h1>Test h1</h1>
 
 </body>
-</html>`
+</html>
+`
 
-	if !equalStrings(respBody, expectedBody) {
-		t.Fatalf("Expected body: %v got: %v", expectedBody, respBody)
+	if respBody != expectedBody {
+		t.Fatalf("Expected body:\n%q\ngot:\n%q", expectedBody, respBody)
 	}
-}
-
-func equalStrings(s1, s2 string) bool {
-	s1 = strings.TrimSpace(s1)
-	s2 = strings.TrimSpace(s2)
-	in := bufio.NewScanner(strings.NewReader(s1))
-	for in.Scan() {
-		txt := strings.TrimSpace(in.Text())
-		if !strings.HasPrefix(strings.TrimSpace(s2), txt) {
-			return false
-		}
-		s2 = strings.Replace(s2, txt, "", 1)
-	}
-	return true
 }
 
 func setDefaultTemplate(filename string) *template.Template {

--- a/caddyhttp/markdown/markdown_test.go
+++ b/caddyhttp/markdown/markdown_test.go
@@ -81,14 +81,17 @@ func TestMarkdown(t *testing.T) {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			t.Fatalf("Could not create HTTP request: %v", err)
+			return ""
 		}
 		rec := httptest.NewRecorder()
 		code, err := md.ServeHTTP(rec, req)
 		if err != nil {
 			t.Fatal(err)
+			return ""
 		}
 		if code != http.StatusOK {
 			t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, code)
+			return ""
 		}
 		return rec.Body.String()
 	}
@@ -223,9 +226,11 @@ func TestTemplateReload(t *testing.T) {
 		code, err := md.ServeHTTP(rec, req)
 		if err != nil {
 			t.Fatal(err)
+			return ""
 		}
 		if code != http.StatusOK {
 			t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, code)
+			return ""
 		}
 		return rec.Body.String()
 	}

--- a/caddyhttp/markdown/setup.go
+++ b/caddyhttp/markdown/setup.go
@@ -115,15 +115,17 @@ func loadParams(c *caddy.Controller, mdc *Config) error {
 			fpath := filepath.ToSlash(filepath.Clean(cfg.Root + string(filepath.Separator) + tArgs[0]))
 
 			if err := SetTemplate(mdc.Template, "", fpath); err != nil {
-				c.Errf("default template parse error: %v", err)
+				return c.Errf("default template parse error: %v", err)
 			}
+
 			return nil
 		case 2:
 			fpath := filepath.ToSlash(filepath.Clean(cfg.Root + string(filepath.Separator) + tArgs[1]))
 
 			if err := SetTemplate(mdc.Template, tArgs[0], fpath); err != nil {
-				c.Errf("template parse error: %v", err)
+				return c.Errf("template parse error: %v", err)
 			}
+
 			return nil
 		}
 	case "templatedir":
@@ -132,11 +134,12 @@ func loadParams(c *caddy.Controller, mdc *Config) error {
 		}
 		_, err := mdc.Template.ParseGlob(c.Val())
 		if err != nil {
-			c.Errf("template load error: %v", err)
+			return c.Errf("template load error: %v", err)
 		}
 		if c.NextArg() {
 			return c.ArgErr()
 		}
+
 		return nil
 	default:
 		return c.Err("Expected valid markdown configuration property")

--- a/caddyhttp/markdown/setup_test.go
+++ b/caddyhttp/markdown/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 	"text/template"
 
@@ -59,9 +60,10 @@ func TestMarkdownParse(t *testing.T) {
 				".md":  {},
 				".txt": {},
 			},
-			Styles:   []string{"/resources/css/blog.css"},
-			Scripts:  []string{"/resources/js/blog.js"},
-			Template: GetDefaultTemplate(),
+			Styles:        []string{"/resources/css/blog.css"},
+			Scripts:       []string{"/resources/js/blog.js"},
+			Template:      GetDefaultTemplate(),
+			TemplateFiles: make(map[string]string),
 		}}},
 		{`markdown /blog {
 	ext .md
@@ -72,6 +74,9 @@ func TestMarkdownParse(t *testing.T) {
 				".md": {},
 			},
 			Template: setDefaultTemplate("./testdata/tpl_with_include.html"),
+			TemplateFiles: map[string]string{
+				"": "testdata/tpl_with_include.html",
+			},
 		}}},
 	}
 
@@ -107,6 +112,10 @@ func TestMarkdownParse(t *testing.T) {
 			if ok, tx, ty := equalTemplates(actualMarkdownConfig.Template, test.expectedMarkdownConfig[j].Template); !ok {
 				t.Errorf("Test %d the %dth Markdown Config Templates did not match, expected %s to be %s", i, j, tx, ty)
 			}
+			if expect, got := test.expectedMarkdownConfig[j].TemplateFiles, actualMarkdownConfig.TemplateFiles; !reflect.DeepEqual(expect, got) {
+				t.Errorf("Test %d the %d Markdown config TemplateFiles did not match, expect %v, but got %v", i, j, expect, got)
+			}
+
 		}
 	}
 }

--- a/caddyhttp/markdown/setup_test.go
+++ b/caddyhttp/markdown/setup_test.go
@@ -71,12 +71,9 @@ func TestMarkdownParse(t *testing.T) {
 			Extensions: map[string]struct{}{
 				".md": {},
 			},
-			Template: GetDefaultTemplate(),
+			Template: setDefaultTemplate("./testdata/tpl_with_include.html"),
 		}}},
 	}
-	// Setup the extra template
-	tmpl := tests[1].expectedMarkdownConfig[0].Template
-	SetTemplate(tmpl, "", "./testdata/tpl_with_include.html")
 
 	for i, test := range tests {
 		c := caddy.NewTestController("http", test.inputMarkdownConfig)

--- a/caddyhttp/markdown/template.go
+++ b/caddyhttp/markdown/template.go
@@ -38,8 +38,18 @@ func execTemplate(c *Config, mdata metadata.Metadata, meta map[string]string, fi
 		Files:   files,
 	}
 
+	templateName := mdata.Template
+	// reload template on every request for now
+	// TODO: cache templates by a general plugin
+	if templateFile, ok := c.TemplateFiles[templateName]; ok {
+		err := SetTemplate(c.Template, templateName, templateFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	b := new(bytes.Buffer)
-	if err := c.Template.ExecuteTemplate(b, mdata.Template, mdData); err != nil {
+	if err := c.Template.ExecuteTemplate(b, templateName, mdData); err != nil {
 		return nil, err
 	}
 

--- a/caddyhttp/markdown/testdata/blog/test.md
+++ b/caddyhttp/markdown/testdata/blog/test.md
@@ -1,0 +1,14 @@
+---
+title: Markdown test 1
+sitename: A Caddy website
+---
+
+## Welcome on the blog
+
+Body
+
+``` go
+func getTrue() bool {
+    return true
+}
+```

--- a/caddyhttp/markdown/testdata/docflags/template.txt
+++ b/caddyhttp/markdown/testdata/docflags/template.txt
@@ -1,0 +1,2 @@
+Doc.var_string {{.Doc.var_string}}
+Doc.var_bool {{.Doc.var_bool}}

--- a/caddyhttp/markdown/testdata/docflags/test.md
+++ b/caddyhttp/markdown/testdata/docflags/test.md
@@ -1,0 +1,4 @@
+---
+var_string: hello
+var_bool: true
+---

--- a/caddyhttp/markdown/testdata/header.html
+++ b/caddyhttp/markdown/testdata/header.html
@@ -1,0 +1,1 @@
+<h1>Header for: {{.Doc.title}}</h1>

--- a/caddyhttp/markdown/testdata/log/test.md
+++ b/caddyhttp/markdown/testdata/log/test.md
@@ -1,0 +1,14 @@
+---
+title: Markdown test 2
+sitename: A Caddy website
+---
+
+## Welcome on the blog
+
+Body
+
+``` go
+func getTrue() bool {
+    return true
+}
+```

--- a/caddyhttp/markdown/testdata/markdown_tpl.html
+++ b/caddyhttp/markdown/testdata/markdown_tpl.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>{{.Doc.title}}</title>
+</head>
+<body>
+{{.Include "header.html"}}
+Welcome to {{.Doc.sitename}}!
+{{.Doc.body}}
+</body>
+</html>

--- a/caddyhttp/markdown/testdata/og/first.md
+++ b/caddyhttp/markdown/testdata/og/first.md
@@ -1,0 +1,5 @@
+---
+title: first_post
+sitename: title
+---
+# Test h1

--- a/caddyhttp/markdown/testdata/tpl_with_include.html
+++ b/caddyhttp/markdown/testdata/tpl_with_include.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>{{.Doc.title}}</title>
+	</head>
+	<body>
+		Welcome to {{.Doc.sitename}}!
+		<br><br>
+		{{.Doc.body}}
+	</body>
+</html>


### PR DESCRIPTION
This implements the control of markdown's template as said in [this comment](https://github.com/mholt/caddy/issues/1445#issuecomment-294700924).

While working with this issue, I found that markdown's tests won't failed even its template file is missing.
After tracking this down, this issue even exists dating back to ac4fa2c, it seems missed markdown's testdata when migrating.

(Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.)

### 1. What does this change do, exactly?

add template control option and fix fake tests issue.

### 2. Please link to the relevant issues.

#1445 

### 3. Which documentation changes (if any) need to be made because of this PR?

we should inform the user about this option.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
