### PR TITLE
Turn on KeepAlive in QuicConfig of RoundTripper

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -208,7 +208,7 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 		rp.Transport = &h2quic.RoundTripper{
 			QuicConfig: &quic.Config{
 				HandshakeTimeout: defaultCryptoHandshakeTimeout,
-				KeepAlive: true,
+				KeepAlive:        true,
 			},
 		}
 	} else if keepalive != http.DefaultMaxIdleConnsPerHost {

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -208,6 +208,7 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int) *
 		rp.Transport = &h2quic.RoundTripper{
 			QuicConfig: &quic.Config{
 				HandshakeTimeout: defaultCryptoHandshakeTimeout,
+				KeepAlive: true,
 			},
 		}
 	} else if keepalive != http.DefaultMaxIdleConnsPerHost {


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Add `KeepAlive: true` to QuicConfig of `h2quic.RoundTripper`. 
This follows convention of KeepAlive being turned on as a default in the rest of Caddy.


### 2. Please link to the relevant issues.
Issue #999

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ Y] I have written tests and verified that they fail without my change
- [ Y] I have squashed any insignificant commits
- [ Y] This change has comments for package types, values, functions, and non-obvious lines of code
- [ Y] I am willing to help maintain this change if there are issues with it later
