### PR TITLE
Configure systemd to send SIGQUIT on stop

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -20,6 +20,11 @@ Environment=CADDYPATH=/etc/ssl/caddy
 ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
+; Use graceful shutdown with a reasonable timeout
+KillMode=mixed
+KillSignal=SIGQUIT
+TimeoutStopSec=5s
+
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
 ; Unmodified caddy is not expected to use more than that.


### PR DESCRIPTION
(Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.)

### 1. What does this change do, exactly?

This updates the systemd unit to configure the use of SIGQUIT to trigger a graceful shutdown when the service is stopped.

### 2. Please link to the relevant issues.

I didn't create an issue for this, but I did look at open issues matching "systemd", and none of them appeared to be relevant.

### 3. Which documentation changes (if any) need to be made because of this PR?

The exact behavior of `systemctl start caddy`, `systemctl reload caddy`, and `systemctl stop caddy` are not currently discussed in the README. This modification does not, in my opinion, violate the principle of least surprise for the behavior of `systemctl stop caddy`.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
