### PR TITLE
Set `DualStack` to `true` in the reverse proxy default dialer

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -48,6 +48,7 @@ var (
 	defaultDialer = &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
+		DualStack: true,
 	}
 
 	bufferPool = sync.Pool{New: createBuffer}


### PR DESCRIPTION
### 1. What does this change do, exactly?

This PR just sets the `DualStack` field in the `defaultDialer` instance in the `reverseproxy.go` file to `true`.

The reason for this change is because for new connections to Caddy response times can take over 1 second with it set to `false`.

This only became a problem since Caddy v0.10.13 when the new custom default dialer was put in place in the `reverseproxy.go` file. Before that the reverse proxy code used the default dialer in the Go standard library which always has `DualStack` set to `true`. So really this change is just bringing the code more into line with how it was behaving before.

When `DualStack` is set to `true` the response times for new connections come down from over 1 second to ~300ms, which relates to the `net.Dialer`'s `FallbackDelay` field. This is always 300ms because when it's not set, as it isn't in the Go standard library, it defaults to 300ms (incidentally this might be a good field to make configurable?).

I can't see any reason for `DualStack` not be be set to `true` by default, especially given that Caddy was using it in the Go standard library's default dialer all the way up to Caddy v 0.10.12 anyway, but if there is a specific reason this wasn't set please let me know.

### 2. Please link to the relevant issues.

I haven't got any specific issues created, but you can find a forum thread here: https://caddy.community/t/debugging-long-response-times/4499

### 3. Which documentation changes (if any) need to be made because of this PR?

None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
