### PR TITLE
Correct latency placeholder with lower than 1ms elapsed duration

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -359,7 +359,7 @@ func (r *replacer) getSubstitution(key string) string {
 			return r.emptyValue
 		}
 		elapsedDuration := time.Since(r.responseRecorder.start)
-		
+
 		if elapsedDuration == 0 {
 			return "0ms"
 		}

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -358,7 +358,12 @@ func (r *replacer) getSubstitution(key string) string {
 		if r.responseRecorder == nil {
 			return r.emptyValue
 		}
-		return roundDuration(time.Since(r.responseRecorder.start)).String()
+		elapsedDuration := time.Since(r.responseRecorder.start)
+		
+		if elapsedDuration == 0 {
+			return "0ms"
+		}
+		return roundDuration(elapsedDuration).String()
 	case "{latency_ms}":
 		if r.responseRecorder == nil {
 			return r.emptyValue

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -205,13 +205,13 @@ func TestPathRewrite(t *testing.T) {
 
 func TestRound(t *testing.T) {
 	var tests = map[time.Duration]time.Duration{
-		// 599.935µs -> 560µs
+		// 559.935µs -> 0.560ms
 		559935 * time.Nanosecond: 560 * time.Microsecond,
 		// 1.55ms    -> 2ms
 		1550 * time.Microsecond: 2 * time.Millisecond,
-		// 1.5555s   -> 1.556s
+		// 1.5555s   -> 1556ms
 		1555500 * time.Microsecond: 1556 * time.Millisecond,
-		// 1m2.0035s -> 1m2.004s
+		// 1m2.0035s -> 62004ms
 		62003500 * time.Microsecond: 62004 * time.Millisecond,
 	}
 


### PR DESCRIPTION
### 1. What does this change do, exactly?
Fixes #1988. I also adjusted some test comments to make them closer to specs.

Tested on Windows 7 x64. I'm intermediate in Go, so it may not be the be the best way to correct the issue.

### 2. Please link to the relevant issues.
See above.

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
