### PR TITLE
Pushes for /index.html work when surfing to /

### DIFF
--- a/caddyhttp/push/handler.go
+++ b/caddyhttp/push/handler.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/mholt/caddy/caddyhttp/staticfiles"
 )
 
 func (h Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
@@ -25,7 +26,13 @@ func (h Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, erro
 	// push first
 outer:
 	for _, rule := range h.Rules {
-		if httpserver.Path(r.URL.Path).Matches(rule.Path) {
+		urlPath := r.URL.Path
+		matches := httpserver.Path(urlPath).Matches(rule.Path)
+		// Also check IndexPages when requesting a directory
+		if !matches {
+			_, matches = httpserver.IndexFile(h.Root, urlPath, staticfiles.IndexPages)
+		}
+		if matches {
 			for _, resource := range rule.Resources {
 				pushErr := pusher.Push(resource.Path, &http.PushOptions{
 					Method: resource.Method,

--- a/caddyhttp/push/push.go
+++ b/caddyhttp/push/push.go
@@ -24,6 +24,7 @@ type (
 	Middleware struct {
 		Next  httpserver.Handler
 		Rules []Rule
+		Root  http.FileSystem
 	}
 
 	ruleOp func([]Resource)

--- a/caddyhttp/push/setup.go
+++ b/caddyhttp/push/setup.go
@@ -34,8 +34,9 @@ func setup(c *caddy.Controller) error {
 		return err
 	}
 
-	httpserver.GetConfig(c).AddMiddleware(func(next httpserver.Handler) httpserver.Handler {
-		return Middleware{Next: next, Rules: rules}
+	cfg := httpserver.GetConfig(c)
+	cfg.AddMiddleware(func(next httpserver.Handler) httpserver.Handler {
+		return Middleware{Next: next, Rules: rules, Root: http.Dir(cfg.Root)}
 	})
 
 	return nil


### PR DESCRIPTION
### 1. What does this change do, exactly?
Send the push resources for `/index.html` when requesting the root/home page `/`

### 2. Please link to the relevant issues.
Fix #1744 

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
