### PR TITLE
Regular expression support for simple rewrite rule

### DIFF
--- a/caddyhttp/rewrite/rewrite.go
+++ b/caddyhttp/rewrite/rewrite.go
@@ -63,22 +63,29 @@ type Rule interface {
 
 // SimpleRule is a simple rewrite rule.
 type SimpleRule struct {
-	From, To string
+	Regexp *regexp.Regexp
+	To     string
 }
 
 // NewSimpleRule creates a new Simple Rule
-func NewSimpleRule(from, to string) SimpleRule {
-	return SimpleRule{from, to}
+func NewSimpleRule(from, to string) (*SimpleRule, error) {
+	r, err := regexp.Compile(from)
+	if err != nil {
+		return nil, err
+	}
+	return &SimpleRule{Regexp: r, To: to}, nil
 }
 
 // BasePath satisfies httpserver.Config
-func (s SimpleRule) BasePath() string { return s.From }
+func (s SimpleRule) BasePath() string { return "/" }
 
 // Match satisfies httpserver.Config
-func (s SimpleRule) Match(r *http.Request) bool { return s.From == r.URL.Path }
+func (s *SimpleRule) Match(r *http.Request) bool {
+	return len(regexpMatches(s.Regexp, "/", r.URL.Path)) > 0
+}
 
 // Rewrite rewrites the internal location of the current request.
-func (s SimpleRule) Rewrite(fs http.FileSystem, r *http.Request) Result {
+func (s *SimpleRule) Rewrite(fs http.FileSystem, r *http.Request) Result {
 
 	// attempt rewrite
 	return To(fs, r, s.To, newReplacer(r))
@@ -165,7 +172,7 @@ func (r ComplexRule) Match(req *http.Request) bool {
 		return true
 	}
 	// otherwise validate regex
-	return r.regexpMatches(req.URL.Path) != nil
+	return regexpMatches(r.Regexp, r.Base, req.URL.Path) != nil
 }
 
 // Rewrite rewrites the internal location of the current request.
@@ -174,7 +181,7 @@ func (r ComplexRule) Rewrite(fs http.FileSystem, req *http.Request) (re Result) 
 
 	// validate regexp if present
 	if r.Regexp != nil {
-		matches := r.regexpMatches(req.URL.Path)
+		matches := regexpMatches(r.Regexp, r.Base, req.URL.Path)
 		switch len(matches) {
 		case 0:
 			// no match
@@ -230,14 +237,14 @@ func (r ComplexRule) matchExt(rPath string) bool {
 	return !mustUse
 }
 
-func (r ComplexRule) regexpMatches(rPath string) []string {
-	if r.Regexp != nil {
+func regexpMatches(regexp *regexp.Regexp, base, rPath string) []string {
+	if regexp != nil {
 		// include trailing slash in regexp if present
-		start := len(r.Base)
-		if strings.HasSuffix(r.Base, "/") {
+		start := len(base)
+		if strings.HasSuffix(base, "/") {
 			start--
 		}
-		return r.Regexp.FindStringSubmatch(rPath[start:])
+		return regexp.FindStringSubmatch(rPath[start:])
 	}
 	return nil
 }

--- a/caddyhttp/rewrite/rewrite_test.go
+++ b/caddyhttp/rewrite/rewrite_test.go
@@ -136,7 +136,9 @@ func TestWordpress(t *testing.T) {
 	rw := Rewrite{
 		Next: httpserver.HandlerFunc(urlPrinter),
 		Rules: []httpserver.HandlerConfig{
+			// both rules are same, thanks to Go regexp (confusion).
 			newSimpleRule(t, "^/wp-admin", "{path} {path}/ /index.php?{query}", true),
+			newSimpleRule(t, "^\\/wp-admin", "{path} {path}/ /index.php?{query}", true),
 		},
 		FileSys: http.Dir("."),
 	}

--- a/caddyhttp/rewrite/rewrite_test.go
+++ b/caddyhttp/rewrite/rewrite_test.go
@@ -29,9 +29,9 @@ func TestRewrite(t *testing.T) {
 	rw := Rewrite{
 		Next: httpserver.HandlerFunc(urlPrinter),
 		Rules: []httpserver.HandlerConfig{
-			NewSimpleRule("/from", "/to"),
-			NewSimpleRule("/a", "/b"),
-			NewSimpleRule("/b", "/b{uri}"),
+			newSimpleRule(t, "^/from$", "/to"),
+			newSimpleRule(t, "^/a$", "/b"),
+			newSimpleRule(t, "^/b$", "/b{uri}"),
 		},
 		FileSys: http.Dir("."),
 	}

--- a/caddyhttp/rewrite/setup.go
+++ b/caddyhttp/rewrite/setup.go
@@ -111,7 +111,10 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 
 		// the only unhandled case is 2 and above
 		default:
-			rule = NewSimpleRule(args[0], strings.Join(args[1:], " "))
+			rule, err = NewSimpleRule(args[0], strings.Join(args[1:], " "))
+			if err != nil {
+				return nil, err
+			}
 			rules = append(rules, rule)
 		}
 

--- a/caddyhttp/rewrite/setup.go
+++ b/caddyhttp/rewrite/setup.go
@@ -58,6 +58,7 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 		var base = "/"
 		var pattern, to string
 		var ext []string
+		var negate bool
 
 		args := c.RemainingArgs()
 
@@ -111,7 +112,11 @@ func rewriteParse(c *caddy.Controller) ([]httpserver.HandlerConfig, error) {
 
 		// the only unhandled case is 2 and above
 		default:
-			rule, err = NewSimpleRule(args[0], strings.Join(args[1:], " "))
+			if args[0] == "not" {
+				negate = true
+				args = args[1:]
+			}
+			rule, err = NewSimpleRule(args[0], strings.Join(args[1:], " "), negate)
 			if err != nil {
 				return nil, err
 			}

--- a/caddyhttp/rewrite/setup_test.go
+++ b/caddyhttp/rewrite/setup_test.go
@@ -50,8 +50,13 @@ func TestSetup(t *testing.T) {
 	}
 }
 
-func newSimpleRule(t *testing.T, from, to string) Rule {
-	rule, err := NewSimpleRule(from, to)
+// newSimpleRule is convenience test function for SimpleRule.
+func newSimpleRule(t *testing.T, from, to string, negate ...bool) Rule {
+	var n bool
+	if len(negate) > 0 {
+		n = negate[0]
+	}
+	rule, err := NewSimpleRule(from, to, n)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,6 +81,9 @@ func TestRewriteParse(t *testing.T) {
 		{`rewrite`, true, []Rule{}},
 		{`rewrite a b c`, false, []Rule{
 			newSimpleRule(t, "a", "b c"),
+		}},
+		{`rewrite not a b c`, false, []Rule{
+			newSimpleRule(t, "a", "b c", true),
 		}},
 	}
 
@@ -107,6 +115,11 @@ func TestRewriteParse(t *testing.T) {
 			if actualRule.To != expectedRule.To {
 				t.Errorf("Test %d, rule %d: Expected To=%s, got %s",
 					i, j, expectedRule.Regexp.String(), actualRule.Regexp.String())
+			}
+
+			if actualRule.Negate != expectedRule.Negate {
+				t.Errorf("Test %d, rule %d: Expected Negate=%v, got %v",
+					i, j, expectedRule.Negate, actualRule.Negate)
 			}
 		}
 	}

--- a/caddyhttp/rewrite/setup_test.go
+++ b/caddyhttp/rewrite/setup_test.go
@@ -50,6 +50,14 @@ func TestSetup(t *testing.T) {
 	}
 }
 
+func newSimpleRule(t *testing.T, from, to string) Rule {
+	rule, err := NewSimpleRule(from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rule
+}
+
 func TestRewriteParse(t *testing.T) {
 	simpleTests := []struct {
 		input     string
@@ -57,17 +65,17 @@ func TestRewriteParse(t *testing.T) {
 		expected  []Rule
 	}{
 		{`rewrite /from /to`, false, []Rule{
-			SimpleRule{From: "/from", To: "/to"},
+			newSimpleRule(t, "/from", "/to"),
 		}},
 		{`rewrite /from /to
 		  rewrite a b`, false, []Rule{
-			SimpleRule{From: "/from", To: "/to"},
-			SimpleRule{From: "a", To: "b"},
+			newSimpleRule(t, "/from", "/to"),
+			newSimpleRule(t, "a", "b"),
 		}},
 		{`rewrite a`, true, []Rule{}},
 		{`rewrite`, true, []Rule{}},
 		{`rewrite a b c`, false, []Rule{
-			SimpleRule{From: "a", To: "b c"},
+			newSimpleRule(t, "a", "b c"),
 		}},
 	}
 
@@ -88,17 +96,17 @@ func TestRewriteParse(t *testing.T) {
 		}
 
 		for j, e := range test.expected {
-			actualRule := actual[j].(SimpleRule)
-			expectedRule := e.(SimpleRule)
+			actualRule := actual[j].(*SimpleRule)
+			expectedRule := e.(*SimpleRule)
 
-			if actualRule.From != expectedRule.From {
+			if actualRule.Regexp.String() != expectedRule.Regexp.String() {
 				t.Errorf("Test %d, rule %d: Expected From=%s, got %s",
-					i, j, expectedRule.From, actualRule.From)
+					i, j, expectedRule.Regexp.String(), actualRule.Regexp.String())
 			}
 
 			if actualRule.To != expectedRule.To {
 				t.Errorf("Test %d, rule %d: Expected To=%s, got %s",
-					i, j, expectedRule.To, actualRule.To)
+					i, j, expectedRule.Regexp.String(), actualRule.Regexp.String())
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
- Adds regexp support for simple rewrite rule. 
- Also includes an optional `not` syntax to negate the regex. Negating regex can be pain for an average user and Go's regex support makes it even more difficult. I think an optional `not` syntax should not hurt.

Reason:
- The simple rewrite rule is too basic and it is rarely used.
- Many rewrite config blocks are only used for regexp.
- Users that do not need `if` conditions do not need to open to config block, hence a cleaner Caddyfile.

Outcome:

Sample wordpress config can become a one liner.
```
rewrite not ^/wp-admin {path} {path}/ /index.php?{query}
```



### 2. Please link to the relevant issues.
No issues reported. Noticed the trend from users' Caddyfiles.

### 3. Which documentation changes (if any) need to be made because of this PR?
Rewrite:
 
Indication of regexp support and an additional option `not` field.
```
rewrite [not] from to... 
```

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
