### PR TITLE
Handle the case of an OCSP responder certificate expiring before an OCSP response it issued

### DIFF
--- a/caddytls/maintain.go
+++ b/caddytls/maintain.go
@@ -334,8 +334,15 @@ func DeleteOldStapleFiles() {
 // meaning that it is not expedient to get an
 // updated response from the OCSP server.
 func freshOCSP(resp *ocsp.Response) bool {
+	nextUpdate := resp.NextUpdate
+        // If there is an OCSP responder certificate, and it expires before the
+        // OCSP response, use its expiration date as the end of the OCSP
+        // response's validity period.
+	if resp.Certificate && resp.Certificate.NotAfter.Before(nextUpdate) {
+		nextUpdate = resp.Certificate.NotAfter
+	}
 	// start checking OCSP staple about halfway through validity period for good measure
-	refreshTime := resp.ThisUpdate.Add(resp.NextUpdate.Sub(resp.ThisUpdate) / 2)
+	refreshTime := resp.ThisUpdate.Add(nextUpdate.Sub(resp.ThisUpdate) / 2)
 	return time.Now().Before(refreshTime)
 }
 

--- a/caddytls/maintain.go
+++ b/caddytls/maintain.go
@@ -338,7 +338,7 @@ func freshOCSP(resp *ocsp.Response) bool {
         // If there is an OCSP responder certificate, and it expires before the
         // OCSP response, use its expiration date as the end of the OCSP
         // response's validity period.
-	if resp.Certificate && resp.Certificate.NotAfter.Before(nextUpdate) {
+	if resp.Certificate != nil && resp.Certificate.NotAfter.Before(nextUpdate) {
 		nextUpdate = resp.Certificate.NotAfter
 	}
 	// start checking OCSP staple about halfway through validity period for good measure

--- a/caddytls/maintain.go
+++ b/caddytls/maintain.go
@@ -335,9 +335,9 @@ func DeleteOldStapleFiles() {
 // updated response from the OCSP server.
 func freshOCSP(resp *ocsp.Response) bool {
 	nextUpdate := resp.NextUpdate
-        // If there is an OCSP responder certificate, and it expires before the
-        // OCSP response, use its expiration date as the end of the OCSP
-        // response's validity period.
+	// If there is an OCSP responder certificate, and it expires before the
+	// OCSP response, use its expiration date as the end of the OCSP
+	// response's validity period.
 	if resp.Certificate != nil && resp.Certificate.NotAfter.Before(nextUpdate) {
 		nextUpdate = resp.Certificate.NotAfter
 	}


### PR DESCRIPTION
### 1. What does this change do, exactly?

If an OCSP response's issuing OCSP responder certificate expires before the OCSP response itself does, consider the OCSP responder's expiration date to be the end of the OCSP response's vality period, so that we obtain a new OCSP response sooner.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
