### PR TITLE
markdown: fix the real ineffectual assignments in test

### DIFF
--- a/caddyhttp/markdown/markdown_test.go
+++ b/caddyhttp/markdown/markdown_test.go
@@ -81,17 +81,14 @@ func TestMarkdown(t *testing.T) {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			t.Fatalf("Could not create HTTP request: %v", err)
-			return ""
 		}
 		rec := httptest.NewRecorder()
 		code, err := md.ServeHTTP(rec, req)
 		if err != nil {
 			t.Fatal(err)
-			return ""
 		}
 		if code != http.StatusOK {
 			t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, code)
-			return ""
 		}
 		return rec.Body.String()
 	}
@@ -117,6 +114,10 @@ Welcome to A Caddy website!
 </body>
 </html>
 `
+	if respBody != expectedBody {
+		t.Fatalf("Expected body:\n%q\ngot:\n%q", expectedBody, respBody)
+	}
+
 	respBody = get("/docflags/test.md")
 	expectedBody = `Doc.var_string hello
 Doc.var_bool true
@@ -226,11 +227,9 @@ func TestTemplateReload(t *testing.T) {
 		code, err := md.ServeHTTP(rec, req)
 		if err != nil {
 			t.Fatal(err)
-			return ""
 		}
 		if code != http.StatusOK {
 			t.Fatalf("Wrong status, expected: %d and got %d", http.StatusOK, code)
-			return ""
 		}
 		return rec.Body.String()
 	}


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

remove unnecessary `returns` after `Fatal` and fix the real  ineffectual assignments.

### 2. Please link to the relevant issues.

The [last commit](https://github.com/mholt/caddy/pull/1682/commits/655e61ab32a72831e897a46cf8763577fa719612) in pr #1682 .

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
