### PR TITLE
Improve flaky test

### DIFF
--- a/caddytls/user_test.go
+++ b/caddytls/user_test.go
@@ -179,9 +179,9 @@ func TestGetEmail(t *testing.T) {
 	// Test3: Get most recent email from before (in storage)
 	DefaultEmail = ""
 	for i, eml := range []string{
-		"TEST4-3@foo.com", // test case insensitivity
-		"test4-2@foo.com",
 		"test4-1@foo.com",
+		"test4-2@foo.com",
+		"TEST4-3@foo.com", // test case insensitivity
 	} {
 		u, err := newUser(eml)
 		if err != nil {
@@ -197,7 +197,7 @@ func TestGetEmail(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not access user folder for '%s': %v", eml, err)
 		}
-		chTime := f.ModTime().Add(-(time.Duration(i) * time.Hour)) // 1 second isn't always enough space!
+		chTime := f.ModTime().Add(time.Duration(i) * time.Hour) // 1 second isn't always enough space!
 		if err := os.Chtimes(testStorage.user(eml), chTime, chTime); err != nil {
 			t.Fatalf("Could not change user folder mod time for '%s': %v", eml, err)
 		}


### PR DESCRIPTION
### 1. What does this change do, exactly?
Sometimes I got flaky test error like below.
```
$ cd caddytls
$ go test -v . -run 'TestGetEmail'
=== RUN   TestGetEmail
--- FAIL: TestGetEmail (0.03s)
	user_test.go:210: Did not get correct email from storage; expected 'test4-3@foo.com' but got 'test3@foo.com'
FAIL
FAIL	github.com/mholt/caddy/caddytls	0.045s
```

To make the cause cleary, I embed debug code to show what happened.
```
$ cd caddytls
$ go test -v . -run 'TestGetEmail'
=== RUN   TestGetEmail

Your sites will be served over HTTPS automatically using Let's Encrypt.
By continuing, you agree to the Let's Encrypt Subscriber Agreement at:
  (none - testing)
Please enter your email address to signify agreement and to be notified
in case of issues. You can leave it blank, but we don't recommend it.
  Email address: 
(test) 2018-10-12 16:06:38 +0900 JST : test3@foo.com
(test) 2018-10-12 14:06:38 +0900 JST : test4-1@foo.com
(test) 2018-10-12 15:06:38 +0900 JST : test4-2@foo.com
(test) 2018-10-12 16:06:38 +0900 JST : test4-3@foo.com
--- FAIL: TestGetEmail (0.03s)
	user_test.go:210: Did not get correct email from storage; expected 'test4-3@foo.com' but got 'test3@foo.com'
FAIL
FAIL	github.com/mholt/caddy/caddytls	0.046s
```

It seems gonna happen when 'test3@foo.com' and 'test4-3@foo.com' is created at the same time.
I fixed the test code so that the order of time the file created is more deterministic.
The result is like below.
```
$ cd caddytls
$ go test -v . -run 'TestGetEmail'
=== RUN   TestGetEmail


Your sites will be served over HTTPS automatically using Let's Encrypt.
By continuing, you agree to the Let's Encrypt Subscriber Agreement at:
  (none - testing)
Please enter your email address to signify agreement and to be notified
in case of issues. You can leave it blank, but we don't recommend it.
  Email address: 
(test) 2018-10-12 16:20:41 +0900 JST : test3@foo.com
(test) 2018-10-12 16:20:41 +0900 JST : test4-1@foo.com
(test) 2018-10-12 17:20:41 +0900 JST : test4-2@foo.com
(test) 2018-10-12 18:20:41 +0900 JST : test4-3@foo.com
--- PASS: TestGetEmail (0.03s)
PASS
ok  	github.com/mholt/caddy/caddytls	0.047s
```

### 2. Please link to the relevant issues.


### 3. Which documentation changes (if any) need to be made because of this PR?
Nothing.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
