### PR TITLE
implemented sourcing of default file for sysvinit

### DIFF
--- a/dist/init/linux-sysvinit/README.md
+++ b/dist/init/linux-sysvinit/README.md
@@ -9,3 +9,19 @@ Usage
 * Ensure that the folder `/etc/caddy` exists and that the folder `/etc/ssl/caddy` is owned by `www-data`.
 * Create a Caddyfile in `/etc/caddy/Caddyfile`
 * Now you can use `service caddy start|stop|restart|reload|status` as `root`.
+
+Init script manipulation
+-----
+
+The init script supports configuration via the following files:
+* `/etc/default/caddy` ( Debian based https://www.debian.org/doc/manuals/debian-reference/ch03.en.html#_the_default_parameter_for_each_init_script )
+* `/etc/sysconfig/caddy` ( CentOS based https://www.centos.org/docs/5/html/5.2/Deployment_Guide/s1-sysconfig-files.html )
+
+The following variables can be changed:
+* DAEMON: path to the caddy binary file (default: `/usr/local/bin/caddy`)
+* DAEMONUSER: user used to run caddy (default: `www-data`)
+* PIDFILE: path to the pidfile (default: `/var/run/$NAME.pid`)
+* LOGFILE: path to the log file for caddy daemon (not for access logs) (default: `/var/log/$NAME.log`)
+* CONFIGFILE: path to the caddy configuration file (default: `/etc/caddy/Caddyfile`)
+* CADDYPATH: path for SSL certificates managed by caddy (default: `/etc/ssl/caddy`)
+* ULIMIT: open files limit (default: `8192`)

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -30,9 +30,9 @@ test -x $DAEMON || exit 0
 
 # allow overwriting variables
 #   Debian based
-[ -e "/etc/default/caddy" ] && source /etc/default/caddy
+[ -e "/etc/default/caddy" ] && . /etc/default/caddy
 #   CentOS based
-[ -e "/etc/sysconfig/caddy" ] && source /etc/sysconfig/caddy
+[ -e "/etc/sysconfig/caddy" ] && . /etc/sysconfig/caddy
 
 # daemon options
 DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -20,7 +20,6 @@ DAEMONUSER=www-data
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
 CONFIGFILE=/etc/caddy/Caddyfile
-DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
 
 USERBIND="setcap cap_net_bind_service=+ep"
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
@@ -32,8 +31,11 @@ test -x $DAEMON || exit 0
 # allow overwriting variables
 #   Debian based
 [ -e "/etc/default/caddy" ] && source /etc/default/caddy
-#   Red Hat based
+#   CentOS based
 [ -e "/etc/sysconfig/caddy" ] && source /etc/sysconfig/caddy
+
+# daemon options
+DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
 
 # Set the CADDYPATH; Let's Encrypt certificates will be written to this directory.
 export CADDYPATH

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -34,8 +34,10 @@ test -x $DAEMON || exit 0
 #   CentOS based
 [ -e "/etc/sysconfig/caddy" ] && . /etc/sysconfig/caddy
 
-# daemon options
-DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
+if [ -z "$DAEMONOPTS" ]; then
+    # daemon options
+    DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
+fi
 
 # Set the CADDYPATH; Let's Encrypt certificates will be written to this directory.
 export CADDYPATH

--- a/dist/init/linux-sysvinit/caddy
+++ b/dist/init/linux-sysvinit/caddy
@@ -24,14 +24,22 @@ DAEMONOPTS="-agree=true -log=$LOGFILE -conf=$CONFIGFILE"
 
 USERBIND="setcap cap_net_bind_service=+ep"
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
+CADDYPATH=/etc/ssl/caddy
+ULIMIT=8192
 
 test -x $DAEMON || exit 0
 
+# allow overwriting variables
+#   Debian based
+[ -e "/etc/default/caddy" ] && source /etc/default/caddy
+#   Red Hat based
+[ -e "/etc/sysconfig/caddy" ] && source /etc/sysconfig/caddy
+
 # Set the CADDYPATH; Let's Encrypt certificates will be written to this directory.
-export CADDYPATH=/etc/ssl/caddy
+export CADDYPATH
 
 # Set the ulimits
-ulimit -n 8192
+ulimit -n ${ULIMIT}
 
 
 start() {


### PR DESCRIPTION
### 1. What does this change do, exactly?
It allow to overwrite the variables used in the sysvinit script by providing the file caddy in either /etc/default/ (Debian based https://www.debian.org/doc/manuals/debian-reference/ch03.en.html#_the_default_parameter_for_each_init_script ) or in /etc/sysconfig/ (CentOS based https://www.centos.org/docs/5/html/5.2/Deployment_Guide/s1-sysconfig-files.html ).

That way the server administrators can easily increase the ulimit and change installation paths if necessary.

### 2. Please link to the relevant issues.
None

### 3. Which documentation changes (if any) need to be made because of this PR?
Already documented in README

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change (tested on my systems)
- [ ] I have squashed any insignificant commits (tried but got merge conflicts)
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
