### PR TITLE
Fix SCRIPT_NAME for FastCGI

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
@@ -247,6 +248,11 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 
 	// Strip PATH_INFO from SCRIPT_NAME
 	scriptName = strings.TrimSuffix(scriptName, pathInfo)
+
+	// Add vhost path prefix to scriptName. Otherwise, some PHP software will
+	// have difficulty discovering its URL.
+	pathPrefix, _ := r.Context().Value(caddy.CtxKey("path_prefix")).(string)
+	scriptName = path.Join(pathPrefix, scriptName)
 
 	// Get the request URI from context. The context stores the original URI in case
 	// it was changed by a middleware such as rewrite. By default, we pass the

--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
@@ -122,7 +123,11 @@ func TestBuildEnv(t *testing.T) {
 		}
 	}
 
-	rule := Rule{}
+	rule := Rule{
+		Ext:        ".php",
+		SplitPath:  ".php",
+		IndexFiles: []string{"index.php"},
+	}
 	url, err := url.Parse("http://localhost:2015/fgci_test.php?test=foobar")
 	if err != nil {
 		t.Error("Unexpected error:", err.Error())
@@ -156,6 +161,7 @@ func TestBuildEnv(t *testing.T) {
 			"QUERY_STRING":    "test=foobar",
 			"REQUEST_METHOD":  "GET",
 			"HTTP_HOST":       "localhost:2015",
+			"SCRIPT_NAME":     "/fgci_test.php",
 		}
 	}
 
@@ -205,6 +211,14 @@ func TestBuildEnv(t *testing.T) {
 	envExpected["HTTP_HOST"] = "localhost:2015"
 	envExpected["CUSTOM_URI"] = "custom_uri/fgci_test.php?test=foobar"
 	envExpected["CUSTOM_QUERY"] = "custom=true&test=foobar"
+	testBuildEnv(r, rule, fpath, envExpected)
+
+	// 6. Test SCRIPT_NAME includes path prefix
+	r = newReq()
+	ctx := context.WithValue(r.Context(), caddy.CtxKey("path_prefix"), "/test")
+	r = r.WithContext(ctx)
+	envExpected = newEnv()
+	envExpected["SCRIPT_NAME"] = "/test/fgci_test.php"
 	testBuildEnv(r, rule, fpath, envExpected)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
As described in #1846, many PHP apps depend on the `SCRIPT_NAME` CGI environment variable. The Caddy FastCGI plugin sets `SCRIPT_NAME` to roughly what would be expected by NGINX (essentially, a path to the script relative to the URL.) Unfortunately, when using path-based routing with VHosts, the path prefix gets lost, leading to PHP software such as phpBB and anything else depending on Symphony's requestUri logic failing (and probably more stuff too.)

This patch does exactly one thing: it finds the path prefix via the request context and prepends it to the calculated `SCRIPT_NAME`. That's it. This simple change seems to be all you need to do in the circumstances I was able to think of.

### 2. Please link to the relevant issues.
This patch affects #1846.

### 3. Which documentation changes (if any) need to be made because of this PR?
I don't believe any changes need to be made, since this simply brings Caddy's behavior into accordance with what one would expect from any other FastCGI server.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
