### PR TITLE
Regex rewriting of upstream/downstream headers in proxy

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -92,8 +92,10 @@ type UpstreamHost struct {
 	// This is an int32 so that we can use atomic operations to do concurrent
 	// reads & writes to this value.  The default value of 0 indicates that it
 	// is healthy and any non-zero value indicates unhealthy.
-	Unhealthy         int32
-	HealthCheckResult atomic.Value
+	Unhealthy                    int32
+	HealthCheckResult            atomic.Value
+	UpstreamHeaderReplacements   headerReplacements
+	DownstreamHeaderReplacements headerReplacements
 }
 
 // Down checks whether the upstream host is down or not.
@@ -220,7 +222,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		// set headers for request going upstream
 		if host.UpstreamHeaders != nil {
 			// modify headers for request that will be sent to the upstream host
-			mutateHeadersByRules(outreq.Header, host.UpstreamHeaders, replacer)
+			mutateHeadersByRules(outreq.Header, host.UpstreamHeaders, replacer, host.UpstreamHeaderReplacements)
 			if hostHeaders, ok := outreq.Header["Host"]; ok && len(hostHeaders) > 0 {
 				outreq.Host = hostHeaders[len(hostHeaders)-1]
 			}
@@ -230,7 +232,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		// headers coming back downstream
 		var downHeaderUpdateFn respUpdateFn
 		if host.DownstreamHeaders != nil {
-			downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownstreamHeaders, replacer)
+			downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownstreamHeaders, replacer, host.UpstreamHeaderReplacements)
 		}
 
 		// Before we retry the request we have to make sure
@@ -376,13 +378,13 @@ func createUpstreamRequest(rw http.ResponseWriter, r *http.Request) (*http.Reque
 	return outreq, cancel
 }
 
