### PR TITLE
rlimit_posix.go: Use backticks for shell code

### DIFF
--- a/rlimit_posix.go
+++ b/rlimit_posix.go
@@ -31,7 +31,7 @@ func checkFdlimit() {
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimit)
 	if err == nil && rlimit.Cur < min {
 		fmt.Printf("WARNING: File descriptor limit %d is too low for production servers. "+
-			"At least %d is recommended. Fix with \"ulimit -n %d\".\n", rlimit.Cur, min, min)
+			"At least %d is recommended. Fix with `ulimit -n %d`.\n", rlimit.Cur, min, min)
 	}
 
 }


### PR DESCRIPTION
### 1. What does this change do, exactly?

Minor fix to use backticks for something that should be executed on shell.

### 2. Please link to the relevant issues.

n/a

### 3. Which documentation changes (if any) need to be made because of this PR?

n/a

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change -- n/a
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code -- n/a
- [ ] I am willing to help maintain this change if there are issues with it later -- n/a
