### PR TITLE
optimized parse cli's disabledMetrics flag string to initTelemetry

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -418,7 +418,7 @@ func initTelemetry() error {
 	return nil
 }
 
-// Split slices s into all substrings separated by sep and returns a slice of
+// Split string s into all substrings separated by sep and returns a slice of
 // the substrings between those separators.
 //
 // If s does not contain sep and sep is not empty, Split returns a

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -392,14 +392,14 @@ func initTelemetry() error {
 	}
 
 	// parse and check the list of disabled metrics
-	var fixedDisabledMetrics []string
+	var disabledMetricsSlice []string
 	if len(disabledMetrics) > 0 {
 		if len(disabledMetrics) > 1024 {
 			// mitigate disk space exhaustion at the collection endpoint
 			return fmt.Errorf("too many metrics to disable")
 		}
-		fixedDisabledMetrics := splitTrim(disabledMetrics, ",")
-		for _, metric := range fixedDisabledMetrics {
+		disabledMetricsSlice = splitTrim(disabledMetrics, ",")
+		for _, metric := range disabledMetricsSlice {
 			if metric == "instance_id" || metric == "timestamp" || metric == "disabled_metrics" {
 				return fmt.Errorf("instance_id, timestamp, and disabled_metrics cannot be disabled")
 			}
@@ -407,11 +407,11 @@ func initTelemetry() error {
 	}
 
 	// initialize telemetry
-	telemetry.Init(id, fixedDisabledMetrics)
+	telemetry.Init(id, disabledMetricsSlice)
 
 	// if any metrics were disabled, report which ones (so we know how representative the data is)
-	if len(fixedDisabledMetrics) > 0 {
-		telemetry.Set("disabled_metrics", fixedDisabledMetrics)
+	if len(disabledMetricsSlice) > 0 {
+		telemetry.Set("disabled_metrics", disabledMetricsSlice)
 		log.Printf("[NOTICE] The following telemetry metrics are disabled: %s", disabledMetrics)
 	}
 

--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -398,15 +398,10 @@ func initTelemetry() error {
 			// mitigate disk space exhaustion at the collection endpoint
 			return fmt.Errorf("too many metrics to disable")
 		}
-		disabledMetricsSlice := strings.Split(disabledMetrics, ",")
-		fixedDisabledMetrics := make([]string, 0, len(disabledMetricsSlice))
-		for _, metric := range disabledMetricsSlice {
-			metric = strings.TrimSpace(metric)
+		fixedDisabledMetrics := splitTrim(disabledMetrics, ",")
+		for _, metric := range fixedDisabledMetrics {
 			if metric == "instance_id" || metric == "timestamp" || metric == "disabled_metrics" {
 				return fmt.Errorf("instance_id, timestamp, and disabled_metrics cannot be disabled")
-			}
-			if metric != "" {
-				fixedDisabledMetrics = append(fixedDisabledMetrics, metric)
 			}
 		}
 	}
@@ -421,6 +416,27 @@ func initTelemetry() error {
 	}
 
 	return nil
+}
+
+// Split slices s into all substrings separated by sep and returns a slice of
+// the substrings between those separators.
+//
+// If s does not contain sep and sep is not empty, Split returns a
+// slice of length 1 whose only element is s.
+//
+// If sep is empty, Split splits after each UTF-8 sequence. If both s
+// and sep are empty, Split returns an empty slice.
+//
+// Each item that in result is trim space and not empty string
+func splitTrim(s string, sep string) []string {
+	splitItems := strings.Split(s, sep)
+	trimItems := make([]string, 0, len(splitItems))
+	for _, item := range splitItems {
+		if item = strings.TrimSpace(item); item != "" {
+			trimItems = append(trimItems, item)
+		}
+	}
+	return trimItems
 }
 
 // LoadEnvFromFile loads additional envs if file provided and exists

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -60,6 +60,30 @@ func TestSetCPU(t *testing.T) {
 	}
 }
 
+func TestSplitTrim(t *testing.T) {
+	for i, test := range []struct {
+		input     string
+		output    []string
+		sep       string
+	}{
+		{"os,arch,cpu,caddy_version", []string{"os", "arch", "cpu", "caddy_version"}, ","},
+		{"os,arch,cpu,caddy_version,", []string{"os", "arch", "cpu", "caddy_version"}, ","},
+		{"os,,, arch, cpu, caddy_version,", []string{"os", "arch", "cpu", "caddy_version"}, ","},
+		{", , os, arch, cpu , caddy_version,, ,", []string{"os", "arch", "cpu", "caddy_version"}, ","},
+		{"os, ,, arch, cpu , caddy_version,, ,", []string{"os", "arch", "cpu", "caddy_version"}, ","},
+	} {
+		got := splitTrim(test.input, test.sep)
+		if len(got) != len(test.output) {
+			t.Errorf("Test %d: spliteTrim() = %v, want %v", i, test.input, test.output)
+		}
+		for i, item := range test.output {
+			if item != got[i]  {
+				t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
+			}
+		}
+	}
+}
+
 func TestParseEnvFile(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -75,10 +75,12 @@ func TestSplitTrim(t *testing.T) {
 		got := splitTrim(test.input, test.sep)
 		if len(got) != len(test.output) {
 			t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
+			continue
 		}
-		for i, item := range test.output {
-			if item != got[i] {
+		for j, item := range test.output {
+			if item != got[j] {
 				t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
+				break
 			}
 		}
 	}

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -62,9 +62,9 @@ func TestSetCPU(t *testing.T) {
 
 func TestSplitTrim(t *testing.T) {
 	for i, test := range []struct {
-		input     string
-		output    []string
-		sep       string
+		input  string
+		output []string
+		sep    string
 	}{
 		{"os,arch,cpu,caddy_version", []string{"os", "arch", "cpu", "caddy_version"}, ","},
 		{"os,arch,cpu,caddy_version,", []string{"os", "arch", "cpu", "caddy_version"}, ","},
@@ -77,7 +77,7 @@ func TestSplitTrim(t *testing.T) {
 			t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
 		}
 		for i, item := range test.output {
-			if item != got[i]  {
+			if item != got[i] {
 				t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
 			}
 		}

--- a/caddy/caddymain/run_test.go
+++ b/caddy/caddymain/run_test.go
@@ -74,7 +74,7 @@ func TestSplitTrim(t *testing.T) {
 	} {
 		got := splitTrim(test.input, test.sep)
 		if len(got) != len(test.output) {
-			t.Errorf("Test %d: spliteTrim() = %v, want %v", i, test.input, test.output)
+			t.Errorf("Test %d: spliteTrim() = %v, want %v", i, got, test.output)
 		}
 		for i, item := range test.output {
 			if item != got[i]  {


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
run caddy:
```
$ ./caddy --disabled-metrics "os,,, arch, cpu, caddy_version,"
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/mholt/caddy/caddy/caddymain.initTelemetry(0x0, 0x0)
	/go/src/github.com/mholt/caddy/caddy/caddymain/run.go:407 +0x8d4
github.com/mholt/caddy/caddy/caddymain.Run()
	/go/src/github.com/mholt/caddy/caddy/caddymain/run.go:102 +0xb99
main.main()
	/go/src/github.com/mholt/caddy/caddy/main.go:27 +0x27
```
This patch fixed above problem.
### 4. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
