### PR TITLE
http.browse: Set page background color (fixes #2214)

### DIFF
--- a/caddyhttp/browse/setup.go
+++ b/caddyhttp/browse/setup.go
@@ -125,6 +125,7 @@ const defaultTemplate = `<!DOCTYPE html>
 body {
 	font-family: sans-serif;
 	text-rendering: optimizespeed;
+	background-color: #ffffff;
 }
 
 a {


### PR DESCRIPTION
Fixes #2214

Browser defaults vary and this way we prevent mix-ups from setting only some colors.

Thanks for your consideration.

Best, Sebastian