### PR TITLE
freebsd init: typo in filename.

### DIFF
--- a/dist/init/freebsd/caddy
+++ b/dist/init/freebsd/caddy
@@ -73,7 +73,7 @@ caddy_startprecmd()
 	fi
 
 	if [ ! -e "${caddy_logfile}" ]; then
-		install -o "${caddy_user}" -g "${caddy_group}" "dev/null" "${caddy_logfile}"
+		install -o "${caddy_user}" -g "${caddy_group}" "/dev/null" "${caddy_logfile}"
 	fi
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
The freebsd init will fail in precmd because the path is wrong.

### 2. Please link to the relevant issues.
There is none, yet.

### 3. Which documentation changes (if any) need to be made because of this PR?
No

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
