### PR TITLE
tls: Add root CA to obtain certificates.

### DIFF
--- a/caddytls/certificates.go
+++ b/caddytls/certificates.go
@@ -196,6 +196,8 @@ func (cfg *Config) cacheUnmanagedCertificatePEMBytes(certBytes, keyBytes []byte)
 	}
 	cfg.cacheCertificate(cert)
 	telemetry.Increment("tls_manual_cert_count")
+
+	cfg.SelfCAName = cert.Names[0]
 	return nil
 }
 

--- a/caddytls/client.go
+++ b/caddytls/client.go
@@ -34,11 +34,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
+	"os"
+
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/telemetry"
 	"github.com/xenolf/lego/acmev2"
-	"math/big"
-	"os"
 )
 
 // acmeMu ensures that only one ACME challenge occurs at a time.

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -17,6 +17,7 @@ package caddytls
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -27,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 
-	"crypto/x509"
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/telemetry"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Some words from mitmproxy's docs:

> This CA is used for on-the-fly generation of dummy certificates for each of the SSL sites that your client visits. Since your browser won’t trust the mitmproxy CA out of the box, you will see an SSL certificate warning every time you visit a new SSL domain through mitmproxy. When you are testing a single site through a browser, just accepting the bogus SSL cert manually is not too much trouble, but there are a many circumstances where you will want to configure your testing system or browser to trust the mitmproxy CA as a signing root authority.

*I'm trying to make Caddy can work like mitmproxy while I dealing with [MITM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) things with my own plugin, but only works with modified Caddy, so I apply this pull request first.*

So, I need Caddy to load a root CA, and then generate a certificate with domain(wildcard or not) on-the-fly.

Steps: 

1. handle sub directive in tls: `root_signed`
2. load the cert and key of CA
3. generate cert with the root cert and key in the fly if needs

### 2. Please link to the relevant issues.

**Do I need to open an issue to discuss about this feature?**

### 3. Which documentation changes (if any) need to be made because of this PR?

1. add to a sub directive for doc of `tls`
2. add `root_signed_wild` for doc of `tls` settings block, will obtain and manage a wildcard certificate for this name by replacing the left-most label with *, ignore the DNS challenge.

For example, part of Caddyfile with enable wildcard for root signed:

```
	tls root_signed ./ssl/rootCA.crt ./ssl/rootCA.key {
		root_signed_wild
	}
```

Thing looks like,

![caddy_tls_wildcard](https://user-images.githubusercontent.com/2942042/46846182-41e39580-ce11-11e8-8709-ff2ae6024b19.PNG)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
