### PR TITLE
WIP: Implement own CA certificates of backends

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -69,6 +70,7 @@ type staticUpstream struct {
 	insecureSkipVerify bool
 	MaxFails           int32
 	resolver           srvResolver
+	CaCertPool         *x509.CertPool
 }
 
 type srvResolver interface {
@@ -231,6 +233,9 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix, u.KeepAlive, u.Timeout, u.FallbackDelay)
 	if u.insecureSkipVerify {
 		uh.ReverseProxy.UseInsecureTransport()
+	}
+	if u.CaCertPool != nil {
+		uh.ReverseProxy.UseOwnCACertificates(u.CaCertPool)
 	}
 
 	return uh, nil
@@ -464,6 +469,32 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		u.IgnoredSubPaths = ignoredPaths
 	case "insecure_skip_verify":
 		u.insecureSkipVerify = true
+	case "ca_certificates":
+		caCertificates := c.RemainingArgs()
+		if len(caCertificates) == 0 {
+			return c.ArgErr()
+		}
+		pool := x509.NewCertPool()
+		caCertificatesAdded := make(map[string]struct{})
+		for _, caFile := range caCertificates {
+			// don't add cert to pool more than once
+			if _, ok := caCertificatesAdded[caFile]; ok {
+				continue
+			}
+			caCertificatesAdded[caFile] = struct{}{}
+
+			// Any client with a certificate from this CA will be allowed to connect
+			caCrt, err := ioutil.ReadFile(caFile)
+			if err != nil {
+				return err
+			}
+
+			if !pool.AppendCertsFromPEM(caCrt) {
+				return fmt.Errorf("error loading CA certificate '%s': no certificates were successfully parsed", caFile)
+			}
+		}
+
+		u.CaCertPool = pool
 	case "keepalive":
 		if !c.NextArg() {
 			return c.ArgErr()


### PR DESCRIPTION
This is WIP and demonstration of where to go for https://github.com/mholt/caddy/issues/1550

### 1. What does this change do, exactly?

It adds `ca_certificates` option to proxy, which allows to use own PEM with CA certificates to validate backend against.

### 2. Please link to the relevant issues.

https://github.com/mholt/caddy/issues/1550

### 3. Which documentation changes (if any) need to be made because of this PR?

https://caddyserver.com/docs/proxy would need documentation updated.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
  - [ ] test that option work
  - [ ] (maybe) (implement) test that it conflicts with `insecure_skip_verify`
  - [ ] (maybe) test proving that system pool (eg. provided locally with `SSL_CERT_FILES` environment variable) is overridden by the option
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
