### PR TITLE
Fix for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - quic.clemente.io
 
 go:
-  - 1.x
+  - "1.10"
   - tip
 
 matrix:


### PR DESCRIPTION
Fix golang version, because build is failing with golang 1.11beta2