### PR TITLE
Bump the default minimum TLS version to 1.2

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -511,7 +511,7 @@ func SetDefaultTLSParams(config *Config) {
 
 	// Set default protocol min and max versions - must balance compatibility and security
 	if config.ProtocolMinVersion == 0 {
-		config.ProtocolMinVersion = tls.VersionTLS11
+		config.ProtocolMinVersion = tls.VersionTLS12
 	}
 	if config.ProtocolMaxVersion == 0 {
 		config.ProtocolMaxVersion = tls.VersionTLS12

--- a/caddytls/config_test.go
+++ b/caddytls/config_test.go
@@ -24,23 +24,6 @@ import (
 	"github.com/codahale/aesnicheck"
 )
 
-func TestDefaultTLSConfigProtocolVersions(t *testing.T) {
-	config := &Config{
-		Enabled: true,
-	}
-	SetDefaultTLSParams(config)
-	err := config.buildStandardTLSConfig()
-	if err != nil {
-		t.Fatalf("Did not expect an error, but got %v", err)
-	}
-	if got, want := config.tlsConfig.MinVersion, uint16(tls.VersionTLS12); got != want {
-		t.Errorf("Expected min version to be %x, got %x", want, got)
-	}
-	if got, want := config.tlsConfig.MaxVersion, uint16(tls.VersionTLS12); got != want {
-		t.Errorf("Expected max version to be %x, got %x", want, got)
-	}
-}
-
 func TestConvertTLSConfigProtocolVersions(t *testing.T) {
 	// same min and max protocol versions
 	config := &Config{

--- a/caddytls/config_test.go
+++ b/caddytls/config_test.go
@@ -24,6 +24,23 @@ import (
 	"github.com/codahale/aesnicheck"
 )
 
+func TestDefaultTLSConfigProtocolVersions(t *testing.T) {
+	config := &Config{
+		Enabled: true,
+	}
+	SetDefaultTLSParams(config)
+	err := config.buildStandardTLSConfig()
+	if err != nil {
+		t.Fatalf("Did not expect an error, but got %v", err)
+	}
+	if got, want := config.tlsConfig.MinVersion, uint16(tls.VersionTLS12); got != want {
+		t.Errorf("Expected min version to be %x, got %x", want, got)
+	}
+	if got, want := config.tlsConfig.MaxVersion, uint16(tls.VersionTLS12); got != want {
+		t.Errorf("Expected max version to be %x, got %x", want, got)
+	}
+}
+
 func TestConvertTLSConfigProtocolVersions(t *testing.T) {
 	// same min and max protocol versions
 	config := &Config{

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -67,8 +67,8 @@ func TestSetupParseBasic(t *testing.T) {
 	}
 
 	// Security defaults
-	if cfg.ProtocolMinVersion != tls.VersionTLS11 {
-		t.Errorf("Expected 'tls1.1 (0x0302)' as ProtocolMinVersion, got %#v", cfg.ProtocolMinVersion)
+	if cfg.ProtocolMinVersion != tls.VersionTLS12 {
+		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion, got %#v", cfg.ProtocolMinVersion)
 	}
 	if cfg.ProtocolMaxVersion != tls.VersionTLS12 {
 		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMaxVersion, got %v", cfg.ProtocolMaxVersion)


### PR DESCRIPTION
### 1. What does this change do, exactly?
It bumps the default minimum TLS version to 1.2 instead of 1.1

### 2. Please link to the relevant issues.
#2045 

### 3. Which documentation changes (if any) need to be made because of this PR?
[Caddy Documentation](https://caddyserver.com/docs/tls]) section `Protocols`

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
