### PR TITLE
Fix upstart script for Centos 6 (and Amazon Linux)

### DIFF
--- a/dist/init/linux-upstart/caddy.conf.centos-6
+++ b/dist/init/linux-upstart/caddy.conf.centos-6
@@ -3,18 +3,10 @@ description "Caddy HTTP/2 web server"
 start on runlevel [2345]
 stop on runlevel [016]
 
-# centos 6 upstart version does not support console
-console log
-
-# centos 6 upstart version does not support setuid/setgid
-setuid www-data
-setgid www-data
+console output
 
 respawn
 respawn limit 10 5
-
-# centos 6 upstart version does not support reload
-reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH=/etc/ssl/caddy
@@ -24,5 +16,6 @@ limit nofile 1048576 1048576
 script
         cd /etc/ssl/caddy
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
-        exec /usr/local/bin/caddy -agree -log=stdout -conf=/etc/caddy/Caddyfile -root=$rootdir
+        chown www-data:www-data $rootdir
+        exec sudo -u www-data /usr/local/bin/caddy -agree -log=/var/log/caddy.log -conf=/etc/caddy/Caddyfile -root=$rootdir
 end script


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Fixes upstart script so it actually works on Centos 6 and Amazon Linux. The script had comments that Centos6 upstart doesn't support some features, but it still used them.

### 2. Please link to the relevant issues.

https://github.com/mholt/caddy/pull/1189

### 3. Which documentation changes (if any) need to be made because of this PR?

None I can think of.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
