### PR TITLE
Add a new `fallback_delay` sub-directive to the `proxy` directive

### DIFF
--- a/caddyhttp/proxy/proxy.go
+++ b/caddyhttp/proxy/proxy.go
@@ -47,6 +47,12 @@ type Upstream interface {
 	// Checks if subpath is not an ignored path
 	AllowedPath(string) bool
 
+	// Gets the duration of the headstart the first
+	// connection is given in the Go standard library's
+	// implementation of "Happy Eyeballs" when DualStack
+	// is enabled in net.Dialer.
+	GetFallbackDelay() time.Duration
+
 	// Gets how long to try selecting upstream hosts
 	// in the case of cascading failures.
 	GetTryDuration() time.Duration
@@ -195,6 +201,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 					host.WithoutPathPrefix,
 					http.DefaultMaxIdleConnsPerHost,
 					upstream.GetTimeout(),
+					upstream.GetFallbackDelay(),
 				)
 			}
 

--- a/caddyhttp/proxy/proxy_test.go
+++ b/caddyhttp/proxy/proxy_test.go
@@ -122,7 +122,7 @@ func TestReverseProxy(t *testing.T) {
 	// set up proxy
 	p := &Proxy{
 		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
-		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second)},
+		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)},
 	}
 
 	// Create the fake request body.
