### PR TITLE
caddymain: fix setCPU silently ignoring small percent values

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -221,6 +221,8 @@ func setVersion() {
 // setCPU parses string cpu and sets GOMAXPROCS
 // according to its value. It accepts either
 // a number (e.g. 3) or a percent (e.g. 50%).
+// If the percent resolves to less than a single
+// GOMAXPROCS, it rounds it up to GOMAXPROCS=1.
 func setCPU(cpu string) error {
 	var numCPU int
 
@@ -236,6 +238,9 @@ func setCPU(cpu string) error {
 		}
 		percent = float32(pctInt) / 100
 		numCPU = int(float32(availCPU) * percent)
+		if numCPU < 1 {
+			numCPU = 1
+		}
 	} else {
 		// Number
 		num, err := strconv.Atoi(cpu)

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -41,7 +41,7 @@ func TestSetCPU(t *testing.T) {
 		{"invalid input", currentCPU, true},
 		{"invalid input%", currentCPU, true},
 		{"9999", maxCPU, false}, // over available CPU
-		{"1%", 1, false}, // under a single CPU; assume maxCPU < 100
+		{"1%", 1, false},        // under a single CPU; assume maxCPU < 100
 	} {
 		err := setCPU(test.input)
 		if test.shouldErr && err == nil {

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -41,6 +41,7 @@ func TestSetCPU(t *testing.T) {
 		{"invalid input", currentCPU, true},
 		{"invalid input%", currentCPU, true},
 		{"9999", maxCPU, false}, // over available CPU
+		{"1%", 1, false}, // under a single CPU; assume maxCPU < 100
 	} {
 		err := setCPU(test.input)
 		if test.shouldErr && err == nil {


### PR DESCRIPTION
### 1. What does this change do, exactly?
caddy/run.go:238
the percent value is resolved in a GOMAXPROCS relative number by simple
division, thus rounding down the non-integer quotient. If zero, the call
to runtime.GOMAXPROCS is silently ignored.

We decide here to exceptionally round up the CPU cap in case of percent
values that are too small.

### 2. Please link to the relevant issues.
#1962 

### 3. Which documentation changes (if any) need to be made because of this PR?


### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
