### PR TITLE
Fix restart restart behaviour of the systemd service

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -5,9 +5,7 @@ After=network-online.target
 Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
-Restart=on-failure
-StartLimitInterval=86400
-StartLimitBurst=5
+Restart=on-abnormal
 
 ; User and group the process will run as.
 User=www-data


### PR DESCRIPTION
This is a follow up to #1719 

In short, we are now using systemd's restart limit default that is 5 allowed service restarts in 10 seconds and the restart directive was changed to `on-abnormal`, i.e. it won't restart on non-zero exit codes (e.g. on a bad Caddyfile).