### PR TITLE
Publish caddy-cache

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -453,6 +453,7 @@ var directives = []string{
 	// directives that add middleware to the stack
 	"locale", // github.com/simia-tech/caddy-locale
 	"log",
+	"cache", // github.com/nicolasazrak/caddy-cache
 	"rewrite",
 	"ext",
 	"gzip",


### PR DESCRIPTION
After a long time I finally think caddy-cache is ready to be published. It does not have every feature I want but I think it handles the basic thinks it needs to support:

- it handles Vary header
- it handles correct usage of cache headers with the help of https://github.com/pquerna/cachecontrol
- it handles locking and concurrency (if two request gets the server at the same time, there will be only one fetch to upstream and both original requests will get the response at the same time without having to wait until the upstream request ends)

What do you think?

### 1. What does this change do, exactly?

Adds a middleware for http caching

### 2. Please link to the relevant issues.

https://github.com/mholt/caddy/issues/10

### 3. Which documentation changes (if any) need to be made because of this PR?

It needs a new section for the new cache directive

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
