### PR TITLE
all: few code improvements

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -565,12 +565,7 @@ func ValidateAndExecuteDirectives(cdyfile Input, inst *Instance, justValidate bo
 		return err
 	}
 
-	err = executeDirectives(inst, cdyfile.Path(), stype.Directives(), sblocks, justValidate)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return executeDirectives(inst, cdyfile.Path(), stype.Directives(), sblocks, justValidate)
 }
 
 func executeDirectives(inst *Instance, filename string,

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -84,7 +84,7 @@ func trapSignalsPosix() {
 				}
 
 				// Kick off the restart; our work is done
-				inst, err = inst.Restart(caddyfileToUse)
+				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {
 					log.Printf("[ERROR] SIGUSR1: %v", err)
 				}

--- a/upgrade.go
+++ b/upgrade.go
@@ -148,7 +148,7 @@ func Upgrade() error {
 
 	// determine whether child startup succeeded
 	answer, readErr := ioutil.ReadAll(sigrpipe)
-	if answer == nil || len(answer) == 0 {
+	if len(answer) == 0 {
 		cmdErr := cmd.Wait() // get exit status
 		errStr := fmt.Sprintf("child failed to initialize: %v", cmdErr)
 		if readErr != nil {


### PR DESCRIPTION
caddy.go:569: could be simplified

sigtrap_posix.go:87: value of inst is never used

upgrade.go:151: should omit nil check; len() for nil slices is defined as zero

### 1. What does this change do, exactly?
Simplifies return, removes unused variable and reduces a variable check.

### 2. Please link to the relevant issues.
fixes #1935

### 3. Which documentation changes (if any) need to be made because of this PR?
none

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
