### PR TITLE
caddy: Purge event hooks after USR1 reload

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -271,6 +271,19 @@ func EmitEvent(event EventName, info interface{}) {
 	})
 }
 
+// purgeEventHooks purges all event hooks from the map
+func purgeEventHooks() {
+	eventHooks.Range(func(k, _ interface{}) bool {
+		eventHooks.Delete(k)
+		return true
+	})
+}
+
+// deleteEventHook deletes one event hook from the map
+func deleteEventHook(name string) {
+	eventHooks.Delete(name)
+}
+
 // ParsingCallback is a function that is called after
 // a directive's setup functions have been executed
 // for all the server blocks.

--- a/plugins.go
+++ b/plugins.go
@@ -279,11 +279,6 @@ func purgeEventHooks() {
 	})
 }
 
-// deleteEventHook deletes one event hook from the map
-func deleteEventHook(name string) {
-	eventHooks.Delete(name)
-}
-
 // ParsingCallback is a function that is called after
 // a directive's setup functions have been executed
 // for all the server blocks.

--- a/plugins.go
+++ b/plugins.go
@@ -39,7 +39,7 @@ var (
 
 	// eventHooks is a map of hook name to Hook. All hooks plugins
 	// must have a name.
-	eventHooks = sync.Map{}
+	eventHooks = &sync.Map{}
 
 	// parsingCallbacks maps server type to map of directive
 	// to list of callback functions. These aren't really
@@ -269,6 +269,16 @@ func EmitEvent(event EventName, info interface{}) {
 		}
 		return true
 	})
+}
+
+// cloneEventHooks return a clone of the event hooks *sync.Map
+func cloneEventHooks() *sync.Map {
+	c := &sync.Map{}
+	eventHooks.Range(func(k, v interface{}) bool {
+		c.LoadOrStore(k, v)
+		return true
+	})
+	return c
 }
 
 // purgeEventHooks purges all event hooks from the map

--- a/plugins.go
+++ b/plugins.go
@@ -275,7 +275,7 @@ func EmitEvent(event EventName, info interface{}) {
 func cloneEventHooks() *sync.Map {
 	c := &sync.Map{}
 	eventHooks.Range(func(k, v interface{}) bool {
-		c.LoadOrStore(k, v)
+		c.Store(k, v)
 		return true
 	})
 	return c
@@ -285,6 +285,18 @@ func cloneEventHooks() *sync.Map {
 func purgeEventHooks() {
 	eventHooks.Range(func(k, _ interface{}) bool {
 		eventHooks.Delete(k)
+		return true
+	})
+}
+
+// restoreEventHooks restores eventHooks with a provided *sync.Map
+func restoreEventHooks(m *sync.Map) {
+	// Purge old event hooks
+	purgeEventHooks()
+
+	// Restore event hooks
+	m.Range(func(k, v interface{}) bool {
+		eventHooks.Store(k, v)
 		return true
 	})
 }

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -76,12 +76,17 @@ func trapSignalsPosix() {
 					caddyfileToUse = newCaddyfile
 				}
 
+				// Backup old event hooks
+				oldEventHooks := cloneEventHooks()
+
 				// Purge the old event hooks
 				purgeEventHooks()
 
 				// Kick off the restart; our work is done
 				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {
+					eventHooks = oldEventHooks
+
 					log.Printf("[ERROR] SIGUSR1: %v", err)
 				}
 

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -77,7 +77,6 @@ func trapSignalsPosix() {
 				}
 
 				// Purge the old event hooks
-				log.Println("[INFO: Purging old event hooks]")
 				purgeEventHooks()
 
 				// Kick off the restart; our work is done

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -85,7 +85,7 @@ func trapSignalsPosix() {
 				// Kick off the restart; our work is done
 				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {
-					eventHooks = oldEventHooks
+					restoreEventHooks(oldEventHooks)
 
 					log.Printf("[ERROR] SIGUSR1: %v", err)
 				}

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -76,6 +76,10 @@ func trapSignalsPosix() {
 					caddyfileToUse = newCaddyfile
 				}
 
+				// Purge the old event hooks
+				log.Println("[INFO: Purging old event hooks]")
+				purgeEventHooks()
+
 				// Kick off the restart; our work is done
 				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {


### PR DESCRIPTION
### 1. What does this change do, exactly?

- Purge event hooks after USR1 reload
- ~Create a new func to delete event hooks~

### 2. Please link to the relevant issues.

#2044

### 3. Which documentation changes (if any) need to be made because of this PR?

/

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
