### PR TITLE
Increase restart rate limit

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -6,11 +6,6 @@ Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
 Restart=on-failure
-; Renamed to StartLimitIntervalSec for systemd>=230
-; Set StartLimitInterval=0 to disable rate limiting.
-; To reset the restart counter run 'systemctl reset-failed caddy'
-StartLimitInterval=10
-StartLimitBurst=10
 
 ; User and group the process will run as.
 User=www-data

--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -6,8 +6,11 @@ Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
 Restart=on-failure
-StartLimitInterval=86400
-StartLimitBurst=5
+; Renamed to StartLimitIntervalSec for systemd>=230
+; Set StartLimitInterval=0 to disable rate limiting.
+; To reset the restart counter run 'systemctl reset-failed caddy'
+StartLimitInterval=10
+StartLimitBurst=10
 
 ; User and group the process will run as.
 User=www-data


### PR DESCRIPTION
The previous setting caused the service to hit a rate-limit when it was
restarted more than 5 times in 24h.
Editing the Caddyfile and restarting the service could also easily
trigger this rate limit.
One could argue that users could simply call `systemctl reset-failed
caddy` to reset the rate-limit counter, but this is counterintuitive
because most users won't know this command and are possibly unaware that
they had hit a rate-limit.

The service is now allowed to restart 10 times in 10 seconds before
hitting a rate limit.
This should be conservative enough to rate limit quickly failing
services and to allow users to edit and test their caddy configuration.

This closes #1718
