### PR TITLE
Implement placeholders for tls_protocol and tls_cipher

### DIFF
--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"crypto/tls"
+
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"github.com/mholt/caddy/caddytls"

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -33,10 +33,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"crypto/tls"
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"github.com/mholt/caddy/caddytls"
-	"crypto/tls"
 )
 
 // Handler is a middleware type that can handle requests as a FastCGI client.
@@ -327,7 +327,7 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 		env["HTTPS"] = "on"
 		// and pass the protocol details like apache's mod_ssl
 		v, ok := sslProtocolToStringMap[r.TLS.Version]
-		if (ok) {
+		if ok {
 			env["SSL_PROTOCOL"] = v
 		}
 		// and pass the cipher like apache's mod_ssl
@@ -483,7 +483,7 @@ func (l LogError) Error() string {
 // Map of supported protocols to Apache ssl_mod format
 // Note that these are slightly different from SupportedProtocols in caddytls/config.go's
 var sslProtocolToStringMap = map[uint16]string{
-	tls.VersionTLS10 : "TLSv1",
-	tls.VersionTLS11 : "TLSv1.1",
-	tls.VersionTLS12 : "TLSv1.2",
+	tls.VersionTLS10: "TLSv1",
+	tls.VersionTLS11: "TLSv1.1",
+	tls.VersionTLS12: "TLSv1.2",
 }

--- a/caddyhttp/fastcgi/fastcgi.go
+++ b/caddyhttp/fastcgi/fastcgi.go
@@ -326,12 +326,13 @@ func (h Handler) buildEnv(r *http.Request, rule Rule, fpath string) (map[string]
 	// Some web apps rely on knowing HTTPS or not
 	if r.TLS != nil {
 		env["HTTPS"] = "on"
-		// and pass the protocol details like apache's mod_ssl
-		v, ok := sslProtocolToStringMap[r.TLS.Version]
+		// and pass the protocol details in a manner compatible with apache's mod_ssl
+		// (which is why they have a SSL_ prefix and not TLS_).
+		v, ok := tlsProtocolStringToMap[r.TLS.Version]
 		if ok {
 			env["SSL_PROTOCOL"] = v
 		}
-		// and pass the cipher like apache's mod_ssl
+		// and pass the cipher suite in a manner compatible with apache's mod_ssl
 		for k, v := range caddytls.SupportedCiphersMap {
 			if v == r.TLS.CipherSuite {
 				env["SSL_CIPHER"] = k
@@ -483,7 +484,7 @@ func (l LogError) Error() string {
 
 // Map of supported protocols to Apache ssl_mod format
 // Note that these are slightly different from SupportedProtocols in caddytls/config.go's
-var sslProtocolToStringMap = map[uint16]string{
+var tlsProtocolStringToMap = map[uint16]string{
 	tls.VersionTLS10: "TLSv1",
 	tls.VersionTLS11: "TLSv1.1",
 	tls.VersionTLS12: "TLSv1.2",

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -376,17 +376,17 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 		elapsedDuration := time.Since(r.responseRecorder.start)
 		return strconv.FormatInt(convertToMilliseconds(elapsedDuration), 10)
-	case "{ssl_protocol}":
+	case "{tls_protocol}":
 		if r.request.TLS != nil {
 			for k, v := range caddytls.SupportedProtocols {
 				if v == r.request.TLS.Version {
 					return k
 				}
 			}
-			return "yes" // this should never happen, but guard in case
+			return "tls" // this should never happen, but guard in case
 		}
-		return "none" // because not using a secure channel
-	case "{ssl_cipher}":
+		return r.emptyValue // because not using a secure channel
+	case "{tls_cipher}":
 		if r.request.TLS != nil {
 			for k, v := range caddytls.SupportedCiphersMap {
 				if v == r.request.TLS.CipherSuite {
@@ -395,7 +395,7 @@ func (r *replacer) getSubstitution(key string) string {
 			}
 			return "UNKNOWN" // this should never happen, but guard in case
 		}
-		return "na" // "not applicable" because not using a secure connection
+		return r.emptyValue
 	}
 
 	return r.emptyValue

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddytls"
 )
 
 // requestReplacer is a strings.Replacer which is used to
@@ -375,6 +376,26 @@ func (r *replacer) getSubstitution(key string) string {
 		}
 		elapsedDuration := time.Since(r.responseRecorder.start)
 		return strconv.FormatInt(convertToMilliseconds(elapsedDuration), 10)
+	case "{ssl_protocol}":
+		if r.request.TLS != nil {
+			for k, v := range caddytls.SupportedProtocols {
+				if v == r.request.TLS.Version {
+					return k
+				}
+			}
+			return "yes" // this should never happen, but guard in case
+		}
+		return "none" // because not using a secure channel
+	case "{ssl_cipher}":
+		if r.request.TLS != nil {
+			for k, v := range caddytls.SupportedCiphersMap {
+				if v == r.request.TLS.CipherSuite {
+					return k
+				}
+			}
+			return "UNKNOWN" // this should never happen, but guard in case
+		}
+		return "na" // "not applicable" because not using a secure connection
 	}
 
 	return r.emptyValue

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -537,6 +537,7 @@ var SupportedProtocols = map[string]uint16{
 	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
 }
+
 // NOTE: if updating the above map, also update sslProtocolToStringMap in caddyhttp/fastcgi/fastcgi.go
 
 // Map of supported ciphers, used only for parsing config.

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -532,13 +532,12 @@ var supportedKeyTypes = map[string]acme.KeyType{
 
 // Map of supported protocols.
 // HTTP/2 only supports TLS 1.2 and higher.
+// If updating this map, also update tlsProtocolStringToMap in caddyhttp/fastcgi/fastcgi.go
 var SupportedProtocols = map[string]uint16{
 	"tls1.0": tls.VersionTLS10,
 	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
 }
-
-// NOTE: if updating the above map, also update sslProtocolToStringMap in caddyhttp/fastcgi/fastcgi.go
 
 // Map of supported ciphers, used only for parsing config.
 //

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -532,11 +532,12 @@ var supportedKeyTypes = map[string]acme.KeyType{
 
 // Map of supported protocols.
 // HTTP/2 only supports TLS 1.2 and higher.
-var supportedProtocols = map[string]uint16{
+var SupportedProtocols = map[string]uint16{
 	"tls1.0": tls.VersionTLS10,
 	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
 }
+// NOTE: if updating the above map, also update sslProtocolToStringMap in caddyhttp/fastcgi/fastcgi.go
 
 // Map of supported ciphers, used only for parsing config.
 //
@@ -548,7 +549,7 @@ var supportedProtocols = map[string]uint16{
 // it is always added (even though it is not technically a cipher suite).
 //
 // This map, like any map, is NOT ORDERED. Do not range over this map.
-var supportedCiphersMap = map[string]uint16{
+var SupportedCiphersMap = map[string]uint16{
 	"ECDHE-ECDSA-AES256-GCM-SHA384":      tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-RSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-ECDSA-AES128-GCM-SHA256":      tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -106,19 +106,19 @@ func setupTLS(c *caddy.Controller) error {
 			case "protocols":
 				args := c.RemainingArgs()
 				if len(args) == 1 {
-					value, ok := supportedProtocols[strings.ToLower(args[0])]
+					value, ok := SupportedProtocols[strings.ToLower(args[0])]
 					if !ok {
 						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[0])
 					}
 
 					config.ProtocolMinVersion, config.ProtocolMaxVersion = value, value
 				} else {
-					value, ok := supportedProtocols[strings.ToLower(args[0])]
+					value, ok := SupportedProtocols[strings.ToLower(args[0])]
 					if !ok {
 						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[0])
 					}
 					config.ProtocolMinVersion = value
-					value, ok = supportedProtocols[strings.ToLower(args[1])]
+					value, ok = SupportedProtocols[strings.ToLower(args[1])]
 					if !ok {
 						return c.Errf("Wrong protocol name or protocol not supported: '%s'", args[1])
 					}
@@ -129,7 +129,7 @@ func setupTLS(c *caddy.Controller) error {
 				}
 			case "ciphers":
 				for c.NextArg() {
-					value, ok := supportedCiphersMap[strings.ToUpper(c.Val())]
+					value, ok := SupportedCiphersMap[strings.ToUpper(c.Val())]
 					if !ok {
 						return c.Errf("Wrong cipher name or cipher not supported: '%s'", c.Val())
 					}


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

It implements two new placeholders: ```tls_protocol``` and ```tls_cipher``` which will contain, when using a secure connection, the protocol and cipher respectively.

For fastcgi, it passes these two placeholders in a manner that is compatible with Apache's [mod_ssl](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html), i.e. as environment variables ```SSL_PROTOCOL``` and ```SSL_CIPHER```.

### 2. Please link to the relevant issues.

#2055

### 3. Which documentation changes (if any) need to be made because of this PR?

The documentation for placeholders will need to incorporate details of these two placeholders. Essentially:

```{tls_protocol}``` The protocol used for a secure transport connection (e.g. "tls1.2").

```{tls_cipher}``` The cipher used for a secure transport connection (e.g. "ECDHE-ECDSA-WITH-CHACHA20-POLY1305").

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later