### PR TITLE
proxy: fix hang on chunked websocket server

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -272,7 +272,7 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, outreq *http.Request, 
 	}
 
 	if isWebsocket {
-		res.Body.Close()
+		defer res.Body.Close()
 		hj, ok := rw.(http.Hijacker)
 		if !ok {
 			panic(httpserver.NonHijackerError{Underlying: rw})


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

When proxying to a chunked websocket server, we will hang when closing the response's body because underlying connection isn't closed. Now we defer this action until the proxying is finished.

### 2. Please link to the relevant issues.

#1316 

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
