### PR TITLE
Revert "Implement Caddy-Sponsors HTTP response header"

### DIFF
--- a/caddyhttp/header/header.go
+++ b/caddyhttp/header/header.go
@@ -27,10 +27,6 @@ func (h Headers) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	for _, rule := range h.Rules {
 		if httpserver.Path(r.URL.Path).Matches(rule.Path) {
 			for name := range rule.Headers {
-				if name == "Caddy-Sponsors" || name == "-Caddy-Sponsors" {
-					// see EULA
-					continue
-				}
 
 				// One can either delete a header, add multiple values to a header, or simply
 				// set a header.

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -343,8 +343,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(c)
 
 	w.Header().Set("Server", caddy.AppName)
-	sponsors := "Minio, Uptime Robot, and Sourcegraph"
-	w.Header().Set("Caddy-Sponsors", "This free web server is made possible by its sponsors: "+sponsors)
 
 	status, _ := s.serveHTTP(w, r)
 


### PR DESCRIPTION
### 1. What does this change do, exactly?

Reverts the recent change to add sponsor headers to HTTP responses. I'm opening this PR here in the hope we can discuss undoing this recent addition. Ref https://github.com/WedgeServer/wedge/issues/2 and the [HN post](https://news.ycombinator.com/item?id=15237923).

You're of course free to simply close this PR immediately, but I really hope you'll consider feedback from the community (especially on HackerNews) regarding this change before doing so.

### 2. Please link to the relevant issues.

N/A

### 3. Which documentation changes (if any) need to be made because of this PR?

N/A

### 4. Checklist

- **N/A** I have written tests and verified that they fail without my change
- **N/A** I have squashed any insignificant commits
- **N/A** This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
