### PR TITLE
iteration on init script for freebsd

### DIFF
--- a/dist/init/freebsd/caddy
+++ b/dist/init/freebsd/caddy
@@ -23,8 +23,18 @@
 # caddy_config_path (str):    Set to "/usr/local/www/Caddyfile" by default.
 #                             Defines the path for the configuration file caddy will load on boot
 #
-# caddy_run_user (str):       Set to "root" by default.
+# caddy_user (str):           Set to "root" by default.
 #                             Defines the user that caddy will run on
+#
+# caddy_group (str):  	      Set to "wheel" by default.
+#                             Defines the group that caddy files will be attached to
+#
+# caddy_logfile (str)	      Set to "/var/log/caddy.log" by default.
+#			      Defines where the process log file is written, this is not a web access log
+#
+# caddy_env (str)	      Set to "" by default.
+#			      This allows environment variable to be set that may be required, for example when using "DNS Challenge" account credentials are required.
+#			      e.g. (in your rc.conf)   caddy_env="CLOUDFLARE_EMAIL=me@domain.com CLOUDFLARE_API_KEY=my_api_key"
 #
 
 . /etc/rc.subr
@@ -32,13 +42,16 @@
 name="caddy"
 rcvar="${name}_enable"
 
-load_rc_config $name
-: ${caddy_enable:=no}
+load_rc_config ${name}
+
+: ${caddy_enable:="NO"}
 : ${caddy_cert_email=""}
 : ${caddy_bin_path="/usr/local/bin/caddy"}
 : ${caddy_cpu="99%"} # was a bug for me that caused a crash within jails
 : ${caddy_config_path="/usr/local/www/Caddyfile"}
-: ${caddy_run_user="root"}
+: ${caddy_logfile="/var/log/caddy.log"}
+: ${caddy_user="root"}
+: ${caddy_group="wheel"}
 
 if [ "$caddy_cert_email" = "" ]
 then
@@ -46,38 +59,25 @@ then
     exit 1
 fi
 
-pidfile="/var/run/caddy.pid"
-logfile="/var/log/caddy.log"
+pidfile="/var/run/${name}.pid"
+procname="${caddy_bin_path}" #enabled builtin pid checking for start / stop
+command="/usr/sbin/daemon"
+command_args="-u ${caddy_user} -p ${pidfile} /usr/bin/env ${caddy_env} ${procname} -cpu ${caddy_cpu} -log stdout -conf ${caddy_config_path} -agree -email ${caddy_cert_email} < /dev/null >> ${caddy_logfile} 2>&1"
 
-command="${caddy_bin_path} -log ${logfile} -cpu ${caddy_cpu} -conf ${caddy_config_path} -agree -email ${caddy_cert_email}"
+start_precmd="caddy_startprecmd"
 
-start_cmd="caddy_start"
-status_cmd="caddy_status"
-stop_cmd="caddy_stop"
+caddy_startprecmd()
+{
+	if [ ! -e "${pidfile}" ]; then
+		install -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${pidfile}"
+	fi
 
-caddy_start() {
-    echo "Starting ${name}..."
-    /usr/sbin/daemon -u ${caddy_run_user} -c -p ${pidfile} -f ${command}
+	if [ ! -e "${caddy_logfile}" ]; then
+		install -o "${caddy_user}" -g "${caddy_group}" "dev/null" "${caddy_logfile}"
+	fi
 }
 
-caddy_status() {
-    if [ -f ${pidfile} ]; then
-      echo "${name} is running as $(cat $pidfile)."
-    else
-      echo "${name} is not running."
-      return 1
-    fi
-}
-
-caddy_stop() {
-    if [ ! -f ${pidfile} ]; then
-      echo "${name} is not running."
-      return 1
-    fi
-
-    echo -n "Stopping ${name}..."
-    kill -KILL $(cat $pidfile) 2> /dev/null && echo "stopped"
-    rm -f ${pidfile}
-}
+required_files="${caddy_config_path}"
 
 run_rc_command "$1"
+


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
* uses more of the builtin functionality for starting and stopping of the process by using command and command_args along with procname
* removed -f from daemon as this was hiding error message that were sent to stdout on startup, now writing stdout to the logfile directly

for example, this was being hidden:

“Activating privacy features.. [www.domain.com] failed to get certificate: Error presenting token: Could not find the start of authority”

it now shows up in the log

* aded “caddy_env” to allow the setting of environment variables that caddy might need, for example when setting creds for “DNS Challenge”

* added a check to ensure caddy_config_path file exists

### 2. Please link to the relevant issues.
N/A

### 3. Which documentation changes (if any) need to be made because of this PR?
None! Documented in the init script

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have squashed any insignificant commits
- [x] I am willing to help maintain this change if there are issues with it later
