### PR TITLE
gzip: cleaned up writer pool initialization code

### DIFF
--- a/caddyhttp/gzip/setup.go
+++ b/caddyhttp/gzip/setup.go
@@ -146,11 +146,7 @@ func initWriterPool() {
 
 	// add default writer pool
 	defaultWriterPoolIndex = i
-	writerPool[defaultWriterPoolIndex] = &sync.Pool{
-		New: func() interface{} {
-			return gzip.NewWriter(ioutil.Discard)
-		},
-	}
+	writerPool[defaultWriterPoolIndex] = newWriterPool(gzip.DefaultCompression)
 }
 
 func getWriter(level int) *gzip.Writer {


### PR DESCRIPTION
### 1. What does this change do, exactly?

Cleans up some redundant code in the gzip initialization code.

Specifically, `gzip.NewWriter` calls `gzip.NewWriterLevel` with the compression level `gzip.DefaultCompression`.

This code otherwise functions similarly to the previous code.

### 2. Please link to the relevant issues.

n/a

### 3. Which documentation changes (if any) need to be made because of this PR?

None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
