### PR TITLE
Disable basic authentication for OPTIONS method

### DIFF
--- a/caddyhttp/basicauth/basicauth_test.go
+++ b/caddyhttp/basicauth/basicauth_test.go
@@ -194,3 +194,30 @@ md5:$apr1$l42y8rex$pOA2VJ0x/0TwaFeAF9nX61`
 		}
 	}
 }
+
+func TestOptionsMethod(t *testing.T) {
+	rw := BasicAuth{
+		Next: httpserver.HandlerFunc(contentHandler),
+		Rules: []Rule{
+			{Username: "username", Password: PlainMatcher("password"), Resources: []string{"/testing"}},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodOptions, "/testing", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+
+	// add basic auth with invalid username
+	// and password to make sure basic auth is ignored
+	req.SetBasicAuth("invaliduser", "invalidpassword")
+
+	rec := httptest.NewRecorder()
+	result, err := rw.ServeHTTP(rec, req)
+	if err != nil {
+		t.Fatalf("Could not ServeHTTP: %v", err)
+	}
+	if result != http.StatusOK {
+		t.Errorf("Expected status code %d but was %d", http.StatusOK, result)
+	}
+}


### PR DESCRIPTION
### 1. What does this change do, exactly?
The pull request disables basic auth on OPTION method calls.

### 2. Please link to the relevant issues.
https://github.com/mholt/caddy/issues/1568

### 3. Which documentation changes (if any) need to be made because of this PR?
No. The pull request is minimal and changes the behaviour of the basic auth plugin without adding new configuration options

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later