### PR TITLE
fastcgi: Fix for #1788. Align atomic fields to 64-bit word (Go bug)

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -366,8 +366,11 @@ type balancer interface {
 
 // roundRobin is a round robin balancer for fastcgi upstreams.
 type roundRobin struct {
-	addresses []string
+	// Known Go bug: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	// must be first field for 64 bit alignment
+	// on x86 and arm.
 	index     int64
+	addresses []string
 }
 
 func (r *roundRobin) Address() string {


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Closes https://github.com/mholt/caddy/issues/1788

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1788

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
