### PR TITLE
introduced own ChallengeProvider type, based on acme.ChallengeProvide…

### DIFF
--- a/caddytls/challenge_provider.go
+++ b/caddytls/challenge_provider.go
@@ -2,6 +2,5 @@ package caddytls
 
 import "github.com/xenolf/lego/acme"
 
-// own ChallengeProvider type to be used in Caddy plugins over acme.ChallengeProvider directly, to avoid
-// https://github.com/mattfarina/golang-broken-vendor
+// ChallengeProvider type to be used in Caddy plugins over acme.ChallengeProvider directly, to avoid https://github.com/mattfarina/golang-broken-vendor
 type ChallengeProvider acme.ChallengeProvider

--- a/caddytls/challenge_provider.go
+++ b/caddytls/challenge_provider.go
@@ -1,0 +1,7 @@
+package caddytls
+
+import "github.com/xenolf/lego/acme"
+
+// own ChallengeProvider type to be used in Caddy plugins over acme.ChallengeProvider directly, to avoid
+// https://github.com/mattfarina/golang-broken-vendor
+type ChallengeProvider acme.ChallengeProvider

--- a/caddytls/challenge_provider.go
+++ b/caddytls/challenge_provider.go
@@ -1,6 +1,0 @@
-package caddytls
-
-import "github.com/xenolf/lego/acme"
-
-// ChallengeProvider type to be used in Caddy plugins over acme.ChallengeProvider directly, to avoid https://github.com/mattfarina/golang-broken-vendor
-type ChallengeProvider acme.ChallengeProvider

--- a/caddytls/tls.go
+++ b/caddytls/tls.go
@@ -142,7 +142,7 @@ func QualifiesForManagedTLS(c ConfigHolder) bool {
 
 // DNSProviderConstructor is a function that takes credentials and
 // returns a type that can solve the ACME DNS challenges.
-type DNSProviderConstructor func(credentials ...string) (acme.ChallengeProvider, error)
+type DNSProviderConstructor func(credentials ...string) (ChallengeProvider, error)
 
 // dnsProviders is the list of DNS providers that have been plugged in.
 var dnsProviders = make(map[string]DNSProviderConstructor)

--- a/caddytls/tls.go
+++ b/caddytls/tls.go
@@ -140,6 +140,15 @@ func QualifiesForManagedTLS(c ConfigHolder) bool {
 		(HostQualifies(c.Host()) || tlsConfig.OnDemand)
 }
 
+// ChallengeProvider defines an own type that should be used in Caddy plugins
+// over acme.ChallengeProvider. Using acme.ChallengeProvider causes version mismatches
+// with vendored dependencies (see https://github.com/mattfarina/golang-broken-vendor)
+//
+// acme.ChallengeProvider is an interface that allows the implementation of custom
+// challenge providers. For more details, see:
+// https://godoc.org/github.com/xenolf/lego/acme#ChallengeProvider
+type ChallengeProvider acme.ChallengeProvider
+
 // DNSProviderConstructor is a function that takes credentials and
 // returns a type that can solve the ACME DNS challenges.
 type DNSProviderConstructor func(credentials ...string) (ChallengeProvider, error)


### PR DESCRIPTION
…r to avoid vendoring/version mismatches in Caddy plugins; see Caddy issue #1697

(Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.)

### 1. What does this change do, exactly?
I introduced Caddys own ChallengeProvider type, which should be used over acme.ChallengeProvider directly to avoid vendoring and version conflicts. This change was suggested in the linked issue.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1697

### 3. Which documentation changes (if any) need to be made because of this PR?
None as far as I can tell

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
