### PR TITLE
gzip: change ETag to weak etag after gzip

### DIFF
--- a/caddyhttp/gzip/gzip.go
+++ b/caddyhttp/gzip/gzip.go
@@ -105,6 +105,10 @@ func (w *gzipResponseWriter) WriteHeader(code int) {
 	w.Header().Del("Content-Length")
 	w.Header().Set("Content-Encoding", "gzip")
 	w.Header().Add("Vary", "Accept-Encoding")
+	originalEtag := w.Header().Get("ETag")
+	if originalEtag != "" && !strings.HasPrefix(originalEtag, "W/") {
+		w.Header().Set("ETag", "W/"+originalEtag)
+	}
 	w.ResponseWriterWrapper.WriteHeader(code)
 	w.statusCodeWritten = true
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

According to https://tools.ietf.org/html/rfc7232#section-2.1
> Likewise, a validator is weak if it is shared by two or more
representations of a given resource at the same time, unless those
representations have identical representation data.  For example, if
the origin server sends the same validator for a representation with
a gzip content coding applied as it does for a representation with no
content coding, then that validator is weak.

Although it seems to be harmless at most time, follow the RFC would be appreciate.

### 2. Please link to the relevant issues.

Not yet.

### 3. Which documentation changes (if any) need to be made because of this PR?

No documentation need to be changed.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
