### PR TITLE
Double systemd LimitNPROC to allow more threads

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -26,7 +26,7 @@ TimeoutStopSec=5s
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
 ; Unmodified caddy is not expected to use more than that.
-LimitNPROC=64
+LimitNPROC=512
 
 ; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp=true


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

`LimitNPROC` in `caddy.service` changed from `64` to `512`

### 2. Please link to the relevant issues.

This change solved #1723 for me. I arbitrarily doubled 64 to 128, not sure what is a better value. The error seems to be that caddy requests a 65th thread and then gets denied. Not sure if relevant to #1823 since perhaps that will affect restarting (no more "restart too quickly" errors?). Pinging @wmark

### 3. Which documentation changes (if any) need to be made because of this PR?

None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits (only one commit)
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
