### PR TITLE
add gopkg plugin

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -492,6 +492,7 @@ var directives = []string{
 	"mailout",   // github.com/SchumacherFM/mailout
 	"awslambda", // github.com/coopernurse/caddy-awslambda
 	"grpc",      // github.com/pieterlouw/caddy-grpc
+	"gopkg",     // github.com/zikes/gopkg
 }
 
 const (


### PR DESCRIPTION
### 1. What does this change do, exactly?

Adds the [gopkg plugin](https://github.com/zikes/gopkg) to Caddy.

### 2. Please link to the relevant issues.

NA

### 3. Which documentation changes (if any) need to be made because of this PR?

None necessary, however I can contribute to https://caddyserver.com/docs/http.gopkg if desired.

### 4. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
