### PR TITLE
Fix TestListenerAddrEqual

### DIFF
--- a/caddy_test.go
+++ b/caddy_test.go
@@ -142,13 +142,13 @@ func TestListenerAddrEqual(t *testing.T) {
 		addr   string
 		expect bool
 	}{
-		{ln1, ":1234", false},
-		{ln1, "0.0.0.0:1234", false},
+		{ln1, ":" + ln2port, false},
+		{ln1, "0.0.0.0:" + ln2port, false},
 		{ln1, "0.0.0.0", false},
 		{ln1, ":" + ln1port, true},
 		{ln1, "0.0.0.0:" + ln1port, true},
 		{ln2, ":" + ln2port, false},
-		{ln2, "127.0.0.1:1234", false},
+		{ln2, "127.0.0.1:" + ln1port, false},
 		{ln2, "127.0.0.1", false},
 		{ln2, "127.0.0.1:" + ln2port, true},
 	} {


### PR DESCRIPTION
### 1. What does this change do, exactly?

AppVeyor fails randomly, this PR fixes this issue (https://ci.appveyor.com/project/mholt/caddy/build/2930)

```
--- FAIL: TestListenerAddrEqual (0.00s)
	caddy_test.go:156: Test 6 (127.0.0.1:1234 == 127.0.0.1:1234): expected false but was true
FAIL
FAIL	github.com/mholt/caddy	0.068s
Command exited with code 1
```

### 2. Please link to the relevant issues.

see #1711 

### 3. Which documentation changes (if any) need to be made because of this PR?

None 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
