### PR TITLE
log,error: fix roller parser issue

### DIFF
--- a/caddyhttp/errors/setup.go
+++ b/caddyhttp/errors/setup.go
@@ -44,18 +44,20 @@ func errorsParse(c *caddy.Controller) (*ErrorHandler, error) {
 		for c.NextBlock() {
 
 			what := c.Val()
-			if !c.NextArg() {
-				return c.ArgErr()
-			}
-			where := c.Val()
+			where := c.RemainingArgs()
 
 			if httpserver.IsLogRollerSubdirective(what) {
 				var err error
-				err = httpserver.ParseRoller(handler.Log.Roller, what, where)
+				err = httpserver.ParseRoller(handler.Log.Roller, what, where...)
 				if err != nil {
 					return err
 				}
 			} else {
+				if len(where) != 1 {
+					return c.ArgErr()
+				}
+				where := where[0]
+
 				// Error page; ensure it exists
 				if !filepath.IsAbs(where) {
 					where = filepath.Join(cfg.Root, where)

--- a/caddyhttp/errors/setup_test.go
+++ b/caddyhttp/errors/setup_test.go
@@ -85,7 +85,12 @@ func TestErrorsParse(t *testing.T) {
 				Roller: httpserver.DefaultLogRoller(),
 			},
 		}},
-		{`errors errors.txt { rotate_size 2 rotate_age 10 rotate_keep 3 rotate_compress }`, false, ErrorHandler{
+		{`errors errors.txt {
+			rotate_size 2
+			rotate_age 10
+			rotate_keep 3
+			rotate_compress
+		}`, false, ErrorHandler{
 			ErrorPages: map[int]string{},
 			Log: &httpserver.Logger{
 				Output: "errors.txt", Roller: &httpserver.LogRoller{
@@ -144,6 +149,12 @@ func TestErrorsParse(t *testing.T) {
 				},
 				Log: &httpserver.Logger{},
 			}},
+		{`errors errors.txt { rotate_size 2 rotate_age 10 rotate_keep 3 rotate_compress }`,
+			true, ErrorHandler{ErrorPages: map[int]string{}, Log: &httpserver.Logger{}}},
+		{`errors errors.txt {
+			rotate_compress invalid
+		}`,
+			true, ErrorHandler{ErrorPages: map[int]string{}, Log: &httpserver.Logger{}}},
 		// Next two test cases is the detection of duplicate status codes
 		{`errors {
 			503 503.html

--- a/caddyhttp/log/setup.go
+++ b/caddyhttp/log/setup.go
@@ -38,17 +38,14 @@ func logParse(c *caddy.Controller) ([]*Rule, error) {
 
 		for c.NextBlock() {
 			what := c.Val()
-			if !c.NextArg() {
-				return nil, c.ArgErr()
-			}
-			where := c.Val()
+			where := c.RemainingArgs()
 
 			// only support roller related options inside a block
 			if !httpserver.IsLogRollerSubdirective(what) {
 				return nil, c.ArgErr()
 			}
 
-			if err := httpserver.ParseRoller(logRoller, what, where); err != nil {
+			if err := httpserver.ParseRoller(logRoller, what, where...); err != nil {
 				return nil, err
 			}
 		}

--- a/caddyhttp/log/setup_test.go
+++ b/caddyhttp/log/setup_test.go
@@ -194,7 +194,12 @@ func TestLogParse(t *testing.T) {
 				Format: "{when}",
 			}},
 		}}},
-		{`log access.log { rotate_size 2 rotate_age 10 rotate_keep 3 }`, false, []Rule{{
+		{`log access.log {
+			rotate_size 2
+			rotate_age 10
+			rotate_keep 3
+			rotate_compress
+		}`, false, []Rule{{
 			PathScope: "/",
 			Entries: []*Entry{{
 				Log: &httpserver.Logger{
@@ -203,7 +208,7 @@ func TestLogParse(t *testing.T) {
 						MaxSize:    2,
 						MaxAge:     10,
 						MaxBackups: 3,
-						Compress:   false,
+						Compress:   true,
 						LocalTime:  true,
 					}},
 				Format: DefaultLogFormat,
@@ -226,6 +231,8 @@ func TestLogParse(t *testing.T) {
 				Format: "{when}",
 			}},
 		}}},
+		{`log access.log { rotate_size 2 rotate_age 10 rotate_keep 3 }`, true, nil},
+		{`log access.log { rotate_compress invalid }`, true, nil},
 		{`log access.log { rotate_size }`, true, nil},
 		{`log access.log { invalid_option 1 }`, true, nil},
 		{`log / acccess.log "{remote} - [{when}] "{method} {port}" {scheme} {mitm} "`, true, nil},


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Revise log and error roller parser.

1) Each subdirective must be on its own line.
2) `rotate_compress` subdirective doesn't accept any parameter.

### 2. Please link to the relevant issues.

#1761 

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
