### PR TITLE
shutdown: allow graceful shutdown for SIGTERM on posix

### DIFF
--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -25,7 +25,7 @@ import (
 
 // trapSignalsPosix captures POSIX-only signals.
 func trapSignalsPosix() {
-	signalToString := map[os.Signal]string{syscall.SIGTERM: "SIGTERM", syscall.SIGQUIT: "SIGQUIT"}
+	signalToString := map[os.Signal]string{syscall.SIGHUP: "SIGHUP", syscall.SIGUSR1: "SIGUSR1"}
 
 	go func() {
 		sigchan := make(chan os.Signal, 1)
@@ -33,14 +33,19 @@ func trapSignalsPosix() {
 
 		for sig := range sigchan {
 			switch sig {
-			case syscall.SIGTERM:
-				fallthrough
 			case syscall.SIGQUIT:
-				log.Printf("[INFO] %s: Shutting down", signalToString[sig])
+				log.Println("[INFO] SIGQUIT: Terminating process")
+				if PidFile != "" {
+					os.Remove(PidFile)
+				}
+				os.Exit(0)
+
+			case syscall.SIGTERM:
+				log.Println("[INFO] SIGTERM: Shutting down")
 				exitCode := executeShutdownCallbacks(signalToString[sig])
 				err := Stop()
 				if err != nil {
-					log.Printf("[ERROR] %s stop: %v", signalToString[sig], err)
+					log.Printf("[ERROR] SIGTERM stop: %v", err)
 					exitCode = 3
 				}
 				if PidFile != "" {
@@ -48,32 +53,25 @@ func trapSignalsPosix() {
 				}
 				os.Exit(exitCode)
 
-			case syscall.SIGHUP:
-				log.Println("[INFO] SIGHUP: Hanging up")
-				err := Stop()
-				if err != nil {
-					log.Printf("[ERROR] SIGHUP stop: %v", err)
-				}
-
-			case syscall.SIGUSR1:
-				log.Println("[INFO] SIGUSR1: Reloading")
+			case syscall.SIGUSR1, syscall.SIGHUP:
+				log.Printf("[INFO] %s: Reloading", signalToString[sig])
 
 				// Start with the existing Caddyfile
 				caddyfileToUse, inst, err := getCurrentCaddyfile()
 				if err != nil {
-					log.Printf("[ERROR] SIGUSR1: %v", err)
+					log.Printf("[ERROR] %s: %v", signalToString[sig], err)
 					continue
 				}
 				if loaderUsed.loader == nil {
 					// This also should never happen
-					log.Println("[ERROR] SIGUSR1: no Caddyfile loader with which to reload Caddyfile")
+					log.Printf("[ERROR] %s: no Caddyfile loader with which to reload Caddyfile", signalToString[sig])
 					continue
 				}
 
 				// Load the updated Caddyfile
 				newCaddyfile, err := loaderUsed.loader.Load(inst.serverType)
 				if err != nil {
-					log.Printf("[ERROR] SIGUSR1: loading updated Caddyfile: %v", err)
+					log.Printf("[ERROR] %s: loading updated Caddyfile: %v", signalToString[sig], err)
 					continue
 				}
 				if newCaddyfile != nil {
@@ -83,7 +81,7 @@ func trapSignalsPosix() {
 				// Kick off the restart; our work is done
 				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {
-					log.Printf("[ERROR] SIGUSR1: %v", err)
+					log.Printf("[ERROR] %s: %v", signalToString[sig], err)
 				}
 
 			case syscall.SIGUSR2:


### PR DESCRIPTION
The signal is already trapped; make it do the same thing as SIGQUIT to
be more inline with Unix/Linux shutdown expectations.

Fixes #1993


### 3. Which documentation changes (if any) need to be made because of this PR?

SIGTERM is detailed on various pages/READMEs. I haven't followed up with those yet.