### PR TITLE
onevent/startupshutdown: run command once per server block

### DIFF
--- a/onevent/on.go
+++ b/onevent/on.go
@@ -20,9 +20,12 @@ func setup(c *caddy.Controller) error {
 	}
 
 	// Register Event Hooks.
-	for _, cfg := range config {
-		caddy.RegisterEventHook("on-"+cfg.ID, cfg.Hook)
-	}
+	c.OncePerServerBlock(func() error {
+		for _, cfg := range config {
+			caddy.RegisterEventHook("on-"+cfg.ID, cfg.Hook)
+		}
+		return nil
+	})
 
 	return nil
 }

--- a/startupshutdown/startupshutdown.go
+++ b/startupshutdown/startupshutdown.go
@@ -36,9 +36,12 @@ func Startup(c *caddy.Controller) error {
 	}
 
 	// Register Event Hooks.
-	for _, cfg := range config {
-		caddy.RegisterEventHook("on-"+cfg.ID, cfg.Hook)
-	}
+	c.OncePerServerBlock(func() error {
+		for _, cfg := range config {
+			caddy.RegisterEventHook("on-"+cfg.ID, cfg.Hook)
+		}
+		return nil
+	})
 
 	fmt.Println("NOTICE: Startup directive will be removed in a later version. Please migrate to 'on startup'")
 


### PR DESCRIPTION
### 1. What does this change do, exactly?

Execute onevent commands once per server block

### 2. Please link to the relevant issues.

#1933 

### 3. Which documentation changes (if any) need to be made because of this PR?

n/a

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
