### PR TITLE
static files ending with index filenames redirected incorrectly

### DIFF
--- a/caddyhttp/staticfiles/fileserver.go
+++ b/caddyhttp/staticfiles/fileserver.go
@@ -107,7 +107,7 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 		// if an index file was explicitly requested, strip file name from the request
 		// ("/foo/index.html" -> "/foo/")
 		for _, indexPage := range IndexPages {
-			if strings.HasSuffix(urlCopy.Path, indexPage) {
+			if path.Base(urlCopy.Path) == indexPage {
 				urlCopy.Path = urlCopy.Path[:len(urlCopy.Path)-len(indexPage)]
 				redir = true
 				break

--- a/caddyhttp/staticfiles/fileserver.go
+++ b/caddyhttp/staticfiles/fileserver.go
@@ -106,8 +106,9 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 
 		// if an index file was explicitly requested, strip file name from the request
 		// ("/foo/index.html" -> "/foo/")
+		var requestPage = path.Base(urlCopy.Path)
 		for _, indexPage := range IndexPages {
-			if path.Base(urlCopy.Path) == indexPage {
+			if requestPage == indexPage {
 				urlCopy.Path = urlCopy.Path[:len(urlCopy.Path)-len(indexPage)]
 				redir = true
 				break

--- a/caddyhttp/staticfiles/fileserver_test.go
+++ b/caddyhttp/staticfiles/fileserver_test.go
@@ -219,6 +219,13 @@ func TestServeHTTP(t *testing.T) {
 			expectedLocation:    "https://foo/bar/file1.html",
 			expectedBodyContent: movedPermanently,
 		},
+		{
+			url:                   "https://foo/notindex.html",
+			expectedStatus:        http.StatusOK,
+			expectedBodyContent:   testFiles[webrootNotIndexHTML],
+			expectedEtag:          `"2n9cm"`,
+			expectedContentLength: strconv.Itoa(len(testFiles[webrootNotIndexHTML])),
+		},
 	}
 
 	for i, test := range tests {
@@ -493,6 +500,7 @@ func TestServeHTTPFailingStat(t *testing.T) {
 // Paths for the fake site used temporarily during testing.
 var (
 	webrootFile1HTML                   = filepath.Join(webrootName, "file1.html")
+	webrootNotIndexHTML                = filepath.Join(webrootName, "notindex.html")
 	webrootDirFile2HTML                = filepath.Join(webrootName, "dir", "file2.html")
 	webrootDirHiddenHTML               = filepath.Join(webrootName, "dir", "hidden.html")
 	webrootDirwithindexIndeHTML        = filepath.Join(webrootName, "dirwithindex", "index.html")
@@ -519,6 +527,7 @@ var (
 var testFiles = map[string]string{
 	"unreachable.html":                 "<h1>must not leak</h1>",
 	webrootFile1HTML:                   "<h1>file1.html</h1>",
+	webrootNotIndexHTML:                "<h1>notindex.html</h1>",
 	webrootDirFile2HTML:                "<h1>dir/file2.html</h1>",
 	webrootDirwithindexIndeHTML:        "<h1>dirwithindex/index.html</h1>",
 	webrootDirHiddenHTML:               "<h1>dir/hidden.html</h1>",


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
static files such as notindex.html were redirected to /not.  

### 2. Please link to the relevant issues.
discovered in #1811 

### 3. Which documentation changes (if any) need to be made because of this PR?
none

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
