### PR TITLE
using caddy.AppName as a replacement for the fixed ’Caddy’ string in …

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -331,7 +331,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := context.WithValue(r.Context(), OriginalURLCtxKey, urlCopy)
 	r = r.WithContext(c)
 
-	w.Header().Set("Server", "Caddy")
+	w.Header().Set("Server", caddy.AppName)
 
 	status, _ := s.serveHTTP(w, r)
 


### PR DESCRIPTION
…‘Server’ response-header field

### 1. What does this change do, exactly?
Sets the variable `caddy.AppName` as replacement for the fixed string `Caddy` as value for the `Server`-header-field which is tracked down to the const variable caddymain.appName which value is also `Caddy`. In summary not a change at all but enables someones custom caddy build to overwrite the caddy.AppName and thus the `Server` Reponse-Header-Field to some custom (dynamic) value without writing a plugin to have more options for e.g. the `header` directive.

### 2. Please link to the relevant issues.
n/a

### 3. Which documentation changes (if any) need to be made because of this PR?
n/a

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
