### PR TITLE
Don't ignore the caddyfile/ package (#2237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ access.log
 
 /*.conf
 Caddyfile
+!caddyfile/
 
 og_static/
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Unignores the `caddyfile/` package, which causes problems on systems with case-insensitive filesystems (such as macOS).

### 2. Please link to the relevant issues.
#2237 

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
