### PR TITLE
Fix 502 errors for requests without headers

### DIFF
--- a/caddyhttp/proxy/policy.go
+++ b/caddyhttp/proxy/policy.go
@@ -190,7 +190,8 @@ func (r *Header) Select(pool HostPool, request *http.Request) *UpstreamHost {
 	}
 	val := request.Header.Get(r.Name)
 	if val == "" {
-		return nil
+		// fallback to RoundRobin policy in case no Header in request
+		return (&RoundRobin{}).Select(pool, request)
 	}
 	return hostByHashing(pool, val)
 }

--- a/caddyhttp/proxy/policy.go
+++ b/caddyhttp/proxy/policy.go
@@ -183,6 +183,8 @@ type Header struct {
 	Name string
 }
 
+var roundRobinPolicier RoundRobin
+
 // Select selects the host based on hashing the header value
 func (r *Header) Select(pool HostPool, request *http.Request) *UpstreamHost {
 	if r.Name == "" {
@@ -191,7 +193,7 @@ func (r *Header) Select(pool HostPool, request *http.Request) *UpstreamHost {
 	val := request.Header.Get(r.Name)
 	if val == "" {
 		// fallback to RoundRobin policy in case no Header in request
-		return (&RoundRobin{}).Select(pool, request)
+		return roundRobinPolicier.Select(pool, request)
 	}
 	return hostByHashing(pool, val)
 }

--- a/caddyhttp/proxy/policy_test.go
+++ b/caddyhttp/proxy/policy_test.go
@@ -331,7 +331,10 @@ func TestHeaderPolicy(t *testing.T) {
 		{"empty config+header+value", &Header{""}, "Affinity", "somevalue", true, 0},
 		{"empty config+header", &Header{""}, "Affinity", "", true, 0},
 
-		{"no header(fallback to another policy)", &Header{"Affinity"}, "", "", false, 1},
+		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 1},
+		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 2},
+		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 0},
+
 		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue", false, 1},
 		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue2", false, 0},
 		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue3", false, 2},

--- a/caddyhttp/proxy/policy_test.go
+++ b/caddyhttp/proxy/policy_test.go
@@ -320,21 +320,22 @@ func TestUriPolicy(t *testing.T) {
 func TestHeaderPolicy(t *testing.T) {
 	pool := testPool()
 	tests := []struct {
+		Name               string
 		Policy             *Header
 		RequestHeaderName  string
 		RequestHeaderValue string
 		NilHost            bool
 		HostIndex          int
 	}{
-		{&Header{""}, "", "", true, 0},
-		{&Header{""}, "Affinity", "somevalue", true, 0},
-		{&Header{""}, "Affinity", "", true, 0},
+		{"empty config", &Header{""}, "", "", true, 0},
+		{"empty config+header+value", &Header{""}, "Affinity", "somevalue", true, 0},
+		{"empty config+header", &Header{""}, "Affinity", "", true, 0},
 
-		{&Header{"Affinity"}, "", "", true, 0},
-		{&Header{"Affinity"}, "Affinity", "somevalue", false, 1},
-		{&Header{"Affinity"}, "Affinity", "somevalue2", false, 0},
-		{&Header{"Affinity"}, "Affinity", "somevalue3", false, 2},
-		{&Header{"Affinity"}, "Affinity", "", true, 0},
+		{"no header(fallback to another policy)", &Header{"Affinity"}, "", "", false, 1},
+		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue", false, 1},
+		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue2", false, 0},
+		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue3", false, 2},
+		{"hash route with empty value", &Header{"Affinity"}, "Affinity", "", false, 1},
 	}
 
 	for idx, test := range tests {


### PR DESCRIPTION
### 1. What does this change do, exactly?
This change fixes 502 errors for multiple backends when header policy is used and there is no such header in request

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/2126

### 3. Which documentation changes (if any) need to be made because of this PR?
-

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
