### PR TITLE
caddytls: Raise TLS alert if no certificate matches SAN (closes #1303)

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -576,7 +576,7 @@ var supportedKeyTypes = map[string]acme.KeyType{
 	"RSA2048": acme.RSA2048,
 }
 
-// Map of supported protocols.
+// SupportedProtocols is a map of supported protocols.
 // HTTP/2 only supports TLS 1.2 and higher.
 // If updating this map, also update tlsProtocolStringToMap in caddyhttp/fastcgi/fastcgi.go
 var SupportedProtocols = map[string]uint16{
@@ -596,7 +596,7 @@ func GetSupportedProtocolName(protocol uint16) (string, error) {
 	return "", errors.New("name: unsuported protocol")
 }
 
-// Map of supported ciphers, used only for parsing config.
+// SupportedCiphersMap has supported ciphers, used only for parsing config.
 //
 // Note that, at time of writing, HTTP/2 blacklists 276 cipher suites,
 // including all but four of the suites below (the four GCM suites).

--- a/caddytls/handshake.go
+++ b/caddytls/handshake.go
@@ -63,13 +63,9 @@ func (cg configGroup) getConfig(name string) *Config {
 
 	// try a config that serves all names (the above
 	// loop doesn't try empty string; for hosts defined
-	// with only a port, for instance, like ":443")
+	// with only a port, for instance, like ":443") -
+	// also known as the default config
 	if config, ok := cg[""]; ok {
-		return config
-	}
-
-	// no matches, so just serve up a random config
-	for _, config := range cg {
 		return config
 	}
 
@@ -187,16 +183,12 @@ func (cfg *Config) getCertificate(name string) (cert Certificate, matched, defau
 		return
 	}
 
-	// if nothing matches, use a random certificate
-	// TODO: This is not my favorite behavior; I would rather serve
-	// no certificate if SNI is provided and cause a TLS alert, than
-	// serve the wrong certificate (but sometimes the 'wrong' cert
-	// is what is wanted, but in those cases I would prefer that the
-	// site owner explicitly configure a "default" certificate).
-	// (See issue 2035; any change to this behavior must account for
-	// hosts defined like ":443" or "0.0.0.0:443" where the hostname
-	// is empty or a catch-all IP or something.)
-	for _, certKey := range cfg.Certificates {
+	// if nothing matches, use a "default" certificate
+	// (See issues 2035 and 1303; any change to this behavior
+	// must account for hosts defined like ":443" or
+	// "0.0.0.0:443" where the hostname is empty or a catch-all
+	// IP or something.)
+	if certKey, ok := cfg.Certificates[""]; ok {
 		cert = cfg.certCache.cache[certKey]
 		defaulted = true
 		return

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -282,7 +282,7 @@ func setupTLS(c *caddy.Controller) error {
 
 	// generate self-signed cert if needed
 	if config.SelfSigned {
-		err := makeSelfSignedCert(config)
+		err := makeSelfSignedCertForConfig(config)
 		if err != nil {
 			return fmt.Errorf("self-signed: %v", err)
 		}


### PR DESCRIPTION
I don't love this half-baked solution to the issue raised in #1303 way
more than a year after the original issue was closed (the necro comments
are about an issue separate from the original issue that started it),
but I do like TLS alerts more than wrong certificates.

### 1. What does this change do, exactly?

Raises a TLS alert on mismatching (or missing) SNI if no site is configured with a matching certificate, rather than serving a random certificate. 

### 2. Please link to the relevant issues.

- #1303 
- #2015 
- #2037

/cc @Zenexer @ghoeffner @orenyomtov @mxlje - Please determine whether this addresses your concerns. This is on you now. This is not entirely satisfying to me, but if it makes you happy, let's merge it.