### PR TITLE
[CI configurations]: get golint tool from `golang.org/x/lint/golint`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash dist/gitcookie.sh; fi
   - go get -t ./...
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/FiloSottile/vendorcheck
   - go get github.com/alecthomas/gometalinter
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - go version
   - go env
   - go get -t ./...
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/FiloSottile/vendorcheck
   - go get github.com/alecthomas/gometalinter
 


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

CI configuration changed: use `golang.org/x/lint/golint` instead of `github.com/golang/lint/golint`

### 2. Please link to the relevant issues.

#2319 

### 3. Which documentation changes (if any) need to be made because of this PR?


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
