### PR TITLE
proxy: Fix CI fail from format token in Error call

### DIFF
--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -477,7 +477,7 @@ func TestHealthCheckContentString(t *testing.T) {
 	for i, test := range tests {
 		u, err := NewStaticUpstreams(caddyfile.NewDispenser("Testfile", strings.NewReader(test.config)), "")
 		if err != nil {
-			t.Error("Expected no error. Test %d Got:", i, err.Error())
+			t.Errorf("Expected no error. Test %d Got: %s", i, err.Error())
 		}
 		for _, upstream := range u {
 			staticUpstream, ok := upstream.(*staticUpstream)


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

`go vet` began failing after 078c991574647c27 and causing CI failures. 

This patch changes the Error call added in commit 078c991574647c27 to
an Errorf call to support the use of the %d and %s tokens that are needed.

### 2. Please link to the relevant issues.
https://travis-ci.org/mholt/caddy/jobs/248392875
https://ci.appveyor.com/project/mholt/caddy/build/2979

`caddyhttp/proxy/upstream_test.go:480::error: possible formatting directive in Error call (vet)`

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist
This is a ~one~four-character fix, so I'm pretty sure I can safely check these. ;)
- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later