### PR TITLE
make log directive replacer available on request context

### DIFF
--- a/caddyhttp/log/log_test.go
+++ b/caddyhttp/log/log_test.go
@@ -31,6 +31,9 @@ func (erroringMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) (int
 	if rr, ok := w.(*httpserver.ResponseRecorder); ok {
 		rr.Replacer.Set("testval", "foobar")
 	}
+	if repl := GetReplacer(r); repl != nil {
+		repl.Set("customval", "barbaz")
+	}
 	return http.StatusNotFound, nil
 }
 
@@ -40,7 +43,7 @@ func TestLoggedStatus(t *testing.T) {
 	rule := Rule{
 		PathScope: "/",
 		Entries: []*Entry{{
-			Format: DefaultLogFormat + " {testval}",
+			Format: DefaultLogFormat + " {testval} {customval}",
 			Log:    httpserver.NewTestLogger(&f),
 		}},
 	}
@@ -74,6 +77,10 @@ func TestLoggedStatus(t *testing.T) {
 	// check custom placeholder
 	if !strings.Contains(logged, "foobar") {
 		t.Errorf("Expected the log entry to contain 'foobar' (custom placeholder), but it didn't: %s", logged)
+	}
+	// check contains other placeholder
+	if !strings.Contains(logged, "barbaz") {
+		t.Errorf("Expected the log entry to contain 'barbaz' (custom placeholder from context), but it didn't: %s", logged)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
This change allows custom log values to be made available as placeholders while preventing other directives from breaking that functionality.

This issue I ran into was that the currently available method of retrieving the `httpserver.Replacer`, with a type assertion on the `http.ResponseWriter`, as is dine in the snippet here, breaks down in conjunction with other plugins that wrap the response writer, such as `header`.

https://github.com/mholt/caddy/blob/59a8ada4a8d287abd7e1025293f5d7894a7788c2/caddyhttp/log/log_test.go#L31-L33

The solution in-flight in this PR https://github.com/mholt/caddy/pull/1542 allows for a custom `{user}` placeholder to be logged, but does not facilitate arbitrary custom logs.

This change allows the log replacer to be retrieved at any point, when present.

### 2. Please link to the relevant issues.
There were a few issues I saw referencing this class of problem, but none of the proposed or in-flight solutions fit the use case I was experimenting with.

- https://caddy.community/t/custom-user-placeholder-along-with-header-directive/1676/9
- https://github.com/mholt/caddy/issues/1543

### 3. Which documentation changes (if any) need to be made because of this PR?
Since this is for plugin authors, the godoc from this added method is likely sufficient for minimal documentation. However, if there are other places to document this type of functionality, I'd be happy to update them.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