-func createRespHeaderUpdateFn(rules http.Header, replacer httpserver.Replacer) respUpdateFn {
+func createRespHeaderUpdateFn(rules http.Header, replacer httpserver.Replacer, replacements headerReplacements) respUpdateFn {
 	return func(resp *http.Response) {
-		mutateHeadersByRules(resp.Header, rules, replacer)
+		mutateHeadersByRules(resp.Header, rules, replacer, replacements)
 	}
 }
 
-func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) {
+func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer, replacements headerReplacements) {
 	for ruleField, ruleValues := range rules {
 		if strings.HasPrefix(ruleField, "+") {
 			for _, ruleValue := range ruleValues {
@@ -397,6 +399,17 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer) 
 			replacement := repl.Replace(ruleValues[len(ruleValues)-1])
 			if len(replacement) > 0 {
 				headers.Set(ruleField, replacement)
+			}
+		}
+	}
+
+	for ruleField, ruleValues := range replacements {
+		for _, ruleValue := range ruleValues {
+			replacement := repl.Replace(ruleValue.to)
+			original := headers.Get(ruleField)
+			if len(replacement) > 0 && len(original) > 0 {
+				replaced := ruleValue.regexp.ReplaceAllString(original, replacement)
+				headers.Set(ruleField, replaced)
 			}
 		}
 	}

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -405,9 +405,11 @@ func mutateHeadersByRules(headers, rules http.Header, repl httpserver.Replacer, 
 
 	for ruleField, ruleValues := range replacements {
 		for _, ruleValue := range ruleValues {
+			// Replace variables in replacement string
 			replacement := repl.Replace(ruleValue.to)
 			original := headers.Get(ruleField)
 			if len(replacement) > 0 && len(original) > 0 {
+				// Replace matches in original string with replacement string
 				replaced := ruleValue.regexp.ReplaceAllString(original, replacement)
 				headers.Set(ruleField, replaced)
 			}

--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -232,7 +232,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		// headers coming back downstream
 		var downHeaderUpdateFn respUpdateFn
 		if host.DownstreamHeaders != nil {
-			downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownstreamHeaders, replacer, host.UpstreamHeaderReplacements)
+			downHeaderUpdateFn = createRespHeaderUpdateFn(host.DownstreamHeaders, replacer, host.DownstreamHeaderReplacements)
 		}
 
 		// Before we retry the request we have to make sure

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -467,7 +467,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 			}
 			u.upstreamHeaderReplacements.Add(header, headerReplacement{r, replaced})
 		} else {
-			if !c.Args(&header, &value) {
+			if len(value) == 0 {
 				// When removing a header, the value can be optional.
 				if !strings.HasPrefix(header, "-") {
 					return c.ArgErr()
@@ -486,9 +486,9 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 			if err != nil {
 				return c.ArgErr()
 			}
-			u.upstreamHeaderReplacements.Add(header, headerReplacement{r, replaced})
+			u.downstreamHeaderReplacements.Add(header, headerReplacement{r, replaced})
 		} else {
-			if !c.Args(&header, &value) {
+			if len(value) == 0 {
 				// When removing a header, the value can be optional.
 				if !strings.HasPrefix(header, "-") {
 					return c.ArgErr()

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -81,11 +81,14 @@ type srvResolver interface {
 	LookupSRV(context.Context, string, string, string) (string, []*net.SRV, error)
 }
 
+// headerReplacement stores a compiled regex matcher and a string replacer, for replacement rules
 type headerReplacement struct {
 	regexp *regexp.Regexp
 	to     string
 }
 
+// headerReplacements stores a mapping of canonical MIME header to headerReplacement
+// Implements a subset of http.Header functions, to allow convenient addition and deletion of rules
 type headerReplacements map[string][]headerReplacement
 
 func (h headerReplacements) Add(key string, value headerReplacement) {

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -23,8 +23,10 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -65,16 +67,34 @@ type staticUpstream struct {
 		Port          string
 		ContentString string
 	}
-	WithoutPathPrefix  string
-	IgnoredSubPaths    []string
-	insecureSkipVerify bool
-	MaxFails           int32
-	resolver           srvResolver
-	CaCertPool         *x509.CertPool
+	WithoutPathPrefix            string
+	IgnoredSubPaths              []string
+	insecureSkipVerify           bool
+	MaxFails                     int32
+	resolver                     srvResolver
+	CaCertPool                   *x509.CertPool
+	upstreamHeaderReplacements   headerReplacements
+	downstreamHeaderReplacements headerReplacements
 }
 
 type srvResolver interface {
 	LookupSRV(context.Context, string, string, string) (string, []*net.SRV, error)
+}
+
+type headerReplacement struct {
+	regexp *regexp.Regexp
+	to     string
+}
+
+type headerReplacements map[string][]headerReplacement
+
+func (h headerReplacements) Add(key string, value headerReplacement) {
+	key = textproto.CanonicalMIMEHeaderKey(key)
+	h[key] = append(h[key], value)
+}
+
+func (h headerReplacements) Del(key string) {
+	delete(h, textproto.CanonicalMIMEHeaderKey(key))
 }
 
 // NewStaticUpstreams parses the configuration input and sets up
@@ -86,18 +106,20 @@ func NewStaticUpstreams(c caddyfile.Dispenser, host string) ([]Upstream, error) 
 	for c.Next() {
 
 		upstream := &staticUpstream{
-			from:              "",
-			stop:              make(chan struct{}),
-			upstreamHeaders:   make(http.Header),
-			downstreamHeaders: make(http.Header),
-			Hosts:             nil,
-			Policy:            &Random{},
-			MaxFails:          1,
-			TryInterval:       250 * time.Millisecond,
-			MaxConns:          0,
-			KeepAlive:         http.DefaultMaxIdleConnsPerHost,
-			Timeout:           30 * time.Second,
-			resolver:          net.DefaultResolver,
+			from:                         "",
+			stop:                         make(chan struct{}),
+			upstreamHeaders:              make(http.Header),
+			downstreamHeaders:            make(http.Header),
+			Hosts:                        nil,
+			Policy:                       &Random{},
+			MaxFails:                     1,
+			TryInterval:                  250 * time.Millisecond,
+			MaxConns:                     0,
+			KeepAlive:                    http.DefaultMaxIdleConnsPerHost,
+			Timeout:                      30 * time.Second,
+			resolver:                     net.DefaultResolver,
+			upstreamHeaderReplacements:   make(headerReplacements),
+			downstreamHeaderReplacements: make(headerReplacements),
 		}
 
 		if !c.Args(&upstream.from) {
@@ -220,9 +242,11 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 				return false
 			}
 		}(u),
-		WithoutPathPrefix: u.WithoutPathPrefix,
-		MaxConns:          u.MaxConns,
-		HealthCheckResult: atomic.Value{},
+		WithoutPathPrefix:            u.WithoutPathPrefix,
+		MaxConns:                     u.MaxConns,
+		HealthCheckResult:            atomic.Value{},
+		UpstreamHeaderReplacements:   u.upstreamHeaderReplacements,
+		DownstreamHeaderReplacements: u.downstreamHeaderReplacements,
 	}
 
 	baseURL, err := url.Parse(uh.Name)
@@ -431,23 +455,47 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		}
 		u.HealthCheck.ContentString = c.Val()
 	case "header_upstream":
-		var header, value string
-		if !c.Args(&header, &value) {
-			// When removing a header, the value can be optional.
-			if !strings.HasPrefix(header, "-") {
+		var header, value, replaced string
+		if c.Args(&header, &value, &replaced) {
+			// Don't allow - or + in replacements
+			if strings.HasPrefix(header, "-") || strings.HasPrefix(header, "+") {
 				return c.ArgErr()
 			}
+			r, err := regexp.Compile(value)
+			if err != nil {
+				return c.ArgErr()
+			}
+			u.upstreamHeaderReplacements.Add(header, headerReplacement{r, replaced})
+		} else {
+			if !c.Args(&header, &value) {
+				// When removing a header, the value can be optional.
+				if !strings.HasPrefix(header, "-") {
+					return c.ArgErr()
+				}
+			}
+			u.upstreamHeaders.Add(header, value)
 		}
-		u.upstreamHeaders.Add(header, value)
 	case "header_downstream":
-		var header, value string
-		if !c.Args(&header, &value) {
-			// When removing a header, the value can be optional.
-			if !strings.HasPrefix(header, "-") {
+		var header, value, replaced string
+		if c.Args(&header, &value, &replaced) {
+			// Don't allow - or + in replacements
+			if strings.HasPrefix(header, "-") || strings.HasPrefix(header, "+") {
 				return c.ArgErr()
 			}
+			r, err := regexp.Compile(value)
+			if err != nil {
+				return c.ArgErr()
+			}
+			u.upstreamHeaderReplacements.Add(header, headerReplacement{r, replaced})
+		} else {
+			if !c.Args(&header, &value) {
+				// When removing a header, the value can be optional.
+				if !strings.HasPrefix(header, "-") {
+					return c.ArgErr()
+				}
+			}
+			u.downstreamHeaders.Add(header, value)
 		}
-		u.downstreamHeaders.Add(header, value)
 	case "transparent":
 		// Note: X-Forwarded-For header is always being appended for proxy connections
 		// See implementation of createUpstreamRequest in proxy.go

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -386,6 +386,61 @@ func TestParseBlockTransparent(t *testing.T) {
 	}
 }
 
+func TestParseBlockRegex(t *testing.T) {
+	// tests for regex replacement of headers
+	r, _ := http.NewRequest("GET", "/", nil)
+	tests := []struct {
+		config string
+	}{
+		// Test #1: transparent preset with replacement of Host
+		{"proxy / localhost:8080 {\n transparent \nheader_upstream Host (.*) NewHost \n}"},
+
+		// Test #2: transparent preset with replacement of another param
+		{"proxy / localhost:8080 {\n transparent \nheader_upstream X-Test Tester \nheader_upstream X-Test Test Host \n}"},
+
+		// Test #3: transparent preset with multiple params
+		{"proxy / localhost:8080 {\n transparent \nheader_upstream X-Test Tester \nheader_upstream X-Test Test Host \nheader_upstream X-Test er ing \n}"},
+	}
+
+	for i, test := range tests {
+		upstreams, err := NewStaticUpstreams(caddyfile.NewDispenser("Testfile", strings.NewReader(test.config)), "")
+		if err != nil {
+			t.Errorf("Expected no error. Got: %s", err.Error())
+		}
+		for _, upstream := range upstreams {
+			headers := upstream.Select(r).UpstreamHeaderReplacements
+
+			switch i {
+			case 0:
+				if host, ok := headers["Host"]; !ok || host[0].to != "NewHost" {
+					t.Errorf("Test %d: Incorrect Host replacement: %v", i+1, host[0])
+				}
+			case 1:
+				if v, ok := headers["X-Test"]; !ok {
+					t.Errorf("Test %d: Incorrect X-Test replacement", i+1)
+				} else {
+					if v[0].to != "Host" {
+						t.Errorf("Test %d: Incorrect X-Test replacement: %v", i+1, v[0])
+					}
+				}
+			case 2:
+				if v, ok := headers["X-Test"]; !ok {
+					t.Errorf("Test %d: Incorrect X-Test replacement", i+1)
+				} else {
+					if v[0].to != "Host" {
+						t.Errorf("Test %d: Incorrect X-Test replacement: %v", i+1, v[0])
+					}
+					if v[1].to != "ing" {
+						t.Errorf("Test %d: Incorrect X-Test replacement: %v", i+1, v[1])
+					}
+				}
+			default:
+				t.Error("Testing error")
+			}
+		}
+	}
+}
+
 func TestHealthSetUp(t *testing.T) {
 	// tests for insecure skip verify
 	tests := []struct {


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Adds an extra parameter to header_upstream and header_downstream that allows regex-based replacement of headers. They are in the format `header_upstream [header] [regex] [replacement]`

This allows unwanted values from the server and client (e.g. redirects, cookies) to be modified by Caddy. This therefore allows search (and mobile) to be fixed on [wikipedia.matt.life](https://wikipedia.matt.life), and [wikimirror](https://github.com/CristianCantoro/wikimirror).

### 2. Please link to the relevant issues.
#442 - An existing (but not merged) implementation of Location rewriting
#606 - Nginx proxy_redirect feature request
This change may be obsoleted by #1639, the proxy middleware rewrite.

### 3. Which documentation changes (if any) need to be made because of this PR?
Add the extra parameter to header_upstream and header_downstream, and describe it. Give examples of it being used to change the Location header, possibly referencing proxy_redirect.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
