### PR TITLE
hook: Change log output

### DIFF
--- a/onevent/hook/hook.go
+++ b/onevent/hook/hook.go
@@ -28,10 +28,10 @@ func (cfg *Config) Hook(event caddy.EventName, info interface{}) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if nonblock {
-		log.Printf("[INFO] Nonblocking Command with ID %s: \"%s %s\"", cfg.ID, cfg.Command, strings.Join(cfg.Args, " "))
+		log.Printf("[INFO] Nonblocking Command \"%s %s\" with ID %s", cfg.Command, strings.Join(cfg.Args, " "), cfg.ID)
 		return cmd.Start()
 	}
-	log.Printf("[INFO] Blocking Command with ID %s: \"%s %s\"", cfg.ID, cfg.Command, strings.Join(cfg.Args, " "))
+	log.Printf("[INFO] Blocking Command \"%s %s\" with ID %s", cfg.Command, strings.Join(cfg.Args, " "), cfg.ID)
 	err := cmd.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION

### 1. What does this change do, exactly?
Changes the log output of on startup from 

> 2017/10/22 10:43:18 [INFO] Nonblocking Command with ID 880159d2-fe8c-4457-982b-0a7154ebbed6: "d:\php7\php-cgi.exe -b 43249"

to 

> 2017/10/22 11:02:32 [INFO] Nonblocking Command "d:\php7\php-cgi.exe -b 43249" with ID 347a7d5c-e281-49df-a6b0-cf27d8d0dfc0

Personally I think this is easier to read when looking for commands that are being executed in the logs.


