### PR TITLE
Systemd - disable privatedevices as it may not work for some devices

### DIFF
--- a/dist/init/linux-systemd/caddy.service
+++ b/dist/init/linux-systemd/caddy.service
@@ -30,8 +30,8 @@ LimitNPROC=512
 
 ; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp=true
-; Use a minimal /dev
-PrivateDevices=true
+; Use a minimal /dev (May bring additional security if switched to 'true', but it may not work on Raspberry Pi's or other devices, so it has been disabled in this dist.)
+PrivateDevices=false
 ; Hide /home, /root, and /run/user. Nobody will steal your SSH-keys.
 ProtectHome=true
 ; Make /usr, /boot, /etc and possibly some more folders read-only.
@@ -41,7 +41,7 @@ ProtectSystem=full
 ReadWriteDirectories=/etc/ssl/caddy
 
 ; The following additional security directives only work with systemd v229 or later.
-; They further retrict privileges that can be gained by caddy. Uncomment if you like.
+; They further restrict privileges that can be gained by caddy. Uncomment if you like.
 ; Note that you may have to add capabilities required by any plugins in use.
 ;CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ;AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
### 1. What does this change do, exactly?
Sets privatedevices in systemd to 'false' as it may not work for some devices.

### 2. Please link to the relevant issues.
I didn't create one yet. It was discussed in the forum recently here:
https://caddy.community/t/systemd-fails-to-load-caddy-on-a-raspberry-pi/3170

It is related to: 
https://github.com/mholt/caddy/issues/1853
https://serverfault.com/questions/871635/error-running-otherwise-working-caddy-under-systemd-v232
https://caddy.community/t/error-running-otherwise-working-caddy-under-systemd-v232/2638

More details on this feature here:
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateDevices=

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later

  