### PR TITLE
Let "transparent" subdirective imply "Forwarded" header

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -436,6 +436,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		u.upstreamHeaders.Add("Host", "{host}")
 		u.upstreamHeaders.Add("X-Real-IP", "{remote}")
 		u.upstreamHeaders.Add("X-Forwarded-Proto", "{scheme}")
+		u.upstreamHeaders.Add("Forwarded", "for={remote}; host={host}; proto={scheme}")
 	case "websocket":
 		u.upstreamHeaders.Add("Connection", "{>Connection}")
 		u.upstreamHeaders.Add("Upgrade", "{>Upgrade}")


### PR DESCRIPTION
### 1. What does this change do, exactly?
Let `transparent` subdirective imply `Forwarded` header. The `Forwarded` Header is the standardized version of `X-Forwarded-For`, `X-Forwarded-Host` and `X-Forwarded-Proto` headers. Since Caddy is now one of the most popular web servers, I editted it to follow RFC7239 standards.

Alternatively, we can choose to make Caddy always serve `Forwarded` header whenever `proxy` directive is used, just like `X-Forwarded-For` header. But I was not sure if it is acceptable to the maintainers, so I hereby just append it to existing `transparent` subdirective.

### 2. Please link to the relevant issues.
- https://github.com/mholt/caddy/pull/881
- https://github.com/mholt/caddy/blob/88edca/caddyhttp/proxy/proxy.go#L347-L355
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
- https://tools.ietf.org/html/rfc7239#section-4

### 3. Which documentation changes (if any) need to be made because of this PR?
- https://caddyserver.com/docs/proxy#presets

### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later