### PR TITLE
Setup a Replacer and ResponseRecorder per-request, making interactions with placeholders more coherent

### DIFF
--- a/caddyhttp/httpserver/middleware.go
+++ b/caddyhttp/httpserver/middleware.go
@@ -214,6 +214,9 @@ func SameNext(next1, next2 Handler) bool {
 
 // Context key constants.
 const (
+	// ReplacerCtxKey is the context key for a per-request replacer.
+	ReplacerCtxKey caddy.CtxKey = "replacer"
+
 	// RemoteUserCtxKey is the key for the remote user of the request, if any (basicauth).
 	RemoteUserCtxKey caddy.CtxKey = "remote_user"
 

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -356,6 +356,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := context.WithValue(r.Context(), OriginalURLCtxKey, urlCopy)
 	r = r.WithContext(c)
 
+	// Setup a replacer for the request that keeps track of placeholder
+	// values across plugins.
+	replacer := NewReplacer(r, nil, "")
+	c = context.WithValue(r.Context(), ReplacerCtxKey, replacer)
+	r = r.WithContext(c)
+
 	w.Header().Set("Server", caddy.AppName)
 
 	status, _ := s.serveHTTP(w, r)


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

This PR sets up a `Replacer` and `ResponseRecorder` object per-request, so that the functions that "create" them preferentially retrieve them from the request itself before creating a new one. This allows directives throughout the middleware chain to leverage shared information collected over the course of the request.

I have tested this locally using a custom plugin that adds custom placeholders, in combination with the `headers` directive, which were previously in conflict, causing the placeholders to not be available in the `log ` directive, and that now works as expected!

Tests here still need to be added.

Follows on from a comment on a previous PR attacking a manifestation of this underlying issue: https://github.com/mholt/caddy/pull/1931#pullrequestreview-71723741

### 2. Please link to the relevant issues.

Previous PR: https://github.com/mholt/caddy/pull/1931

Issues linked to from previous PR:
- https://caddy.community/t/custom-user-placeholder-along-with-header-directive/1676/9
- #1543

### 3. Which documentation changes (if any) need to be made because of this PR?

There is a slight behavioral change if plugin implementers were relying on the previous under the hood behavior of these where separate replacers/response recorders could be created, though it's hard to imagine a use case for that.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later