### PR TITLE
Fixes #2114 by allowing redirects from staticfiles to pass through templates

### DIFF
--- a/caddyhttp/templates/templates.go
+++ b/caddyhttp/templates/templates.go
@@ -70,6 +70,9 @@ func (t Templates) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		// pass request up the chain to let another middleware provide us the template
 		code, err := t.Next.ServeHTTP(rb, r)
 		if !rb.Buffered() || code >= 300 || err != nil {
+			if code >= 300 && code < 400 {
+				continue
+			}
 			return code, err
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
It allows HTTP status codes in the 300s created by staticfiles (and other middlewares) to pass through the templates middleware untouched. 

### 2. Please link to the relevant issues.
This should close #2114 

### 3. Which documentation changes (if any) need to be made because of this PR?
None. It should restore expected behavior. 