### PR TITLE
Fix errors caught by fuzzing

### DIFF
--- a/caddyfile/parse.go
+++ b/caddyfile/parse.go
@@ -263,9 +263,10 @@ func (p *parser) doImport() error {
 		} else {
 			globPattern = importPattern
 		}
-		if strings.Count(globPattern, "*") > 1 {
-			// See issue #2096 - a pattern with many wildcards can hang for too long
-			return p.Errf("Glob pattern may only contain one wildcard, but have multiple: %s", globPattern)
+		if strings.Count(globPattern, "*") > 1 || strings.Count(globPattern, "?") > 1 ||
+			(strings.Contains(globPattern, "[") && strings.Contains(globPattern, "]")) {
+			// See issue #2096 - a pattern with many glob expansions can hang for too long
+			return p.Errf("Glob pattern may only contain one wildcard (*), but has others: %s", globPattern)
 		}
 		matches, err = filepath.Glob(globPattern)
 
@@ -273,8 +274,8 @@ func (p *parser) doImport() error {
 			return p.Errf("Failed to use import pattern %s: %v", importPattern, err)
 		}
 		if len(matches) == 0 {
-			if strings.Contains(globPattern, "*") {
-				log.Printf("[WARNING] No files matching import pattern: %s", importPattern)
+			if strings.ContainsAny(globPattern, "*?[]") {
+				log.Printf("[WARNING] No files matching import glob pattern: %s", importPattern)
 			} else {
 				return p.Errf("File to import not found: %s", importPattern)
 			}
@@ -444,7 +445,7 @@ func replaceEnvReferences(s, refStart, refEnd string) string {
 	index := strings.Index(s, refStart)
 	for index != -1 {
 		endIndex := strings.Index(s, refEnd)
-		if endIndex > index {
+		if endIndex > index+len(refStart) {
 			ref := s[index : endIndex+len(refEnd)]
 			s = strings.Replace(s, ref, os.Getenv(ref[len(refStart):len(ref)-len(refEnd)]), -1)
 		} else {

--- a/caddyfile/parse_test.go
+++ b/caddyfile/parse_test.go
@@ -228,6 +228,10 @@ func TestParseOneAndImport(t *testing.T) {
 		{`""`, false, []string{}, map[string]int{}},
 
 		{``, false, []string{}, map[string]int{}},
+
+		// test cases found by fuzzing!
+		{`import }{$"`, true, []string{}, map[string]int{}},
+		{`import /*/*.txt`, true, []string{}, map[string]int{}},
 	} {
 		result, err := testParseOne(test.input)
 

--- a/caddyfile/parse_test.go
+++ b/caddyfile/parse_test.go
@@ -232,6 +232,13 @@ func TestParseOneAndImport(t *testing.T) {
 		// test cases found by fuzzing!
 		{`import }{$"`, true, []string{}, map[string]int{}},
 		{`import /*/*.txt`, true, []string{}, map[string]int{}},
+		{`import /???/?*?o`, true, []string{}, map[string]int{}},
+		{`import /??`, true, []string{}, map[string]int{}},
+		{`import /[a-z]`, true, []string{}, map[string]int{}},
+		{`import {$}`, true, []string{}, map[string]int{}},
+		{`import {%}`, true, []string{}, map[string]int{}},
+		{`import {$$}`, true, []string{}, map[string]int{}},
+		{`import {%%}`, true, []string{}, map[string]int{}},
 	} {
 		result, err := testParseOne(test.input)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Fix errors caught by fuzzing.

The fix for hanging involves limiting the number of wildcards in an
import pattern to just 1. Otherwise some patterns can expand to the
entire disk.

The other fix requires that the end string for an environment variable
expansion come after the start string.


### 2. Please link to the relevant issues.

Fix #2096 

### 3. Which documentation changes (if any) need to be made because of this PR?

- The `import` directive can have only one wildcard (`*` and `?`), instead of unlimited. And no `[ ]` globbing.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

/cc @Mohammed90 