### PR TITLE
Allow graceful restart of TLS listener

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -177,15 +177,22 @@ func (i *Instance) Restart(newCaddyfile Input) (*Instance, error) {
 	restartFds := make(map[string]restartTriple)
 	for _, s := range i.servers {
 		gs, srvOk := s.server.(GracefulServer)
-		ln, lnOk := s.listener.(Listener)
+		dupLn, dupLnOk := s.listener.(DuppableListener)
+		if !dupLnOk {
+			ln, lnOk := s.listener.(Listener)
+			if lnOk {
+				dupLn = makeDuppableListener(ln)
+				dupLnOk = true
+			}
+		}
 		pc, pcOk := s.packet.(PacketConn)
 		if srvOk {
-			if lnOk && pcOk {
-				restartFds[gs.Address()] = restartTriple{server: gs, listener: ln, packet: pc}
+			if dupLnOk && pcOk {
+				restartFds[gs.Address()] = restartTriple{server: gs, listener: dupLn, packet: pc}
 				continue
 			}
-			if lnOk {
-				restartFds[gs.Address()] = restartTriple{server: gs, listener: ln}
+			if dupLnOk {
+				restartFds[gs.Address()] = restartTriple{server: gs, listener: dupLn}
 				continue
 			}
 			if pcOk {
@@ -347,12 +354,29 @@ type GracefulServer interface {
 	Address() string
 }
 
-// Listener is a net.Listener with an underlying file descriptor.
-// A server's listener should implement this interface if it is
-// to support zero-downtime reloads.
+// Listener is a net.Listener with an underlying file descriptor. It is
+// assumed that the File() method returns a file descriptor that can be
+// passed to net.FileListener() to create a valid net.Listener for use
+// by Server.Serve().
+// A server's listener should implement this interface or the
+// DuppableListener interface below if it is to support zero-downtime reloads.
 type Listener interface {
 	net.Listener
 	File() (*os.File, error)
+}
+
+// DuppableListener is similar to Listener, however it assumes that
+// the Dup() method is implemented to perform the dup operation
+// which utilizes the underlying file descriptor itself. It is assumed
+// that the Dup() method returns a valid net.Listener for use by
+// Server.Serve()
+// A server's listener should implement this interface or the
+// Listener interface above if it is to support zero-downtime reloads.
+type DuppableListener interface {
+	net.Listener
+
+	// Returns new Listener and closes old file descriptor
+	Dup() (net.Listener, error)
 }
 
 // PacketConn is a net.PacketConn with an underlying file descriptor.
@@ -690,15 +714,7 @@ func startServers(serverList []Server, inst *Instance, restartFds map[string]res
 			if old, ok := restartFds[addr]; ok {
 				// listener
 				if old.listener != nil {
-					file, err := old.listener.File()
-					if err != nil {
-						return err
-					}
-					ln, err = net.FileListener(file)
-					if err != nil {
-						return err
-					}
-					err = file.Close()
+					ln, err = old.listener.Dup()
 					if err != nil {
 						return err
 					}
@@ -938,8 +954,35 @@ func writePidFile() error {
 
 type restartTriple struct {
 	server   GracefulServer
-	listener Listener
+	listener DuppableListener
 	packet   PacketConn
+}
+
+type duppableListener struct {
+	Listener
+}
+
+func (d duppableListener) Dup() (net.Listener, error) {
+	file, err := d.Listener.File()
+	if err != nil {
+		return nil, err
+	}
+
+	ln, err := net.FileListener(file)
+	if err != nil {
+		return nil, err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return ln, nil
+}
+
+func makeDuppableListener(l Listener) DuppableListener {
+	return duppableListener{Listener: l}
 }
 
 var (


### PR DESCRIPTION
Previously, graceful restart of TLS listener does not work because:
1) tls.Listener does not implement the caddy.Listener interface as it
   lacks the File() method.
2) tls.Listener utilizes an underlying net.Listener which breaks the
   code in startServers() that attempt to do a dup.

This change introduces a new caddy.DuppableListener interface that
encapsulates the dup logic for TLS listener.

Fixes issue: https://github.com/coredns/coredns/issues/1244

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
(please see commit msg)

### 2. Please link to the relevant issues.
https://github.com/coredns/coredns/issues/1244

### 3. Which documentation changes (if any) need to be made because of this PR?
Document additional interface, caddy.DuppableListener

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
