### PR TITLE
Register Web Key Directory directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -657,6 +657,7 @@ var directives = []string{
 	"grpc",      // github.com/pieterlouw/caddy-grpc
 	"gopkg",     // github.com/zikes/gopkg
 	"restic",    // github.com/restic/caddy
+	"wkd",       // github.com/emersion/caddy-wkd
 }
 
 const (


### PR DESCRIPTION
This adds a little [WKD](https://tools.ietf.org/html/draft-koch-openpgp-webkey-service-06) plugin. WKD is a simple PGP public key discovery system.

https://github.com/emersion/caddy-wkd