### PR TITLE
instance restart (reload) event

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -263,9 +263,10 @@ type EventName string
 // Define names for the various events
 const (
 	StartupEvent         EventName = "startup"
-	ShutdownEvent        EventName = "shutdown"
-	CertRenewEvent       EventName = "certrenew"
-	InstanceStartupEvent EventName = "instancestartup"
+	ShutdownEvent                  = "shutdown"
+	CertRenewEvent                 = "certrenew"
+	InstanceStartupEvent           = "instancestartup"
+	InstanceRestartEvent           = "instancerestart"
 )
 
 // EventHook is a type which holds information about a startup hook plugin.

--- a/sigtrap_posix.go
+++ b/sigtrap_posix.go
@@ -90,6 +90,7 @@ func trapSignalsPosix() {
 				purgeEventHooks()
 
 				// Kick off the restart; our work is done
+				EmitEvent(InstanceRestartEvent, nil)
 				_, err = inst.Restart(caddyfileToUse)
 				if err != nil {
 					restoreEventHooks(oldEventHooks)


### PR DESCRIPTION
### 1. What does this change do, exactly?
New event type called *restart* added which is emitted at server restart (at SIGUSR1)


### 2. Please link to the relevant issues.
We are using caddy as embedded server and we need to make preparations before restarts


### 3. Which documentation changes (if any) need to be made because of this PR?
Nothing

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
