### PR TITLE
Change default tls minimum version to 1.2

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -511,7 +511,7 @@ func SetDefaultTLSParams(config *Config) {
 
 	// Set default protocol min and max versions - must balance compatibility and security
 	if config.ProtocolMinVersion == 0 {
-		config.ProtocolMinVersion = tls.VersionTLS11
+		config.ProtocolMinVersion = tls.VersionTLS12
 	}
 	if config.ProtocolMaxVersion == 0 {
 		config.ProtocolMaxVersion = tls.VersionTLS12

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -67,8 +67,8 @@ func TestSetupParseBasic(t *testing.T) {
 	}
 
 	// Security defaults
-	if cfg.ProtocolMinVersion != tls.VersionTLS11 {
-		t.Errorf("Expected 'tls1.1 (0x0302)' as ProtocolMinVersion, got %#v", cfg.ProtocolMinVersion)
+	if cfg.ProtocolMinVersion != tls.VersionTLS12 {
+		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion, got %#v", cfg.ProtocolMinVersion)
 	}
 	if cfg.ProtocolMaxVersion != tls.VersionTLS12 {
 		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMaxVersion, got %v", cfg.ProtocolMaxVersion)


### PR DESCRIPTION
### 1. What does this change do, exactly?
It ups the default minimum TLS version to 1.2 instead 1.2

### 2. Please link to the relevant issues.
#2045

### 3. Which documentation changes (if any) need to be made because of this PR?
[Caddy Documentation](https://caddyserver.com/docs/tls]) section `Protocols`

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later