### PR TITLE
Fix for #1927

### DIFF
--- a/caddyhttp/httpserver/server.go
+++ b/caddyhttp/httpserver/server.go
@@ -413,7 +413,12 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 	// the URL path, so a request to example.com/foo/blog on the site
 	// defined as example.com/foo appears as /blog instead of /foo/blog.
 	if pathPrefix != "/" {
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, pathPrefix)
+		// We are unable to use strings.TrimPrefix to trim the pathPrefix as
+		// it will decode any url encoded characters. See #1927
+		idx := strings.Index(pathPrefix, r.URL.Path)
+		if idx > -1 {
+			r.URL.Path = r.URL.Path[idx:]
+		}
 		if !strings.HasPrefix(r.URL.Path, "/") {
 			r.URL.Path = "/" + r.URL.Path
 		}


### PR DESCRIPTION
### 1. What does this change do, exactly?
This is a fix for #1927 .  Ensures that encoded / (%2f) in url is retained when the site definition includes a directory.

The problem turned out to be a call to strings.TrimPrefix which also decoded any encoded values in the string.  It has been replaced by code to simply perform the trim.
### 2. Please link to the relevant issues.
#1927 

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
