### PR TITLE
Update Initscripts

### DIFF
--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -14,7 +14,7 @@
 
 DESC="the caddy web server"
 NAME=caddy
-DAEMON=$(which caddy)
+DAEMON=/usr/local/bin/caddy
 
 DAEMONUSER=www-data
 PIDFILE=/var/run/$NAME.pid


### PR DESCRIPTION
"$(which caddy)" is not work at system startup.
After this change, I can run "insserv -d caddy" to start caddy automatically on boot.