### PR TITLE
FreeBSD init: Remove unnecessary daemon -u option

### DIFF
--- a/dist/init/freebsd/caddy
+++ b/dist/init/freebsd/caddy
@@ -62,7 +62,7 @@ fi
 pidfile="/var/run/${name}.pid"
 procname="${caddy_bin_path}" #enabled builtin pid checking for start / stop
 command="/usr/sbin/daemon"
-command_args="-u ${caddy_user} -p ${pidfile} /usr/bin/env ${caddy_env} ${procname} -cpu ${caddy_cpu} -log stdout -conf ${caddy_config_path} -agree -email ${caddy_cert_email} < /dev/null >> ${caddy_logfile} 2>&1"
+command_args="-p ${pidfile} /usr/bin/env ${caddy_env} ${procname} -cpu ${caddy_cpu} -log stdout -conf ${caddy_config_path} -agree -email ${caddy_cert_email} < /dev/null >> ${caddy_logfile} 2>&1"
 
 start_precmd="caddy_startprecmd"
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Fixes #1923 by removing unnecessary `-u ${caddy_user}` option for the `daemon` command in the init script for FreeBSD.

### 2. Please link to the relevant issues.

#1923 

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
