### PR TITLE
Bump required version of golang to 1.10 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Caddy binaries have no dependencies and are available for every platform. Get Ca
 
 ## Build
 
-To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.9 or newer). Follow these instruction for fast building:
+To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.10 or newer). Follow these instruction for fast building:
 
 - Get the source with `go get github.com/mholt/caddy/caddy` and then run `go get github.com/caddyserver/builds`
 - Now `cd $GOPATH/src/github.com/mholt/caddy/caddy` and run `go run build.go`


### PR DESCRIPTION
Adding TLS client cert placeholders #2217 uses features of go
v1.10.  Update README requirements accordingly.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
README documentation update

### 2. Please link to the relevant issues.
Issue not raised.  Simply ran into problem getting sources per instructions with the version of go mentioned

### 3. Which documentation changes (if any) need to be made because of this PR?
Just the README file

### 4. Checklist
n/a
- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
