### PR TITLE
Update paths for filebrowser plugins

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -645,12 +645,12 @@ var directives = []string{
 	"fastcgi",
 	"cgi", // github.com/jung-kurt/caddy-cgi
 	"websocket",
-	"filemanager", // github.com/filebrowser/filebrowser/caddy/filemanager
+	"filemanager", // github.com/filebrowser/caddy/filemanager
 	"webdav",      // github.com/hacdias/caddy-webdav
 	"markdown",
 	"browse",
-	"jekyll",    // github.com/filebrowser/filebrowser/caddy/jekyll
-	"hugo",      // github.com/filebrowser/filebrowser/caddy/hugo
+	"jekyll",    // github.com/filebrowser/caddy/jekyll
+	"hugo",      // github.com/filebrowser/caddy/hugo
 	"mailout",   // github.com/SchumacherFM/mailout
 	"awses",     // github.com/miquella/caddy-awses
 	"awslambda", // github.com/coopernurse/caddy-awslambda


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Filebrowser changed their github structure, this just updates the paths in plugins.go

### 2. Please link to the relevant issues.


### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [ X] I have written tests and verified that they fail without my change
- [X ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
