### PR TITLE
Change README to remove reference to old docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Please see our [contributing guidelines](https://github.com/mholt/caddy/blob/mas
 
 We use GitHub issues and pull requests only for discussing bug reports and the development of specific changes. We welcome all other topics on the [forum](https://caddy.community)!
 
-If you want to contribute to the documentation, please submit pull requests to [caddyserver/website](https://github.com/caddyserver/website).
+If you want to contribute to the documentation, please [submit an issue](https://github.com/mholt/caddy/issues/new) describing the change that should be made.
 
 Thanks for making Caddy -- and the Web -- better!
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Removes the reference to caddyserver/website which is no longer valid. Suggests to open an issue on this repo for now.

### 2. Please link to the relevant issues.
#1940

### 3. Which documentation changes (if any) need to be made because of this PR?
N/A

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
