### PR TITLE
Add fastcgi timeouts

### DIFF
--- a/caddyhttp/fastcgi/setup.go
+++ b/caddyhttp/fastcgi/setup.go
@@ -27,6 +27,8 @@ import (
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
+var defaultTimeout = 60 * time.Second
+
 func init() {
 	caddy.RegisterPlugin("fastcgi", caddy.Plugin{
 		ServerType: "http",
@@ -76,8 +78,11 @@ func fastcgiParse(c *caddy.Controller) ([]Rule, error) {
 		}
 
 		rule := Rule{
-			Root: absRoot,
-			Path: args[0],
+			Root:           absRoot,
+			Path:           args[0],
+			ConnectTimeout: defaultTimeout,
+			ReadTimeout:    defaultTimeout,
+			SendTimeout:    defaultTimeout,
 		}
 
 		upstreams := []string{args[1]}


### PR DESCRIPTION
### 1. What does this change do, exactly?
Add default timeouts for fastCGI
Timeouts still can be disabled if you explicitly set timeout to 0.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/2113

### 3. Which documentation changes (if any) need to be made because of this PR?
There should be documentation changes at this link https://caddyserver.com/docs/fastcgi, but i don't know how to update documentation.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
