### PR TITLE
Add support for SRV upstreams in fastcgi

### DIFF
--- a/caddyhttp/fastcgi/fastcgi_test.go
+++ b/caddyhttp/fastcgi/fastcgi_test.go
@@ -84,11 +84,15 @@ func TestRuleParseAddress(t *testing.T) {
 	}
 
 	for _, entry := range getClientTestTable {
-		if actualnetwork, _ := parseAddress(entry.rule.Address()); actualnetwork != entry.expectednetwork {
-			t.Errorf("Unexpected network for address string %v. Got %v, expected %v", entry.rule.Address(), actualnetwork, entry.expectednetwork)
+		addr, err := entry.rule.Address()
+		if err != nil {
+			t.Errorf("Unexpected error in retrieving address: %s", err.Error())
 		}
-		if _, actualaddress := parseAddress(entry.rule.Address()); actualaddress != entry.expectedaddress {
-			t.Errorf("Unexpected parsed address for address string %v. Got %v, expected %v", entry.rule.Address(), actualaddress, entry.expectedaddress)
+		if actualnetwork, _ := parseAddress(addr); actualnetwork != entry.expectednetwork {
+			t.Errorf("Unexpected network for address string %v. Got %v, expected %v", addr, actualnetwork, entry.expectednetwork)
+		}
+		if _, actualaddress := parseAddress(addr); actualaddress != entry.expectedaddress {
+			t.Errorf("Unexpected parsed address for address string %v. Got %v, expected %v", addr, actualaddress, entry.expectedaddress)
 		}
 	}
 }
@@ -365,7 +369,10 @@ func TestBalancer(t *testing.T) {
 	for i, test := range tests {
 		b := address(test...)
 		for _, host := range test {
-			a := b.Address()
+			a, err := b.Address()
+			if err != nil {
+				t.Errorf("Unexpected error in trying to retrieve address: %s", err.Error())
+			}
 			if a != host {
 				t.Errorf("Test %d: expected %s, found %s", i, host, a)
 			}


### PR DESCRIPTION
### 1. What does this change do, exactly?
Adds support in fastcgi module to discover upstreams using SRV lookup

### 2. Please link to the relevant issues.
closes: https://github.com/mholt/caddy/issues/1803

### 3. Which documentation changes (if any) need to be made because of this PR?
The fastcgi module documentation (https://caddyserver.com/docs/fastcgi) requires an update:

``` diff
- endpoint is the address or Unix socket of the FastCGI server.
+ endpoint is the address or Unix socket of the FastCGI server. Service discovery using SRV lookup is supported. If the endpoint start with `srv://` it will be considered as a service locator and caddy will attempt to resolve available services via SRV DNS lookup.
```

``` diff
- upstream specifies an additional backend to use. Basic load balancing will be performed. This can be specified multiple times.
+ upstream specifies an additional backend to use. Basic load balancing will be performed. This can be specified multiple times. upstream directive is not supported if endpoint is a service locator.
```

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later


I'm sorry that the tests are not super clean code, I had to employ a dirty trick to prevent tests from making network calls.