### PR TITLE
rewrite: Add client-side redirect support

### DIFF
--- a/caddyhttp/rewrite/rewrite_test.go
+++ b/caddyhttp/rewrite/rewrite_test.go
@@ -2,6 +2,7 @@ package rewrite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +45,7 @@ func TestRewrite(t *testing.T) {
 		if s := strings.Split(regexpRule[3], "|"); len(s) > 1 {
 			ext = s[:len(s)-1]
 		}
-		rule, err := NewComplexRule(regexpRule[0], regexpRule[1], regexpRule[2], ext, httpserver.IfMatcher{})
+		rule, err := NewComplexRule(regexpRule[0], regexpRule[1], regexpRule[2], ext, 0, httpserver.IfMatcher{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +118,121 @@ func TestRewrite(t *testing.T) {
 	}
 }
 
+func TestRewriteRedirects(t *testing.T) {
+	rw := Rewrite{
+		Next:    httpserver.HandlerFunc(mustNeverCall),
+		Rules:   []httpserver.HandlerConfig{},
+		FileSys: http.Dir("."),
+	}
+
+	regexps := [][]string{
+		{"", "from", "/to", ""},
+		{"", "^/a$", "/b", ""},
+		{"", "^/b$", "/b{uri}", ""},
+		{"/reg/", ".*", "/to", ""},
+		{"/r/", "[a-z]+", "/toaz", "!.html|"},
+		{"/path/", "[a-z0-9]", "/to/{path}", ""},
+		{"/url/", "a([a-z0-9]*)s([A-Z]{2})", "/to/{rewrite_path}", ""},
+		{"/ab/", "ab", "/ab?{query}", ".txt|"},
+		{"/ab/", "ab", "/ab?type=html&{query}", ".html|"},
+		{"/abc/", "ab", "/abc/{file}", ".html|"},
+		{"/abcd/", "ab", "/a/{dir}/{file}", ".html|"},
+		{"/abcde/", "ab", "/a#{fragment}", ".html|"},
+		{"/ab/", `.*\.jpg`, "/ajpg", ""},
+		{"/reggrp", `/ad/([0-9]+)([a-z]*)`, "/a{1}/{2}", ""},
+		{"/reg2grp", `(.*)`, "/{1}", ""},
+		{"/reg3grp", `(.*)/(.*)/(.*)`, "/{1}{2}{3}", ""},
+		{"/hashtest", "(.*)", "/{1}", ""},
+	}
+
+	for _, regexpRule := range regexps {
+		var ext []string
+		if s := strings.Split(regexpRule[3], "|"); len(s) > 1 {
+			ext = s[:len(s)-1]
+		}
+		rule, err := NewComplexRule(regexpRule[0], regexpRule[1], regexpRule[2], ext, http.StatusTemporaryRedirect, httpserver.IfMatcher{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rw.Rules = append(rw.Rules, rule)
+	}
+
+	tests := []struct {
+		from       string
+		expectedTo string
+	}{
+		{"/from", "/to"},
+		{"/a", "/b"},
+		{"/b", "/b/b"},
+		{"/aa", "/aa"},
+		{"/", "/"},
+		{"/a?foo=bar", "/b?foo=bar"},
+		{"/asdf?foo=bar", "/asdf?foo=bar"},
+		{"/foo#bar", "/foo#bar"},
+		{"/a#foo", "/b#foo"},
+		{"/reg/foo", "/to"},
+		{"/re", "/re"},
+		{"/r/", "/r/"},
+		{"/r/123", "/r/123"},
+		{"/r/a123", "/toaz"},
+		{"/r/abcz", "/toaz"},
+		{"/r/z", "/toaz"},
+		{"/r/z.html", "/r/z.html"},
+		{"/r/z.js", "/toaz"},
+		{"/path/a1b2c", "/to/path/a1b2c"},
+		{"/path/d3e4f", "/to/path/d3e4f"},
+		{"/url/asAB", "/to/url/asAB"},
+		{"/url/aBsAB", "/url/aBsAB"},
+		{"/url/a00sAB", "/to/url/a00sAB"},
+		{"/url/a0z0sAB", "/to/url/a0z0sAB"},
+		{"/ab/aa", "/ab/aa"},
+		{"/ab/ab", "/ab/ab"},
+		{"/ab/ab.txt", "/ab"},
+		{"/ab/ab.txt?name=name", "/ab?name=name"},
+		{"/ab/ab.html?name=name", "/ab?type=html&name=name"},
+		{"/abcd/abcd.html", "/a/abcd/abcd.html"},
+		{"/abcde/abcde.html", "/a"},
+		{"/abcde/abcde.html#1234", "/a#1234"},
+		{"/ab/ab.jpg", "/ajpg"},
+		{"/reggrp/ad/12", "/a12/"},
+		{"/reggrp/ad/124a", "/a124/a"},
+		{"/reggrp/ad/124abc", "/a124/abc"},
+		{"/reg2grp/ad/124abc", "/ad/124abc"},
+		{"/reg3grp/ad/aa/66", "/adaa66"},
+		{"/reg3grp/ad612/n1n/ab", "/ad612n1nab"},
+		{"/hashtest/a%20%23%20test", "/a%20%23%20test"},
+		{"/hashtest/a%20%3F%20test", "/a%20%3F%20test"},
+		{"/hashtest/a%20%3F%23test", "/a%20%3F%23test"},
+	}
+
+	for i, test := range tests {
+		req, err := http.NewRequest("GET", test.from, nil)
+		if err != nil {
+			t.Fatalf("Test %d: Could not create HTTP request: %v", i, err)
+		}
+		ctx := context.WithValue(req.Context(), httpserver.OriginalURLCtxKey, *req.URL)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		rw.ServeHTTP(rec, req)
+
+		if test.from == test.expectedTo {
+			if rec.Code != http.StatusOK {
+				t.Errorf("Test %d: Expected ok response, but got code %d", i, rec.Code)
+			}
+		} else {
+			if got, want := rec.Header().Get("Location"), test.expectedTo; got != want {
+				t.Errorf("Test %d: Expected redirect to be '%s' but was '%s'", i, want, got)
+			}
+		}
+	}
+}
+
 func urlPrinter(w http.ResponseWriter, r *http.Request) (int, error) {
 	fmt.Fprint(w, r.URL.String())
 	return 0, nil
+}
+
+func mustNeverCall(w http.ResponseWriter, r *http.Request) (int, error) {
+	return 0, errors.New("request was transparently rewritten but was not expected")
 }

--- a/caddyhttp/rewrite/setup.go
+++ b/caddyhttp/rewrite/setup.go
@@ -2,6 +2,7 @@ package rewrite
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/mholt/caddy"
@@ -44,6 +45,7 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 		var base = "/"
 		var pattern, to string
 		var ext []string
+		var redirectCode int
 
 		args := c.RemainingArgs()
 
@@ -82,6 +84,14 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 						return nil, c.ArgErr()
 					}
 					ext = args1
+				case "redirect":
+					if !c.NextArg() {
+						return nil, c.ArgErr()
+					}
+					redirectCode, err = strconv.Atoi(c.Val())
+					if err != nil {
+						return nil, err
+					}
 				default:
 					return nil, c.ArgErr()
 				}
@@ -90,7 +100,7 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 			if to == "" {
 				return nil, c.ArgErr()
 			}
-			if rule, err = NewComplexRule(base, pattern, to, ext, matcher); err != nil {
+			if rule, err = NewComplexRule(base, pattern, to, ext, redirectCode, matcher); err != nil {
 				return nil, err
 			}
 			rules = append(rules, rule)

--- a/caddyhttp/rewrite/setup_test.go
+++ b/caddyhttp/rewrite/setup_test.go
@@ -137,6 +137,13 @@ func TestRewriteParse(t *testing.T) {
 		 }`, false, []Rule{
 			&ComplexRule{Base: "/", To: "/to"},
 		}},
+		{`rewrite /redir {
+			r   .*
+			to  /to{path}
+			redirect 301
+		}`, false, []Rule{
+			&ComplexRule{Base: "/redir", To: "/to{path}", Regexp: regexp.MustCompile(".*"), RedirectCode: 301},
+		}},
 	}
 
 	for i, test := range regexpTests {
@@ -181,6 +188,12 @@ func TestRewriteParse(t *testing.T) {
 				}
 			}
 
+			if actualRule.RedirectCode != 0 {
+				if actualRule.RedirectCode != expectedRule.RedirectCode {
+					t.Errorf("Test %d, rule %d: Expected RedirectCode=%d, got %d",
+						i, j, expectedRule.RedirectCode, actualRule.RedirectCode)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### 1. What does this change do, exactly?

This adds a new "redirect" directive to the complex rewrite directive. Providing an HTTP response code will force Caddy to issue an HTTP redirect instead of internally rewriting the request.

### 2. Please link to the relevant issues.

#1749, #726, #856 

### 3. Which documentation changes (if any) need to be made because of this PR?

Information about the new `redirect` directive should be added to https://caddyserver.com/docs/rewrite.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
