### PR TITLE
add basicauth {user} to replacer

### DIFF
--- a/caddyhttp/basicauth/basicauth.go
+++ b/caddyhttp/basicauth/basicauth.go
@@ -79,6 +79,10 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 			// user; this replaces the request with a wrapped instance
 			r = r.WithContext(context.WithValue(r.Context(),
 				httpserver.RemoteUserCtxKey, username))
+
+			// Provide username to be used in log by replacer
+			repl := httpserver.NewReplacer(r, nil, "-")
+			repl.Set("user", username)
 		}
 	}
 


### PR DESCRIPTION
### 1. What does this change do, exactly?

Following on from #1937 and #1931 this change adds {user} value in basicauth to be used by replacer

### 2. Please link to the relevant issues.
 - #1937
- #1931
- #1953 

### 3. Which documentation changes (if any) need to be made because of this PR?
I don't think it requires any but I can add if necessary.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change (I dont think it needs tests)
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later