### PR TITLE
templates: delete ETag and Last-Modified headers in ServeHTTP

### DIFF
--- a/caddyhttp/templates/templates.go
+++ b/caddyhttp/templates/templates.go
@@ -110,6 +110,10 @@ func (t Templates) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		// set the actual content length now that the template was executed
 		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 
+		// delete the headers related to cache
+		w.Header().Del("ETag")
+		w.Header().Del("Last-Modified")
+
 		// get the modification time in preparation for http.ServeContent
 		modTime, _ := time.Parse(http.TimeFormat, w.Header().Get("Last-Modified"))
 

--- a/caddyhttp/templates/templates_test.go
+++ b/caddyhttp/templates/templates_test.go
@@ -70,6 +70,7 @@ func TestTemplates(t *testing.T) {
 		req      string
 		respCode int
 		res      string
+		bypass   bool
 	}{
 		{
 			tpl:      tmpl,
@@ -113,6 +114,7 @@ func TestTemplates(t *testing.T) {
 			respCode: http.StatusOK,
 			res: `<!DOCTYPE html><html><head><title>as it is</title></head><body>{{.Include "header.html"}}</body></html>
 `,
+			bypass: true,
 		},
 	} {
 		c := c
@@ -134,6 +136,14 @@ func TestTemplates(t *testing.T) {
 			respBody := rec.Body.String()
 			if respBody != c.res {
 				t.Fatalf("Test: the expected body %v is different from the response one: %v", c.res, respBody)
+			}
+
+			if !c.bypass {
+				eTag := rec.Header().Get("ETag")
+				lastModified := rec.Header().Get("Last-Modified")
+				if eTag != "" || lastModified != "" {
+					t.Fatalf("Test: expect a response without ETag or Last-Modified, got %v %v", eTag, lastModified)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### 1. What does this change do, exactly?
In tempates middleware, delete the two headers related to cache.

### 2. Please link to the relevant issues.
#1920

### 3. Which documentation changes (if any) need to be made because of this PR?
None.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
