### PR TITLE
should use bytes.Contains(content, []byte(FAILED)) instead and should…

### DIFF
--- a/caddyhttp/fastcgi/fcgiclient_test.go
+++ b/caddyhttp/fastcgi/fcgiclient_test.go
@@ -155,7 +155,7 @@ func sendFcgi(reqType int, fcgiParams map[string]string, data []byte, posts map[
 	fcgi.Close()
 	time.Sleep(1 * time.Second)
 
-	if bytes.Index(content, []byte("FAILED")) >= 0 {
+	if bytes.Contains(content, []byte("FAILED")) {
 		globalt.Error("Server return failed message")
 	}
 

--- a/caddyhttp/templates/templates.go
+++ b/caddyhttp/templates/templates.go
@@ -94,7 +94,7 @@ func (t Templates) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		rb.CopyHeader()
 
 		// set the actual content length now that the template was executed
-		w.Header().Set("Content-Length", strconv.FormatInt(int64(buf.Len()), 10))
+		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 
 		// get the modification time in preparation to ServeContent
 		modTime, _ := time.Parse(http.TimeFormat, w.Header().Get("Last-Modified"))


### PR DESCRIPTION
… use strconv.Itoa instead of strconv.FormatInt

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

should use bytes.Contains(content, []byte("FAILED")) instead and should use strconv.Itoa instead of strconv.FormatInt

### 2. Please link to the relevant issues.

NONE
### 3. Which documentation changes (if any) need to be made because of this PR?
NONE

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
