### PR TITLE
confLoader: use import to handle globbed values for -conf flag

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -170,10 +170,18 @@ func confLoader(serverType string) (caddy.Input, error) {
 		return caddy.CaddyfileFromPipe(os.Stdin, serverType)
 	}
 
-	contents, err := ioutil.ReadFile(conf)
-	if err != nil {
-		return nil, err
+	var contents []byte
+	if strings.Contains(conf, "*") {
+		// Let caddyfile.doImport logic handle the globbed path
+		contents = []byte("import " + conf)
+	} else {
+		var err error
+		contents, err = ioutil.ReadFile(conf)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return caddy.CaddyfileInput{
 		Contents:       contents,
 		Filepath:       conf,


### PR DESCRIPTION
### 1. What does this change do, exactly?
Implements handling for glob values for the -conf flag.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1910

### 3. Which documentation changes (if any) need to be made because of this PR?
https://caddyserver.com/docs/cli should be updated to mention the ability to use globs.

### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

---
95% of the time spent preparing this pull request was figuring out how to fork, branch, then fix my branch, then rebase and start over, then squash two commits into one branch.

This proposed PR feels pretty hacky to me, but it works and I think the only alternative is to copy a whole lot of code out of `doImport` itself.