### PR TITLE
httpserver.Replacer: Rework loop to ignore escaped placeholder braces

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -140,6 +140,14 @@ func canLogRequest(r *http.Request) bool {
 	return false
 }
 
+// unescapeBraces finds escaped braces in s and returns
+// a string with those braces unescaped.
+func unescapeBraces(s string) string {
+	ret := strings.Replace(s, "\\{", "{", -1)
+	ret = strings.Replace(s, "\\}", "}", -1)
+	return ret
+}
+
 // Replace performs a replacement of values on s and returns
 // the string with the replaced values.
 func (r *replacer) Replace(s string) string {
@@ -149,32 +157,59 @@ func (r *replacer) Replace(s string) string {
 	}
 
 	result := ""
+Placeholders: // process each placeholder in sequence
 	for {
-		idxStart := strings.Index(s, "{")
-		if idxStart == -1 {
-			// no placeholder anymore
-			break
-		}
-		idxEnd := strings.Index(s[idxStart:], "}")
-		if idxEnd == -1 {
-			// unpaired placeholder
-			break
-		}
-		idxEnd += idxStart
+		var idxOffset, idxStart, idxEnd int
 
-		// get a replacement
-		placeholder := s[idxStart : idxEnd+1]
+		idxOffset = 0
+		for { // find first unescaped opening brace
+			searchSpace := s[idxOffset:]
+			idxStart = strings.Index(searchSpace, "{")
+			if idxStart == -1 {
+				// no more placeholders
+				break Placeholders
+			}
+			if idxStart == 0 || searchSpace[idxStart-1:idxStart] != "\\" {
+				// preceding character is not an escape
+				idxStart += idxOffset
+				break
+			}
+			// the brace we found was escaped
+			// search the rest of the string next
+			idxOffset += idxStart + 1
+		}
+
+		idxOffset = 0
+		for { // find first unescaped closing brace
+			searchSpace := s[idxStart+idxOffset:]
+			idxEnd = strings.Index(searchSpace, "}")
+			if idxEnd == -1 {
+				// unpaired placeholder
+				break Placeholders
+			}
+			if idxEnd == 0 || searchSpace[idxEnd-1:idxEnd] != "\\" {
+				// preceeding character is not an escape
+				idxEnd += idxOffset + idxStart
+				break
+			}
+			// the brace we found was escaped
+			// search the rest of the string next
+			idxOffset += idxEnd + 1
+		}
+
+		// get a replacement for the unescaped placeholder
+		placeholder := unescapeBraces(s[idxStart : idxEnd+1])
 		replacement := r.getSubstitution(placeholder)
 
-		// append prefix + replacement
-		result += s[:idxStart] + replacement
+		// append unescaped prefix + replacement
+		result += strings.TrimPrefix(unescapeBraces(s[:idxStart]), "\\") + replacement
 
 		// strip out scanned parts
 		s = s[idxEnd+1:]
 	}
 
 	// append unscanned parts
-	return result + s
+	return result + unescapeBraces(s)
 }
 
 func roundDuration(d time.Duration) time.Duration {

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -159,9 +159,9 @@ func (r *replacer) Replace(s string) string {
 	result := ""
 Placeholders: // process each placeholder in sequence
 	for {
-		var idxOffset, idxStart, idxEnd int
+		var idxStart, idxEnd int
 
-		idxOffset = 0
+		idxOffset := 0
 		for { // find first unescaped opening brace
 			searchSpace := s[idxOffset:]
 			idxStart = strings.Index(searchSpace, "{")
@@ -169,7 +169,7 @@ Placeholders: // process each placeholder in sequence
 				// no more placeholders
 				break Placeholders
 			}
-			if idxStart == 0 || searchSpace[idxStart-1:idxStart] != "\\" {
+			if idxStart == 0 || searchSpace[idxStart-1] != '\\' {
 				// preceding character is not an escape
 				idxStart += idxOffset
 				break
@@ -187,7 +187,7 @@ Placeholders: // process each placeholder in sequence
 				// unpaired placeholder
 				break Placeholders
 			}
-			if idxEnd == 0 || searchSpace[idxEnd-1:idxEnd] != "\\" {
+			if idxEnd == 0 || searchSpace[idxEnd-1] != '\\' {
 				// preceding character is not an escape
 				idxEnd += idxOffset + idxStart
 				break

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -143,9 +143,9 @@ func canLogRequest(r *http.Request) bool {
 // unescapeBraces finds escaped braces in s and returns
 // a string with those braces unescaped.
 func unescapeBraces(s string) string {
-	ret := strings.Replace(s, "\\{", "{", -1)
-	ret = strings.Replace(s, "\\}", "}", -1)
-	return ret
+	s = strings.Replace(s, "\\{", "{", -1)
+	s = strings.Replace(s, "\\}", "}", -1)
+	return s
 }
 
 // Replace performs a replacement of values on s and returns
@@ -188,7 +188,7 @@ Placeholders: // process each placeholder in sequence
 				break Placeholders
 			}
 			if idxEnd == 0 || searchSpace[idxEnd-1:idxEnd] != "\\" {
-				// preceeding character is not an escape
+				// preceding character is not an escape
 				idxEnd += idxOffset + idxStart
 				break
 			}

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -145,6 +145,70 @@ func TestReplace(t *testing.T) {
 	}
 }
 
+func BenchmarkReplace(b *testing.B) {
+	w := httptest.NewRecorder()
+	recordRequest := NewResponseRecorder(w)
+	reader := strings.NewReader(`{"username": "dennis"}`)
+
+	request, err := http.NewRequest("POST", "http://localhost/?foo=bar", reader)
+	if err != nil {
+		b.Fatalf("Failed to make request: %v", err)
+	}
+	ctx := context.WithValue(request.Context(), OriginalURLCtxKey, *request.URL)
+	request = request.WithContext(ctx)
+
+	request.Header.Set("Custom", "foobarbaz")
+	request.Header.Set("ShorterVal", "1")
+	repl := NewReplacer(request, recordRequest, "-")
+	// add some headers after creating replacer
+	request.Header.Set("CustomAdd", "caddy")
+	request.Header.Set("Cookie", "foo=bar; taste=delicious")
+
+	// add some respons headers
+	recordRequest.Header().Set("Custom", "CustomResponseHeader")
+
+	now = func() time.Time {
+		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		repl.Replace("This hostname is {hostname}")
+	}
+}
+
+func BenchmarkReplaceEscaped(b *testing.B) {
+	w := httptest.NewRecorder()
+	recordRequest := NewResponseRecorder(w)
+	reader := strings.NewReader(`{"username": "dennis"}`)
+
+	request, err := http.NewRequest("POST", "http://localhost/?foo=bar", reader)
+	if err != nil {
+		b.Fatalf("Failed to make request: %v", err)
+	}
+	ctx := context.WithValue(request.Context(), OriginalURLCtxKey, *request.URL)
+	request = request.WithContext(ctx)
+
+	request.Header.Set("Custom", "foobarbaz")
+	request.Header.Set("ShorterVal", "1")
+	repl := NewReplacer(request, recordRequest, "-")
+	// add some headers after creating replacer
+	request.Header.Set("CustomAdd", "caddy")
+	request.Header.Set("Cookie", "foo=bar; taste=delicious")
+
+	// add some respons headers
+	recordRequest.Header().Set("Custom", "CustomResponseHeader")
+
+	now = func() time.Time {
+		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		repl.Replace("\\{ 'hostname': '{hostname}' \\}")
+	}
+}
+
 func TestResponseRecorderNil(t *testing.T) {
 
 	reader := strings.NewReader(`{"username": "dennis"}`)

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -112,6 +112,7 @@ func TestReplace(t *testing.T) {
 		{"Query string is {query}", "Query string is foo=bar"},
 		{"Query string value for foo is {?foo}", "Query string value for foo is bar"},
 		{"Missing query string argument is {?missing}", "Missing query string argument is "},
+		{"\\{ 'hostname': '{hostname}' \\}", "{ 'hostname': '" + hostname + "' }"},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Makes placeholder braces escapable by backslash character (`\`) for strings fed to a httpserver.Replacer.

It achieves this by using loops to identify the first unescaped opening brace and closing brace, then cleaning up escaped braces as it works its way through the string.

This allows, for example, JSON to be set as a `header` or a `fastcgi` env var and even allows placeholders to continue working inside that JSON.

### 2. Please link to the relevant issues.
Fixes https://github.com/mholt/caddy/issues/2063

### 3. Which documentation changes (if any) need to be made because of this PR?
A quick search determined that the following areas call some form of `replacer.Replace`:
- Env vars in `fastcgi`
- Log formats for `log`
- Upstream and downstream headers in `proxy`
- The location targets of both `redirect` and `rewrite`
- `httpserver.IfMatcher` when evaluating `ifCond.True()`

There may be more I wasn't able to find. Public documentation of the above should note the new escape capability.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

---

As I don't have much experience with Golang PRs yet, I'd welcome any feedback, but especially regarding:
- The method used for looping and breaking the loops
- The tests used to determine whether the brace is escaped
- The method used to clean up the escaped braces
- Any additional tests that could be helpful