### PR TITLE
fix environment variable substitution after Go template

### DIFF
--- a/caddyfile/parse.go
+++ b/caddyfile/parse.go
@@ -424,7 +424,12 @@ func replaceEnvVars(s string) string {
 func replaceEnvReferences(s, refStart, refEnd string) string {
 	index := strings.Index(s, refStart)
 	for index != -1 {
-		endIndex := strings.Index(s, refEnd)
+		endIndex := strings.Index(s[index:], refEnd)
+		if endIndex == -1 {
+			break
+		}
+
+		endIndex += index
 		if endIndex > index+len(refStart) {
 			ref := s[index : endIndex+len(refEnd)]
 			s = strings.Replace(s, ref, os.Getenv(ref[len(refStart):len(ref)-len(refEnd)]), -1)

--- a/caddyfile/parse_test.go
+++ b/caddyfile/parse_test.go
@@ -518,6 +518,13 @@ func TestEnvironmentReplacement(t *testing.T) {
 	if actual, expected := blocks[0].Tokens["dir1"][1].Text, "Test foobar test"; expected != actual {
 		t.Errorf("Expected argument to be '%s' but was '%s'", expected, actual)
 	}
+
+	// after end token
+	p = testParser(":1234\nanswer \"{{ .Name }} {$FOOBAR}\"")
+	blocks, _ = p.parseAll()
+	if actual, expected := blocks[0].Tokens["answer"][1].Text, "{{ .Name }} foobar"; expected != actual {
+		t.Errorf("Expected argument to be '%s' but was '%s'", expected, actual)
+	}
 }
 
 func testParser(input string) parser {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Handles variable replacement correctly when the substitution string starts after the an occurrence of its end token. e.g.:

```
template IN ANY {
  match "^([a-zA-Z0-9]*\.){1,2}{$CLUSTER_DOMAIN}\.$"
  answer "{{ .Name }} 60 IN CNAME loadbalancer.default.svc.{$CLUSTER_DOMAIN}"
  upstream
  fallthrough
}
```

### 2. Please link to the relevant issues.
https://github.com/coredns/coredns/issues/2153

### 3. Which documentation changes (if any) need to be made because of this PR?
None

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
