### PR TITLE
Issue 1926

### DIFF
--- a/caddyhttp/httpserver/https_test.go
+++ b/caddyhttp/httpserver/https_test.go
@@ -207,6 +207,7 @@ func TestApplyHeaderToRedirs(t *testing.T) {
 			allConfigs := makePlaintextRedirects([]*SiteConfig{tc.siteConfig})
 			redirConfigs := collectRedirsWithMetaTags(allConfigs)
 
+			// Check that meta-tags have been added in redirect configs before we consume them
 			if len(redirConfigs) != tc.expectedRedirsWithMetaCount {
 				t.Errorf("Expected %d redirect(s) with metadata to be present, but got %d",
 					tc.expectedRedirsWithMetaCount, len(redirConfigs))
@@ -217,6 +218,7 @@ func TestApplyHeaderToRedirs(t *testing.T) {
 			consumeRedirMetaTags(ctx, redirConfigs)
 			redirConfigs = collectRedirsWithMetaTags(allConfigs)
 
+			// Check that no meta-tags have been left in redirect configs after we consumed them
 			if len(redirConfigs) != 0 {
 				t.Errorf("Expected no redirects with metadata to be present, but got %d",
 					len(redirConfigs))
@@ -229,6 +231,7 @@ func TestApplyHeaderToRedirs(t *testing.T) {
 				}
 			}
 
+			// Find the redirect config after the meta-tags have been consumed and count the middleware
 			if len(finalRedirConfig.Middleware()) != tc.expectedRedirMiddlewareCount {
 				t.Errorf("Expected redirect to have %d middlewares, but got %d",
 					tc.expectedRedirMiddlewareCount, len(finalRedirConfig.Middleware()))

--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -65,6 +65,7 @@ func init() {
 	caddy.RegisterCaddyfileLoader("short", caddy.LoaderFunc(shortCaddyfileLoader))
 	caddy.RegisterParsingCallback(serverType, "root", hideCaddyfile)
 	caddy.RegisterParsingCallback(serverType, "tls", activateHTTPS)
+	caddy.RegisterParsingCallback(serverType, "header", applyHeaderToRedirs)
 	caddytls.RegisterConfigGetter(serverType, func(c *caddy.Controller) *caddytls.Config { return GetConfig(c).TLS })
 }
 
@@ -413,6 +414,11 @@ func (a Address) Key() string {
 		res += a.Host
 	}
 	if a.Port != "" {
+		if a.Original == "" {
+			// This shouldn't really happen but its useful in tests when you supply an
+			// Address without the Original field and call this method
+			return ""
+		}
 		if strings.HasPrefix(a.Original[len(res):], ":"+a.Port) {
 			// insert port only if the original has its own explicit port
 			res += ":" + a.Port

--- a/caddyhttp/httpserver/siteconfig.go
+++ b/caddyhttp/httpserver/siteconfig.go
@@ -83,7 +83,21 @@ type SiteConfig struct {
 	// If true, any requests not matching other site definitions
 	// may be served by this site.
 	FallbackSite bool
+
+	// meta represents a map of private meta tag symbols we can use to
+	// mark this site config with additional information. We try to keep this
+	// map private and optional
+	meta map[siteConfigMetaTag]string
 }
+
+type siteConfigMetaTag int
+
+const (
+	// Represents a reference to the site config key for the
+	// redirect from http to https server. This is used to apply
+	// any additional header directives on top of the redirect server
+	redirectToHttpsRef siteConfigMetaTag = iota
+)
 
 // Timeouts specify various timeouts for a server to use.
 // If the assocated bool field is true, then the duration


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
It fixes #1926 by registering a new `RegisterParsingCallback` for the `header` directive that will prepend any header middleware to the Redir Configs that are created on the automatic http to https generation.

### 2. Please link to the relevant issues.
#1926

### 3. Which documentation changes (if any) need to be made because of this PR?
We may need to mention that the http to https will honor only the header directives

### 4. Checklist

- [x ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
