### PR TITLE
Cert issuer and subject string conversion fix.

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -461,7 +461,7 @@ func (r *replacer) getSubstitution(key string) string {
 	case "{tls_client_i_dn}":
 		cert := r.getPeerCert()
 		if cert != nil {
-			return cert.Issuer.String()
+			return string(cert.RawIssuer)
 		}
 		return r.emptyValue
 	case "{tls_client_raw_cert}":
@@ -473,7 +473,7 @@ func (r *replacer) getSubstitution(key string) string {
 	case "{tls_client_s_dn}":
 		cert := r.getPeerCert()
 		if cert != nil {
-			return cert.Subject.String()
+			return string(cert.RawSubject)
 		}
 		return r.emptyValue
 	case "{tls_client_serial}":


### PR DESCRIPTION
 The original code causes compilation failures:

```
server1|vagrant$ go get github.com/mholt/caddy/caddy
# github.com/mholt/caddy/caddyhttp/httpserver
src/github.com/mholt/caddy/caddyhttp/httpserver/replacer.go:464:22: cert.Issuer.String undefined (type pkix.Name has no field or method String)
src/github.com/mholt/caddy/caddyhttp/httpserver/replacer.go:476:23: cert.Subject.String undefined (type pkix.Name has no field or method String)

```

Used RawIssuer/RawSubject instead of missing .String() method.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Fixes a compilation error due to missing method call (.String()). This method is not in the "pkix.Name" structure.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/2275#issue-353008788

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
