### PR TITLE
Add restic plugin directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -495,6 +495,7 @@ var directives = []string{
 	"awslambda", // github.com/coopernurse/caddy-awslambda
 	"grpc",      // github.com/pieterlouw/caddy-grpc
 	"gopkg",     // github.com/zikes/gopkg
+	"restic",    // github.com/mholt/caddy-restic
 }
 
 const (


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Adds the `restic` directive to the list of HTTP directives. Plugin repo: https://github.com/restic/caddy

### 2. Please link to the relevant issues.

n/a

### 3. Which documentation changes (if any) need to be made because of this PR?

n/a

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
