### PR TITLE
staticfiles: remove mapFSRootOpenErr because Go stdlib has fixed the relevant issue

### DIFF
--- a/caddyhttp/staticfiles/fileserver.go
+++ b/caddyhttp/staticfiles/fileserver.go
@@ -66,9 +66,6 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 	// open the requested file
 	f, err := fs.Root.Open(reqPath)
 	if err != nil {
-		// TODO: remove when http.Dir handles this (Go 1.9?)
-		// Go issue #18984
-		err = mapFSRootOpenErr(err)
 		if os.IsNotExist(err) {
 			return http.StatusNotFound, nil
 		} else if os.IsPermission(err) {
@@ -279,36 +276,4 @@ var staticEncoding = map[string]string{
 var staticEncodingPriority = []string{
 	"br",
 	"gzip",
-}
-
-// mapFSRootOpenErr maps the provided non-nil error
-// to a possibly better non-nil error. In particular, it turns OS-specific errors
-// about opening files in non-directories into os.ErrNotExist.
-//
-// TODO: remove when http.Dir handles this (slated for Go 1.9)
-// Go issue #18984
-func mapFSRootOpenErr(originalErr error) error {
-	if os.IsNotExist(originalErr) || os.IsPermission(originalErr) {
-		return originalErr
-	}
-
-	perr, ok := originalErr.(*os.PathError)
-	if !ok {
-		return originalErr
-	}
-	name := perr.Path
-	parts := strings.Split(name, string(filepath.Separator))
-	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
-		fi, err := os.Stat(strings.Join(parts[:i+1], string(filepath.Separator)))
-		if err != nil {
-			return originalErr
-		}
-		if !fi.IsDir() {
-			return os.ErrNotExist
-		}
-	}
-	return originalErr
 }


### PR DESCRIPTION
### 1. What does this change do, exactly?
Reverts https://github.com/mholt/caddy/commit/bdb61f4a1d93c412fe08fbd6e4644ec3ac9378da but leaves the test case.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1408
https://github.com/mholt/caddy/pull/1409
https://github.com/golang/go/issues/18984

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
