### PR TITLE
set a GetCertificate callback in the tls.Config

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -269,6 +269,13 @@ func MakeTLSConfig(configs []*Config) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
+		// A tls.Config must have Certificates or GetCertificate
+		// set, in order to be accepted by tls.Listen and quic.Listen.
+		// TODO: remove this once the standard library allows a tls.Config with
+		// only GetConfigForClient set.
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return nil, fmt.Errorf("all certificates configured via GetConfigForClient")
+		},
 		GetConfigForClient: configMap.GetConfigForClient,
 	}, nil
 }


### PR DESCRIPTION
### 1. What does this change do, exactly?

It sets a fake `tls.Config.GetCertificate` callback in the `tls.Config`. According to the Go standard library, a `tls.Config` must have `Certificates` or `GetCertificate` set, otherwise it will be rejected by `tls.Listen`. quic-go recently implemented the same check, and rejects the `tls.Config` as currently constructed by Caddy.
I think it should be permissible to have a `tls.Config` that only sets the `GetConfigForClient` callback, and I opened https://github.com/golang/go/issues/29139, but it looks like this was postponed to Go 1.13.

### 2. Please link to the relevant issues.

#2346, especially https://github.com/mholt/caddy/issues/2346#issuecomment-445248107

### 3. Which documentation changes (if any) need to be made because of this PR?


### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
