### PR TITLE
Update min version to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ customize your build in the browser
 pre-built, vanilla binaries
 
 ## Build
-To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.8 or newer). Follow these instruction for fast building:
+To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.9 or newer). Follow these instruction for fast building:
 
 - Get source `go get github.com/mholt/caddy/caddy` and then run `go get github.com/caddyserver/builds`
 - Now `cd` to `$GOPATH/src/github.com/mholt/caddy/caddy` and run `go run build.go`


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Updates the minimum version of Go required to build from source. 1.8 fails since #2009 from the introduction of `sync.Map`

### 2. Please link to the relevant issues.

#2009

### 3. Which documentation changes (if any) need to be made because of this PR?

This *is* the doc change.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
