### PR TITLE
mitm: Fix out of bounds error when checking software version in UA

### DIFF
--- a/caddyhttp/httpserver/mitm.go
+++ b/caddyhttp/httpserver/mitm.go
@@ -112,6 +112,8 @@ func getVersion(ua, softwareName string) float64 {
 	end := strings.Index(ua[start:], " ")
 	if end < 0 {
 		end = len(ua)
+	} else {
+		end += start
 	}
 	strVer := strings.Replace(ua[start:end], "-", "", -1)
 	firstDot := strings.Index(strVer, ".")

--- a/caddyhttp/httpserver/mitm_test.go
+++ b/caddyhttp/httpserver/mitm_test.go
@@ -352,3 +352,48 @@ func TestHeuristicFunctionsAndHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVersion(t *testing.T) {
+	for i, test := range []struct {
+		UserAgent    string
+		SoftwareName string
+		Version      float64
+	}{
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0",
+			SoftwareName: "Firefox",
+			Version:      45.0,
+		},
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0 more_stuff_here",
+			SoftwareName: "Firefox",
+			Version:      45.0,
+		},
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393",
+			SoftwareName: "Safari",
+			Version:      537.36,
+		},
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393",
+			SoftwareName: "Chrome",
+			Version:      51.0270479,
+		},
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393",
+			SoftwareName: "Mozilla",
+			Version:      5.0,
+		},
+		{
+			UserAgent:    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393",
+			SoftwareName: "curl",
+			Version:      -1,
+		},
+	} {
+		actual := getVersion(test.UserAgent, test.SoftwareName)
+		if actual != test.Version {
+			t.Errorf("Test [%d]: Expected version=%f, got version=%f for %s in '%s'",
+				i, test.Version, actual, test.SoftwareName, test.UserAgent)
+		}
+	}
+}


### PR DESCRIPTION
### 1. What does this change do, exactly?

Fixes a panic in some cases when checking version of software from User-Agent string

### 2. Please link to the relevant issues.

https://caddy.community/t/runtime-error-slice-bounds-out-of-range/2387?u=matt

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
