### PR TITLE
Fix pid error in linux sysvinit

### DIFF
--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -36,6 +36,7 @@ ulimit -n 8192
 
 start() {
     $USERBIND $DAEMON
+    touch $LOGFILE && chown $DAEMONUSER $LOGFILE
     start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE \
         --background --chuid $DAEMONUSER --oknodo --exec $DAEMON -- $DAEMONOPTS
 }

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -20,7 +20,7 @@ DAEMONUSER=www-data
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 CONFIGFILE=/etc/caddy/Caddyfile
-DAEMONOPTS="-agree=true -pidfile=$PIDFILE -log=$LOGFILE -conf=$CONFIGFILE"
+DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
 
 USERBIND="setcap cap_net_bind_service=+ep"
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Fixes two issues with the `dist/init/linux-sysvinit/caddy` init script, specifically it fixes an issue where the log isn't created and secondly it fixes a spurious error in the log file because the daemon user isn't responsible for writing the pid file.

### 2. Please link to the relevant issues.

None as far as I am aware.

### 3. Which documentation changes (if any) need to be made because of this PR?

None.

### 4. Checklist

- [N/A] I have written tests and verified that they fail without my change
- [Yes] I have squashed any insignificant commits
- [N/A] This change has comments for package types, values, functions, and non-obvious lines of code
- [Yes] I am willing to help maintain this change if there are issues with it later
