### PR TITLE
Updated GET requests to send along the body (fcgi)

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -148,7 +148,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 			case "HEAD":
 				resp, err = fcgiBackend.Head(env)
 			case "GET":
-				resp, err = fcgiBackend.Get(env)
+				resp, err = fcgiBackend.Get(env, r.Body, contentLength)
 			case "OPTIONS":
 				resp, err = fcgiBackend.Options(env)
 			default:

--- a/caddyhttp/fastcgi/fcgiclient.go
+++ b/caddyhttp/fastcgi/fcgiclient.go
@@ -460,12 +460,12 @@ func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 }
 
 // Get issues a GET request to the fcgi responder.
-func (c *FCGIClient) Get(p map[string]string) (resp *http.Response, err error) {
+func (c *FCGIClient) Get(p map[string]string, body io.Reader, l int64) (resp *http.Response, err error) {
 
 	p["REQUEST_METHOD"] = "GET"
-	p["CONTENT_LENGTH"] = "0"
+	p["CONTENT_LENGTH"] = strconv.FormatInt(l, 10)
 
-	return c.Request(p, nil)
+	return c.Request(p, body)
 }
 
 // Head issues a HEAD request to the fcgi responder.

--- a/caddyhttp/fastcgi/fcgiclient_test.go
+++ b/caddyhttp/fastcgi/fcgiclient_test.go
@@ -140,7 +140,8 @@ func sendFcgi(reqType int, fcgiParams map[string]string, data []byte, posts map[
 			}
 			resp, err = fcgi.PostForm(fcgiParams, values)
 		} else {
-			resp, err = fcgi.Get(fcgiParams)
+			rd := bytes.NewReader(data)
+			resp, err = fcgi.Get(fcgiParams, rd, int64(rd.Len()))
 		}
 
 	default:


### PR DESCRIPTION
According to RFC 7231 and RFC 7230, there's
no reason a GET-Request can't have a body
(other than it possibly not being supported
by existing software). It's use is simply not
defined, and is left to the application.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
It passes along any HTTP Body for GET requests to fastcgi endpoints. 

### 2. Please link to the relevant issues.
Fixes #1961 

### 3. Which documentation changes (if any) need to be made because of this PR?
None. 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have run existing tests and verified that they did not break
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
