### PR TITLE
Add hook for instance startup

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -213,6 +213,9 @@ func (i *Instance) Restart(newCaddyfile Input) (*Instance, error) {
 	}
 	i.Stop()
 
+	// Execute instantiation events
+	EmitEvent(InstanceStartupEvent, newInst)
+
 	log.Println("[INFO] Reloading complete")
 
 	return newInst, nil

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -140,6 +140,9 @@ func Run() {
 		mustLogFatalf("%v", err)
 	}
 
+	// Execute instantiation events
+	caddy.EmitEvent(caddy.InstanceStartupEvent, instance)
+
 	// Twiddle your thumbs
 	instance.Wait()
 }

--- a/plugins.go
+++ b/plugins.go
@@ -233,9 +233,10 @@ type EventName string
 
 // Define names for the various events
 const (
-	StartupEvent   EventName = "startup"
-	ShutdownEvent  EventName = "shutdown"
-	CertRenewEvent EventName = "certrenew"
+	StartupEvent         EventName = "startup"
+	ShutdownEvent        EventName = "shutdown"
+	CertRenewEvent       EventName = "certrenew"
+	InstanceStartupEvent EventName = "instancestartup"
 )
 
 // EventHook is a type which holds information about a startup hook plugin.


### PR DESCRIPTION
### 1. What does this change do, exactly?
Provides a new hook that plugins can use to gain access to the `caddy.Instance`. This is particularly important to allow plugins the ability to dynamically generate a new Caddyfile and reload the server with the new configuration. 

With this change in place a plugin could access the instance as follows:

```go
func init() {
	caddy.RegisterEventHook("sampleinithook", SampleInitHook)
}

func SampleInitHook(eventType caddy.EventName, eventInfo interface{}) error {
	if eventType != caddy.InstanceStartupEvent {
		return nil
	}

	instance, ok := eventInfo.(*caddy.Instance)
	if !ok {
		return errors.New("Invalid eventInfo provided for caddy.InstanceStartupEvent event")
	}

	// save the instance for later use and/or do something useful with it here
}
```


### 2. Please link to the relevant issues.

- Wiki documents this as a TODO: https://github.com/mholt/caddy/wiki/Writing-a-Plugin:-Caddyfile-Loader#dynamic-reloads
- Community discussion: https://caddy.community/t/dynamically-load-caddy-file/357/11

### 3. Which documentation changes (if any) need to be made because of this PR?
- Caddyfile Loader: https://github.com/mholt/caddy/wiki/Writing-a-Plugin:-Caddyfile-Loader#dynamic-reloads


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change - I have verified existing tests pass but it appears the events are not currently included in tests and I see no obvious way to add tests for this case
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later