### PR TITLE
Add {user} placeholder to CommonLogFormat

### DIFF
--- a/caddyhttp/log/log.go
+++ b/caddyhttp/log/log.go
@@ -91,7 +91,7 @@ const (
 	// DefaultLogFilename is the default log filename.
 	DefaultLogFilename = "access.log"
 	// CommonLogFormat is the common log format.
-	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + " " + CommonLogEmptyValue + ` [{when}] "{method} {uri} {proto}" {status} {size}`
+	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + ` {user} [{when}] "{method} {uri} {proto}" {status} {size}`
 	// CommonLogEmptyValue is the common empty log value.
 	CommonLogEmptyValue = "-"
 	// CombinedLogFormat is the combined log format.


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Make code in line with current documentation for CommonLogFormat for {user} placeholder.

I tested with latest version of the plugin https://github.com/tarent/loginsrv.

It works as noted in the documentation https://caddyserver.com/docs/log under the predefined format `{common} (default)`.

I've not added a new test yet.

### 2. Please link to the relevant issues.
#1951

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
