### PR TITLE
feat: remove jekyll, hugo. Replace by filebrowser

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -660,12 +660,10 @@ var directives = []string{
 	"fastcgi",
 	"cgi", // github.com/jung-kurt/caddy-cgi
 	"websocket",
-	"filemanager", // github.com/filebrowser/caddy/filemanager
+	"filebrowser", // github.com/filebrowser/caddy
 	"webdav",      // github.com/hacdias/caddy-webdav
 	"markdown",
 	"browse",
-	"jekyll",    // github.com/filebrowser/caddy/jekyll
-	"hugo",      // github.com/filebrowser/caddy/hugo
 	"mailout",   // github.com/SchumacherFM/mailout
 	"awses",     // github.com/miquella/caddy-awses
 	"awslambda", // github.com/coopernurse/caddy-awslambda


### PR DESCRIPTION
Hello!

Major changes are coming to File Browser (https://github.com/filebrowser/filebrowser/pull/575) and Hugo and Jekyll plugins are being removed. Also, I'm renaming `filemanager` to `filebrowser` to keep up with the actual name of the software.

`hugo`, `jekyll` and `filemanager` were hidden from the Caddy web site already. I'm working on the new `filebrowser` directive.

## Why change the name? Couldn't I keep it?

No, there are many changes and, unfortunately, the user will be required as an intermediate to make a change. If kept the same directive probably most would ignore and start complaining about bugs.

This will force people to look for information. I'll also provide a guide on Caddy Community as soon as the new plugin is released, which will be soon.

---

That's it!

/cc @mholt 