### PR TITLE
Allow nonblocking onevent command with no other arguments

### DIFF
--- a/onevent/hook/hook.go
+++ b/onevent/hook/hook.go
@@ -16,7 +16,7 @@ func (cfg *Config) Hook(event caddy.EventName, info interface{}) error {
 	}
 
 	nonblock := false
-	if len(cfg.Args) > 1 && cfg.Args[len(cfg.Args)-1] == "&" {
+	if len(cfg.Args) >= 1 && cfg.Args[len(cfg.Args)-1] == "&" {
 		// Run command in background; non-blocking
 		nonblock = true
 		cfg.Args = cfg.Args[:len(cfg.Args)-1]

--- a/onevent/hook/hook_test.go
+++ b/onevent/hook/hook_test.go
@@ -33,6 +33,7 @@ func TestHook(t *testing.T) {
 	}{
 		{name: "blocking", event: caddy.InstanceStartupEvent, command: "mkdir", args: []string{osSenitiveTestDir}, shouldErr: false, shouldRemoveErr: false},
 		{name: "nonBlocking", event: caddy.ShutdownEvent, command: "mkdir", args: []string{osSenitiveTestDir, "&"}, shouldErr: false, shouldRemoveErr: true},
+		{name: "nonBlocking2", event: caddy.ShutdownEvent, command: "echo", args: []string{"&"}, shouldErr: false, shouldRemoveErr: true},
 		{name: "nonExistent", event: caddy.CertRenewEvent, command: strconv.Itoa(int(time.Now().UnixNano())), shouldErr: true, shouldRemoveErr: true},
 	}
 


### PR DESCRIPTION
Take this for example:

    on startup /path/to/my/script.sh &

Currently it will run this script as blocking and passing "&" as if it were a parameter because it only checks for "&" if there is *more than one* argument. If the same is written this way, it works:

    on startup /path/to/my/script.sh dummy &

Now this is run non-blocking.

The change itself is very minimal. I don't know how to write a test to check this new behavior.