### PR TITLE
httpserver: Fix #1859 by cleaning paths when matching them

### DIFF
--- a/caddyhttp/browse/browse_test.go
+++ b/caddyhttp/browse/browse_test.go
@@ -227,7 +227,7 @@ func TestBrowseTemplate(t *testing.T) {
 func TestBrowseJson(t *testing.T) {
 	b := Browse{
 		Next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
-			t.Fatalf("Next shouldn't be called")
+			t.Fatalf("Next shouldn't be called: %s", r.URL)
 			return 0, nil
 		}),
 		Configs: []Config{

--- a/caddyhttp/httpserver/path_test.go
+++ b/caddyhttp/httpserver/path_test.go
@@ -30,6 +30,11 @@ func TestPathMatches(t *testing.T) {
 			shouldMatch: false,
 		},
 		{
+			reqPath:     "/foo/",
+			rulePath:    "/foo/",
+			shouldMatch: true,
+		},
+		{
 			reqPath:     "/Foobar",
 			rulePath:    "/Foo",
 			shouldMatch: true,
@@ -86,10 +91,41 @@ func TestPathMatches(t *testing.T) {
 			rulePath:    "",
 			shouldMatch: true,
 		},
+		{
+			// see issue #1859
+			reqPath:     "//double-slash",
+			rulePath:    "/double-slash",
+			shouldMatch: true,
+		},
+		{
+			reqPath:     "/double//slash",
+			rulePath:    "/double/slash",
+			shouldMatch: true,
+		},
+		{
+			reqPath:     "//more/double//slashes",
+			rulePath:    "/more/double/slashes",
+			shouldMatch: true,
+		},
+		{
+			reqPath:     "/path/../traversal",
+			rulePath:    "/traversal",
+			shouldMatch: true,
+		},
+		{
+			reqPath:     "/path/../traversal",
+			rulePath:    "/path",
+			shouldMatch: false,
+		},
+		{
+			reqPath:     "/keep-slashes/http://something/foo/bar",
+			rulePath:    "/keep-slashes/http://something",
+			shouldMatch: true,
+		},
 	} {
 		CaseSensitivePath = !testcase.caseInsensitive
 		if got, want := testcase.reqPath.Matches(testcase.rulePath), testcase.shouldMatch; got != want {
-			t.Errorf("Test %d: For request path '%s' and other path '%s': expected %v, got %v",
+			t.Errorf("Test %d: For request path '%s' and base path '%s': expected %v, got %v",
 				i, testcase.reqPath, testcase.rulePath, want, got)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

When checking if one path matches another using Path.Matches(), call path.Clean() on the paths to compress/merge multiple slashes. Note that it does NOT effectively match paths where `p == "/foo"` and `base == "//foo"` (this will be a match even though it looks like it shouldn't be) - however I think this is not a concern, as removing slashes is rare... also note that this change doesn't mutilate the request URI at all, it's only a side-effect-less change for path matching. It should fix an issue for all middlewares that use path.Matches. If they use their own path matcher, though, they're on their own...

### 2. Please link to the relevant issues.

#1859


### 3. Which documentation changes (if any) need to be made because of this PR?

Maybe a note somewhere that multiple slashes are merged for path matching, similar to nginx's location block, assuming `merge_slashes` is NOT `off`.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

/cc @hstaugaard @magikstm 