### PR TITLE
Add option for a backend check to approve use of on-demand TLS

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -148,6 +148,11 @@ type OnDemandState struct {
 	// Set from max_certs in tls config, it specifies the
 	// maximum number of certificates that can be issued.
 	MaxObtain int32
+
+	// The url to call to check if an on-demand tls certificate should
+	// be issued. If a request to the URL fails or returns a non 2xx
+	// status on-demand issuances must fail.
+	AskURL *url.URL
 }
 
 // ObtainCert obtains a certificate for name using c, as long


### PR DESCRIPTION

### 1. What does this change do, exactly?
This adds the ask sub-directive to tls that defines the URL of a backend HTTP service to be queried during the TLS handshake to determine if an on-demand TLS certificate should be acquired for incoming hostnames. When the ask sub-directive is defined, Caddy will query the URL for permission to acquire a cert by making a HTTP GET request to the URL including the requested domain in the query string. If the backend service returns a 2xx response Caddy will acquire a cert. Any other response code (including 3xx redirects) are be considered a rejection and the certificate will not be acquired.

### 2. Please link to the relevant issues.
#1847

### 3. Which documentation changes (if any) need to be made because of this PR?
The TLS docs will need a reference to the `ask` directive and some updated language around on-demand TLS in general. 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later