@@ -202,7 +202,7 @@ func TestReverseProxyInsecureSkipVerify(t *testing.T) {
 	// set up proxy
 	p := &Proxy{
 		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
-		Upstreams: []Upstream{newFakeUpstream(backend.URL, true, 30*time.Second)},
+		Upstreams: []Upstream{newFakeUpstream(backend.URL, true, 30*time.Second, 300*time.Millisecond)},
 	}
 
 	// create request and response recorder
@@ -289,6 +289,7 @@ func TestReverseProxyMaxConnLimit(t *testing.T) {
 
 func TestReverseProxyTimeout(t *testing.T) {
 	timeout := 2 * time.Second
+	fallbackDelay := 300 * time.Millisecond
 	errorMargin := 100 * time.Millisecond
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
@@ -296,7 +297,7 @@ func TestReverseProxyTimeout(t *testing.T) {
 	// set up proxy
 	p := &Proxy{
 		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
-		Upstreams: []Upstream{newFakeUpstream("https://8.8.8.8", true, timeout)},
+		Upstreams: []Upstream{newFakeUpstream("https://8.8.8.8", true, timeout, fallbackDelay)},
 	}
 
 	// create request and response recorder
@@ -711,7 +712,7 @@ func TestUpstreamHeadersUpdate(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	upstream := newFakeUpstream(backend.URL, false, 30*time.Second)
+	upstream := newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)
 	upstream.host.UpstreamHeaders = http.Header{
 		"Connection": {"{>Connection}"},
 		"Upgrade":    {"{>Upgrade}"},
@@ -778,7 +779,7 @@ func TestDownstreamHeadersUpdate(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	upstream := newFakeUpstream(backend.URL, false, 30*time.Second)
+	upstream := newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)
 	upstream.host.DownstreamHeaders = http.Header{
 		"+Merge-Me":  {"Merge-Value"},
 		"+Add-Me":    {"Add-Value"},
@@ -918,7 +919,7 @@ func TestHostSimpleProxyNoHeaderForward(t *testing.T) {
 	// set up proxy
 	p := &Proxy{
 		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
-		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second)},
+		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)},
 	}
 
 	r := httptest.NewRequest("GET", "/", nil)
@@ -1007,7 +1008,7 @@ func TestHostHeaderReplacedUsingForward(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	upstream := newFakeUpstream(backend.URL, false, 30*time.Second)
+	upstream := newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)
 	proxyHostHeader := "test2.com"
 	upstream.host.UpstreamHeaders = http.Header{"Host": []string{proxyHostHeader}}
 	// set up proxy
@@ -1069,7 +1070,7 @@ func basicAuthTestcase(t *testing.T, upstreamUser, clientUser *url.Userinfo) {
 
 	p := &Proxy{
 		Next:      httpserver.EmptyNext,
-		Upstreams: []Upstream{newFakeUpstream(backURL.String(), false, 30*time.Second)},
+		Upstreams: []Upstream{newFakeUpstream(backURL.String(), false, 30*time.Second, 300*time.Millisecond)},
 	}
 	r, err := http.NewRequest("GET", "/foo", nil)
 	if err != nil {
@@ -1204,7 +1205,7 @@ func TestProxyDirectorURL(t *testing.T) {
 			continue
 		}
 
-		NewSingleHostReverseProxy(targetURL, c.without, 0, 30*time.Second).Director(req)
+		NewSingleHostReverseProxy(targetURL, c.without, 0, 30*time.Second, 300*time.Millisecond).Director(req)
 		if expect, got := c.expectURL, req.URL.String(); expect != got {
 			t.Errorf("case %d url not equal: expect %q, but got %q",
 				i, expect, got)
@@ -1351,7 +1352,7 @@ func TestCancelRequest(t *testing.T) {
 	// set up proxy
 	p := &Proxy{
 		Next:      httpserver.EmptyNext, // prevents panic in some cases when test fails
-		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second)},
+		Upstreams: []Upstream{newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)},
 	}
 
 	// setup request with cancel ctx
@@ -1400,15 +1401,16 @@ func (r *noopReader) Read(b []byte) (int, error) {
 	return n, nil
 }
 
-func newFakeUpstream(name string, insecure bool, timeout time.Duration) *fakeUpstream {
+func newFakeUpstream(name string, insecure bool, timeout, fallbackDelay time.Duration) *fakeUpstream {
 	uri, _ := url.Parse(name)
 	u := &fakeUpstream{
-		name:    name,
-		from:    "/",
-		timeout: timeout,
+		name:          name,
+		from:          "/",
+		timeout:       timeout,
+		fallbackDelay: fallbackDelay,
 		host: &UpstreamHost{
 			Name:         name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, "", http.DefaultMaxIdleConnsPerHost, timeout),
+			ReverseProxy: NewSingleHostReverseProxy(uri, "", http.DefaultMaxIdleConnsPerHost, timeout, fallbackDelay),
 		},
 	}
 	if insecure {
@@ -1418,11 +1420,12 @@ func newFakeUpstream(name string, insecure bool, timeout time.Duration) *fakeUps
 }
 
 type fakeUpstream struct {
-	name    string
-	host    *UpstreamHost
-	from    string
-	without string
-	timeout time.Duration
+	name          string
+	host          *UpstreamHost
+	from          string
+	without       string
+	timeout       time.Duration
+	fallbackDelay time.Duration
 }
 
 func (u *fakeUpstream) From() string {
@@ -1437,13 +1440,14 @@ func (u *fakeUpstream) Select(r *http.Request) *UpstreamHost {
 		}
 		u.host = &UpstreamHost{
 			Name:         u.name,
-			ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost, u.GetTimeout()),
+			ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost, u.GetTimeout(), u.GetFallbackDelay()),
 		}
 	}
 	return u.host
 }
 
 func (u *fakeUpstream) AllowedPath(requestPath string) bool { return true }
+func (u *fakeUpstream) GetFallbackDelay() time.Duration     { return 300 * time.Millisecond }
 func (u *fakeUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeUpstream) GetTimeout() time.Duration           { return u.timeout }
@@ -1474,10 +1478,11 @@ func newPrefixedWebSocketTestProxy(backendAddr string, prefix string) *Proxy {
 }
 
 type fakeWsUpstream struct {
-	name     string
-	without  string
-	insecure bool
-	timeout  time.Duration
+	name          string
+	without       string
+	insecure      bool
+	timeout       time.Duration
+	fallbackDelay time.Duration
 }
 
 func (u *fakeWsUpstream) From() string {
@@ -1488,7 +1493,7 @@ func (u *fakeWsUpstream) Select(r *http.Request) *UpstreamHost {
 	uri, _ := url.Parse(u.name)
 	host := &UpstreamHost{
 		Name:         u.name,
-		ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost, u.GetTimeout()),
+		ReverseProxy: NewSingleHostReverseProxy(uri, u.without, http.DefaultMaxIdleConnsPerHost, u.GetTimeout(), u.GetFallbackDelay()),
 		UpstreamHeaders: http.Header{
 			"Connection": {"{>Connection}"},
 			"Upgrade":    {"{>Upgrade}"}},
@@ -1500,6 +1505,7 @@ func (u *fakeWsUpstream) Select(r *http.Request) *UpstreamHost {
 }
 
 func (u *fakeWsUpstream) AllowedPath(requestPath string) bool { return true }
+func (u *fakeWsUpstream) GetFallbackDelay() time.Duration     { return 300 * time.Millisecond }
 func (u *fakeWsUpstream) GetTryDuration() time.Duration       { return 1 * time.Second }
 func (u *fakeWsUpstream) GetTryInterval() time.Duration       { return 250 * time.Millisecond }
 func (u *fakeWsUpstream) GetTimeout() time.Duration           { return u.timeout }
@@ -1548,7 +1554,7 @@ func BenchmarkProxy(b *testing.B) {
 	}))
 	defer backend.Close()
 
-	upstream := newFakeUpstream(backend.URL, false, 30*time.Second)
+	upstream := newFakeUpstream(backend.URL, false, 30*time.Second, 300*time.Millisecond)
 	upstream.host.UpstreamHeaders = http.Header{
 		"Hostname":          {"{hostname}"},
 		"Host":              {"{host}"},

--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -148,7 +148,7 @@ func singleJoiningSlash(a, b string) string {
 // the target request will be for /base/dir.
 // Without logic: target's path is "/", incoming is "/api/messages",
 // without is "/api", then the target request will be for /messages.
-func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int, timeout time.Duration) *ReverseProxy {
+func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int, timeout, fallbackDelay time.Duration) *ReverseProxy {
 	targetQuery := target.RawQuery
 	director := func(req *http.Request) {
 		if target.Scheme == "unix" {
@@ -233,6 +233,9 @@ func NewSingleHostReverseProxy(target *url.URL, without string, keepalive int, t
 	dialer := *defaultDialer
 	if timeout != defaultDialer.Timeout {
 		dialer.Timeout = timeout
+	}
+	if fallbackDelay != defaultDialer.FallbackDelay {
+		dialer.FallbackDelay = fallbackDelay
 	}
 
 	rp := &ReverseProxy{

--- a/caddyhttp/proxy/reverseproxy_test.go
+++ b/caddyhttp/proxy/reverseproxy_test.go
@@ -67,7 +67,7 @@ func TestSingleSRVHostReverseProxy(t *testing.T) {
 	}
 	port := uint16(pp)
 
-	rp := NewSingleHostReverseProxy(target, "", http.DefaultMaxIdleConnsPerHost, 30*time.Second)
+	rp := NewSingleHostReverseProxy(target, "", http.DefaultMaxIdleConnsPerHost, 30*time.Second, 300*time.Millisecond)
 	rp.srvResolver = testResolver{
 		result: []*net.SRV{
 			{Target: upstream.Hostname(), Port: port, Priority: 1, Weight: 1},


### PR DESCRIPTION
### 1. What does this change do, exactly?

A previous PR I made (#2305) just enabled `DualStack` in the default dialer that was being used in reverse proxies to improve initial connection speed, or connection speed after the TLS handshake timeout had already passed.

In the Go standard library's `net` package, the `net.Dialer` uses a fallback delay as part of its implementation of "Happy Eyeballs" when `DualStack` is enabled. This fallback delay is just a measure of how much of a head start the first connection gets before allowing another "racer" to attempt a second connection.

By default when this duration is not set the `fallbackDelay` function in the `net` package defaults to returning `300 * time.Millisecond`.

It would be useful to configure this fallback delay duration from a caddyfile instead of having to edit the source and recompile.

So this PR just adds a new `fallback_delay` sub-directive to the existing `proxy` directive, which gets used in the `NewSingleHostReverseProxy` function in the `reverseproxy.go` file to overwrite the default value if it's different from the one set on the default dialer.

The default dialer has been left with this value unset so it can always use the default Go standard library's implementation, since it's possible the Go standard library could change it in the future, in which case we would probably want to pick up those changes by default.

### 2. Please link to the relevant issues.

This PR relates directly to issue #2306 and is a result of a previous PR I made (#2305).

### 3. Which documentation changes (if any) need to be made because of this PR?

A change to the proxy documentation (https://caddyserver.com/docs/proxy) would be needed to add an explanation of the new sub-directive.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

I checked the first box about tests, but what I mean here is that I updated the existing tests, checked that they failed, and then added the new directive and tested again.