### PR TITLE
Revert "Implement Caddy-Sponsors HTTP response header"

### DIFF
--- a/caddyhttp/header/header.go
+++ b/caddyhttp/header/header.go
@@ -27,10 +27,6 @@ func (h Headers) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	for _, rule := range h.Rules {
 		if httpserver.Path(r.URL.Path).Matches(rule.Path) {
 			for name := range rule.Headers {
-				if name == "Caddy-Sponsors" || name == "-Caddy-Sponsors" {
-					// see EULA
-					continue
-				}
 
 				// One can either delete a header, add multiple values to a header, or simply
 				// set a header.

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -343,8 +343,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(c)
 
 	w.Header().Set("Server", caddy.AppName)
-	sponsors := "Minio, Uptime Robot, and Sourcegraph"
-	w.Header().Set("Caddy-Sponsors", "This free web server is made possible by its sponsors: "+sponsors)
 
 	status, _ := s.serveHTTP(w, r)
 


### PR DESCRIPTION
This reverts commit 56453e9664aa2c24115eb52a4e933febb3cac1f7.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
It reverts the implementation of the Caddy-Sponsors HTTP response header.

### 2. Please link to the relevant issues.
[56453e9](https://github.com/mholt/caddy/commit/56453e9664aa2c24115eb52a4e933febb3cac1f7)

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
