### PR TITLE
Adding {when_unix_ms} requests placeholder (unix timestamp with a mil…

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -372,6 +372,8 @@ func (r *replacer) getSubstitution(key string) string {
 		return now().UTC().Format(timeFormatISOUTC)
 	case "{when_unix}":
 		return strconv.FormatInt(now().Unix(), 10)
+	case "{when_unix_ms}":
+		return strconv.FormatInt(nanoToMilliseconds(now().UnixNano()), 10)
 	case "{file}":
 		_, file := path.Split(r.request.URL.Path)
 		return file
@@ -521,9 +523,13 @@ func (r *replacer) getSubstitution(key string) string {
 	return r.emptyValue
 }
 
+func nanoToMilliseconds(d int64) int64 {
+	return d / 1e6
+}
+
 // convertToMilliseconds returns the number of milliseconds in the given duration
 func convertToMilliseconds(d time.Duration) int64 {
-	return d.Nanoseconds() / 1e6
+	return nanoToMilliseconds(d.Nanoseconds())
 }
 
 // Set sets key to value in the r.customReplacements map.

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -86,7 +86,7 @@ func TestReplace(t *testing.T) {
 
 	old := now
 	now = func() time.Time {
-		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
+		return time.Date(2006, 1, 2, 15, 4, 5, 99999999, time.FixedZone("hardcoded", -7))
 	}
 	defer func() {
 		now = old
@@ -102,6 +102,7 @@ func TestReplace(t *testing.T) {
 		{"{when}", "02/Jan/2006:15:04:05 +0000"},
 		{"{when_iso}", "2006-01-02T15:04:12Z"},
 		{"{when_unix}", "1136214252"},
+		{"{when_unix_ms}", "1136214252099"},
 		{"The Custom header is {>Custom}.", "The Custom header is foobarbaz."},
 		{"The CustomAdd header is {>CustomAdd}.", "The CustomAdd header is caddy."},
 		{"The Custom response header is {<Custom}.", "The Custom response header is CustomResponseHeader."},


### PR DESCRIPTION
…liseconds precision)

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Added {when_unix_ms} placeholder for requests. It's like {when_unix}, but with milliseconds precision.

### 2. Please link to the relevant issues.
None

### 3. Which documentation changes (if any) need to be made because of this PR?
Add description of new placeholder to the 'placeholders/requests' section.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
