### PR TITLE
Go version bump for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
 
 install:
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.windows-amd64.zip
-  - 7z x go1.9.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.10.windows-amd64.zip
+  - 7z x go1.10.windows-amd64.zip -y -oC:\ > NUL
   - set PATH=%GOPATH%\bin;%PATH%
   - go version
   - go env


### PR DESCRIPTION
### 1. What does this change do, exactly?
This PR is updating teh Go version to the latest stable version for the AppVeyor build.

### 2. Please link to the relevant issues.
This is related to PR #2217 where the AppVeyor build fails because of old Go version.

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
