### PR TITLE
Allow Response Headers as a placeholder

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -225,7 +225,6 @@ func (r *replacer) getSubstitution(key string) string {
 			}
 		}
 	}
-	log.Printf("ResponseHEaders: %+v, %+V", r.responseRecorder.Header(), r.responseRecorder.Header())
 	// search response headers then
 	if key[1] == '<' {
 		want := key[2 : len(key)-1]

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -218,6 +219,17 @@ func (r *replacer) getSubstitution(key string) string {
 	if key[1] == '>' {
 		want := key[2 : len(key)-1]
 		for key, values := range r.request.Header {
+			// Header placeholders (case-insensitive)
+			if strings.EqualFold(key, want) {
+				return strings.Join(values, ",")
+			}
+		}
+	}
+	log.Printf("ResponseHEaders: %+v, %+V", r.responseRecorder.Header(), r.responseRecorder.Header())
+	// search response headers then
+	if key[1] == '<' {
+		want := key[2 : len(key)-1]
+		for key, values := range r.responseRecorder.Header() {
 			// Header placeholders (case-insensitive)
 			if strings.EqualFold(key, want) {
 				return strings.Join(values, ",")


### PR DESCRIPTION
### 1. What does this change do, exactly?
Allows Response header values to be used by the replacer and log.

It seemed best to use the less than symbol `<` so a response header would be `{<Server}`

Only some response headers seem to be available to the replacer when called .

eg - the following are shown in chrome

Content-Length:16
Content-Type:text/plain; charset=utf-8
Date:Sun, 18 Feb 2018 08:07:13 GMT
Server:Caddy
X-Content-Type-Options:nosniff

only 

    {<Content-Type}
    {<Server}
    {<X-Content-Type-Options}

will return a value.

### 2. Please link to the relevant issues.
#1837 

### 3. Which documentation changes (if any) need to be made because of this PR?

We simply need to add to the placeholder page that {<Header} is allowed as a response placeholder.

### 4. Checklist
I will write tests

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
