### PR TITLE
Prevent errors test fail if $GOPATH is something like /home/user/caddy

### DIFF
--- a/caddyhttp/errors/errors.go
+++ b/caddyhttp/errors/errors.go
@@ -142,7 +142,7 @@ func (h ErrorHandler) recovery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trim file path
-	delim := "/caddy/"
+	delim := "/github.com/mholt/caddy/"
 	pkgPathPos := strings.Index(file, delim)
 	if pkgPathPos > -1 && len(file) > pkgPathPos+len(delim) {
 		file = file[pkgPathPos+len(delim):]


### PR DESCRIPTION
### 1. What does this change do, exactly?
To pass `errors` unit test when source code `$GOPATH` is `/home/user/caddy`.
caddy repository is at `/home/user/caddy/src/github.com/mholt/caddy`
This issue happens on Linux and Windows too.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
