### PR TITLE
Revert "*.txt, *.tpl, *.htm, *.html, *.md should always use eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,10 +10,5 @@
 # go fmt will enforce this, but in case a user has not called "go fmt" allow GIT to catch this:
 *.go      text eol=lf core.whitespace whitespace=indent-with-non-tab,trailing-space,tabwidth=4
 
-*.txt     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
-*.tpl     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
-*.htm     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
-*.html    text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
-*.md      text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
 *.yml     text eol=lf core.whitespace whitespace=tab-in-indent,trailing-space,tabwidth=2
 .git*     text eol=auto core.whitespace whitespace=trailing-space


### PR DESCRIPTION
This reverts commit d9e6e7ffa58bdd21cd9cef0d41802221a7b2fdc1.

fixes #2348

@mholt @cblecker
