### PR TITLE
httpserver: Add 'warp' plugin directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -479,6 +479,7 @@ var directives = []string{
 	"bind",
 	"limits",
 	"timeouts",
+	"warp", // github.com/caddyserver/cloudflare-warp-plugin
 	"tls",
 
 	// services/utilities, or other directives that don't necessarily inject handlers


### PR DESCRIPTION
**NOT ready to merge yet.**

This adds the `warp` directive to the HTTP server's list of supported plugins.

Currently a WIP!