### PR TITLE
Add dontstrip plugin

### DIFF
--- a/caddyhttp/caddyhttp.go
+++ b/caddyhttp/caddyhttp.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/mholt/caddy/caddyhttp/basicauth"
 	_ "github.com/mholt/caddy/caddyhttp/bind"
 	_ "github.com/mholt/caddy/caddyhttp/browse"
+	_ "github.com/mholt/caddy/caddyhttp/dontstrip"
 	_ "github.com/mholt/caddy/caddyhttp/errors"
 	_ "github.com/mholt/caddy/caddyhttp/expvar"
 	_ "github.com/mholt/caddy/caddyhttp/extensions"

--- a/caddyhttp/dontstrip/dontstrip.go
+++ b/caddyhttp/dontstrip/dontstrip.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Light Code Labs, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dontstrip
+
+import (
+	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+)
+
+func init() {
+	caddy.RegisterPlugin("dontstrip", caddy.Plugin{
+		ServerType: "http",
+		Action:     setupDontStrip,
+	})
+}
+
+func setupDontStrip(c *caddy.Controller) error {
+	config := httpserver.GetConfig(c)
+	config.DontStripPath = true
+	return nil
+}

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -449,6 +449,7 @@ func RegisterDevDirective(name, before string) {
 // The ordering of this list is important.
 var directives = []string{
 	// primitive actions that set up the fundamental vitals of each config
+	"dontstrip",
 	"root",
 	"index",
 	"bind",

--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -412,10 +412,12 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	// trim the path portion of the site address from the beginning of
 	// the URL path, so a request to example.com/foo/blog on the site
 	// defined as example.com/foo appears as /blog instead of /foo/blog.
-	if pathPrefix != "/" {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, pathPrefix)
-		if !strings.HasPrefix(r.URL.Path, "/") {
-			r.URL.Path = "/" + r.URL.Path
+	if !vhost.DontStripPath {
+		if pathPrefix != "/" {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, pathPrefix)
+			if !strings.HasPrefix(r.URL.Path, "/") {
+				r.URL.Path = "/" + r.URL.Path
+			}
 		}
 	}
 

--- a/caddyhttp/httpserver/siteconfig.go
+++ b/caddyhttp/httpserver/siteconfig.go
@@ -73,6 +73,10 @@ type SiteConfig struct {
 	// If true, any requests not matching other site definitions
 	// may be served by this site.
 	FallbackSite bool
+
+	// If true, do not trim the path portion of the site address
+	// from the beginning of the URL path
+	DontStripPath bool
 }
 
 // Timeouts specify various timeouts for a server to use.


### PR DESCRIPTION
### 1. What does this change do, exactly?

Adds an option for sites not to strip the path.
This is important to be compatible to software that does not work well with path stripping/trimming.
My use case was that the webdav plugin did not work with the Linux Gnome Desktop, as trimming the path would confuse the client.

My guess is that this will be very useful to a lot of users, as custom protocols may use paths within headers and payload, which will stop being valid when only the request URI is changed.

### 2. Please link to the relevant issues.

No issue was created.

### 3. Which documentation changes (if any) need to be made because of this PR?

Create a new documentation page for this plugin, stating something like:

    If this option is used, caddy will not trim the original request path for this site.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
  - There is so little code, that additional tests don't make any sense.
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
