### PR TITLE
Disable basic authentication for OPTIONS method

### DIFF
--- a/caddyhttp/basicauth/basicauth_test.go
+++ b/caddyhttp/basicauth/basicauth_test.go
@@ -194,3 +194,29 @@ md5:$apr1$l42y8rex$pOA2VJ0x/0TwaFeAF9nX61`
 		}
 	}
 }
+func TestOptionsMethod(t *testing.T) {
+	rw := BasicAuth{
+		Next: httpserver.HandlerFunc(contentHandler),
+		Rules: []Rule{
+			{Username: "username", Password: PlainMatcher("password"), Resources: []string{"/testing"}},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodOptions, "/testing", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+
+	// add basic auth with invalid username
+	// and password to make sure basic auth is ignored
+	req.SetBasicAuth("invaliduser", "invalidpassword")
+
+	rec := httptest.NewRecorder()
+	result, err := rw.ServeHTTP(rec, req)
+	if err != nil {
+		t.Fatalf("Could not ServeHTTP: %v", err)
+	}
+	if result != http.StatusOK {
+		t.Errorf("Expected status code %d but was %d", http.StatusOK, result)
+	}
+}

--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -368,6 +368,8 @@ func (r *replacer) getSubstitution(key string) string {
 		return url.QueryEscape(r.request.URL.RequestURI())
 	case "{when}":
 		return now().Format(timeFormat)
+	case "{when_iso_local}":
+		return now().Format(timeFormatISO)
 	case "{when_iso}":
 		return now().UTC().Format(timeFormatISOUTC)
 	case "{when_unix}":
@@ -539,6 +541,7 @@ func (r *replacer) Set(key, value string) {
 
 const (
 	timeFormat        = "02/Jan/2006:15:04:05 -0700"
+	timeFormatISO     = "2006-01-02T15:04:05"  // ISO 8601 with timezone to be assumed as local
 	timeFormatISOUTC  = "2006-01-02T15:04:05Z" // ISO 8601 with timezone to be assumed as UTC
 	headerContentType = "Content-Type"
 	contentTypeJSON   = "application/json"

--- a/caddyhttp/httpserver/replacer_test.go
+++ b/caddyhttp/httpserver/replacer_test.go
@@ -86,6 +86,7 @@ func TestReplace(t *testing.T) {
 
 	old := now
 	now = func() time.Time {
+		// Note that the `-7` is seconds, not hours.
 		return time.Date(2006, 1, 2, 15, 4, 5, 99999999, time.FixedZone("hardcoded", -7))
 	}
 	defer func() {
@@ -101,6 +102,7 @@ func TestReplace(t *testing.T) {
 		{"The response status is {status}.", "The response status is 200."},
 		{"{when}", "02/Jan/2006:15:04:05 +0000"},
 		{"{when_iso}", "2006-01-02T15:04:12Z"},
+		{"{when_iso_local}", "2006-01-02T15:04:05"},
 		{"{when_unix}", "1136214252"},
 		{"{when_unix_ms}", "1136214252099"},
 		{"The Custom header is {>Custom}.", "The Custom header is foobarbaz."},
@@ -276,6 +278,7 @@ func BenchmarkReplace(b *testing.B) {
 	recordRequest.Header().Set("Custom", "CustomResponseHeader")
 
 	now = func() time.Time {
+		// Note that the `-7` is seconds, not hours.
 		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
 	}
 
@@ -308,6 +311,7 @@ func BenchmarkReplaceEscaped(b *testing.B) {
 	recordRequest.Header().Set("Custom", "CustomResponseHeader")
 
 	now = func() time.Time {
+		// Note that the `-7` is seconds, not hours.
 		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
 	}
 
@@ -334,6 +338,7 @@ func TestResponseRecorderNil(t *testing.T) {
 
 	old := now
 	now = func() time.Time {
+		// Note that the `-7` is seconds, not hours.
 		return time.Date(2006, 1, 2, 15, 4, 5, 02, time.FixedZone("hardcoded", -7))
 	}
 	defer func() {


### PR DESCRIPTION
### 1. What does this change do, exactly?
The pull request disables basic auth on OPTION method calls.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1568

### 3. Which documentation changes (if any) need to be made because of this PR?
No. The pull request is minimal and changes the behaviour of the basic auth plugin without adding new configuration options

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
