### PR TITLE
Fix memory leak

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -606,16 +606,15 @@ func executeDirectives(inst *Instance, filename string,
 	return nil
 }
 
-func startServers(serverList []Server, inst *Instance, restartFds map[string]restartTriple) error {
+func startServers(serverList []Server, inst *Instance, restartFds map[string]restartTriple) (err error) {
 	errChan := make(chan error, len(serverList))
+	var (
+		ln  net.Listener
+		pc  net.PacketConn
+	)
 
 	for _, s := range serverList {
-		var (
-			ln  net.Listener
-			pc  net.PacketConn
-			err error
-		)
-
+	
 		// If this is a reload and s is a GracefulServer,
 		// reuse the listener for a graceful restart.
 		if gs, ok := s.(GracefulServer); ok && restartFds != nil {


### PR DESCRIPTION
I think the way you had it, you were initializing new variables and using more memory every time you iterated through the loop. I think that would cause a memory leak. This should achieve some slight memory improvements, also since err is being returned, we can set it during function initialization.



- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
