### PR TITLE
Update README.md

### DIFF
--- a/dist/init/linux-systemd/README.md
+++ b/dist/init/linux-systemd/README.md
@@ -46,7 +46,7 @@ sudo useradd \
 sudo mkdir /etc/caddy
 sudo chown -R root:www-data /etc/caddy
 sudo mkdir /etc/ssl/caddy
-sudo chown -R www-data:root /etc/ssl/caddy
+sudo chown -R root:www-data /etc/ssl/caddy
 sudo chmod 0770 /etc/ssl/caddy
 ```
 

--- a/dist/init/linux-systemd/README.md
+++ b/dist/init/linux-systemd/README.md
@@ -44,9 +44,9 @@ sudo useradd \
   --system --uid 33 www-data
 
 sudo mkdir /etc/caddy
-sudo chown -R www-data:www-data /etc/caddy
+sudo chown -R root:www-data /etc/caddy
 sudo mkdir /etc/ssl/caddy
-sudo chown -R www-data:www-data /etc/ssl/caddy
+sudo chown -R root:www-data /etc/ssl/caddy
 sudo chmod 0770 /etc/ssl/caddy
 ```
 

--- a/dist/init/linux-systemd/README.md
+++ b/dist/init/linux-systemd/README.md
@@ -44,9 +44,9 @@ sudo useradd \
   --system --uid 33 www-data
 
 sudo mkdir /etc/caddy
-sudo chown -R root:www-data /etc/caddy
+sudo chown -R www-data:www-data /etc/caddy
 sudo mkdir /etc/ssl/caddy
-sudo chown -R root:www-data /etc/ssl/caddy
+sudo chown -R www-data:www-data /etc/ssl/caddy
 sudo chmod 0770 /etc/ssl/caddy
 ```
 


### PR DESCRIPTION
I believe the owner and group of the `chown` command here are mixed up. As it was caused a permissions issue, with the service being unable to read the directory.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Change the command for changing the ownership of the `/etc/ssl/caddy` directory from `www-data:root` to `root:www-data`.

### 2. Please link to the relevant issues.
I don't believe there are any relevant issues at the time of writing.

### 3. Which documentation changes (if any) need to be made because of this PR?
This change consists of the needed documentation change.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
