### PR TITLE
Checking that a server listener is not nil before printing verbose in…

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -518,9 +518,13 @@ func startWithListenerFds(cdyfile Input, inst *Instance, restartFds map[string]r
 		}
 		if !Quiet {
 			for _, srvln := range inst.servers {
-				if !IsLoopback(srvln.listener.Addr().String()) {
-					checkFdlimit()
-					break
+				// only show FD notice if the listener is not nil.
+				// This can happen when only serving UDP or TCP
+				if srvln.listener != nil {
+					if !IsLoopback(srvln.listener.Addr().String()) {
+						checkFdlimit()
+						break
+					}
 				}
 			}
 		}

--- a/caddy.go
+++ b/caddy.go
@@ -520,11 +520,12 @@ func startWithListenerFds(cdyfile Input, inst *Instance, restartFds map[string]r
 			for _, srvln := range inst.servers {
 				// only show FD notice if the listener is not nil.
 				// This can happen when only serving UDP or TCP
-				if srvln.listener != nil {
-					if !IsLoopback(srvln.listener.Addr().String()) {
-						checkFdlimit()
-						break
-					}
+				if srvln.listener == nil {
+					continue
+				}
+				if !IsLoopback(srvln.listener.Addr().String()) {
+					checkFdlimit()
+					break
 				}
 			}
 		}


### PR DESCRIPTION
### 1. What does this change do, exactly?

It adds a check to make sure that a non-nil server listener is used before printing its file descriptor notice in non-quiet mode.
Without this patch, returning a nil listener alongside with a nil error from `Server.Listener` and `Server.PacketListener` would cause a segmentation fault.

In the plugins documentation[1] it's stated that
```
If your server only uses TCP, the *Packet() methods may be no-ops (i.e. they return nil).
The inverse is true for non-TCP servers. A server may also use both TCP and UDP, and
implement all four methods.
```

However the function `startWithListenerFds` (before this patch) would dereference `srvln.listener` in non-quiet mode in any case.

[1] https://github.com/mholt/caddy/wiki/Writing-a-Plugin:-Server-Type

### 2. Please link to the relevant issues.

no issue associated to this PR

### 3. Which documentation changes (if any) need to be made because of this PR?

None, this should more closely match the existing documentation

### 4. Checklist

- no new test has been written. There is currently no other test for `startWithListenerFds`
- I am willing to help maintain this change if there are issues with it later
