### PR TITLE
caddytls: add TLS 1.3 support

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -407,7 +407,7 @@ func SetDefaultTLSParams(config *Config) {
 		config.ProtocolMinVersion = tls.VersionTLS12
 	}
 	if config.ProtocolMaxVersion == 0 {
-		config.ProtocolMaxVersion = tls.VersionTLS12
+		config.ProtocolMaxVersion = tls.VersionTLS13
 	}
 
 	// Prefer server cipher suites
@@ -430,6 +430,7 @@ var SupportedProtocols = map[string]uint16{
 	"tls1.0": tls.VersionTLS10,
 	"tls1.1": tls.VersionTLS11,
 	"tls1.2": tls.VersionTLS12,
+	"tls1.3": tls.VersionTLS13,
 }
 
 // GetSupportedProtocolName returns the protocol name
@@ -489,10 +490,6 @@ var defaultCiphers = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 }
 
 // List of ciphers we should prefer if native AESNI support is missing
@@ -503,10 +500,6 @@ var defaultCiphersNonAESNI = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 }
 
 // getPreferredDefaultCiphers returns an appropriate cipher suite to use, depending on

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -34,6 +34,10 @@ import (
 )
 
 func init() {
+	// opt-in TLS 1.3 for Go1.12
+	// TODO: remove this line when Go1.13 is released.
+	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
+
 	caddy.RegisterPlugin("tls", caddy.Plugin{Action: setupTLS})
 
 	// ensure the default Storage implementation is plugged in

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -75,8 +75,8 @@ func TestSetupParseBasic(t *testing.T) {
 	if cfg.ProtocolMinVersion != tls.VersionTLS12 {
 		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMinVersion, got %#v", cfg.ProtocolMinVersion)
 	}
-	if cfg.ProtocolMaxVersion != tls.VersionTLS12 {
-		t.Errorf("Expected 'tls1.2 (0x0303)' as ProtocolMaxVersion, got %v", cfg.ProtocolMaxVersion)
+	if cfg.ProtocolMaxVersion != tls.VersionTLS13 {
+		t.Errorf("Expected 'tls1.3 (0x0304)' as ProtocolMaxVersion, got %#v", cfg.ProtocolMaxVersion)
 	}
 
 	// Cipher checks


### PR DESCRIPTION
### 1. What does this change do, exactly?
add TLS 1.3

### 2. Please link to the relevant issues.
#2080 

### 3. Which documentation changes (if any) need to be made because of this PR?
https://caddyserver.com/docs/tls
1. "tls1.3" is a new suppoted protocol if caddy is built by Go 1.12 or newer.
2. TLS 1.3 cipher suites are not configurable.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later

If caddy should be able to be built by Go 1.11 after the releasing of 1.12, I think this PR can be accepted now.
If not, the new file with build tag "go1.12" is useless and the change can be applied to config.go directly when Go 1.12 is released.