### PR TITLE
Implement placeholder server_port (#2412)

### DIFF
--- a/caddyhttp/httpserver/replacer.go
+++ b/caddyhttp/httpserver/replacer.go
@@ -506,6 +506,16 @@ func (r *replacer) getSubstitution(key string) string {
 			return cert.NotBefore.Format("Jan 02 15:04:05 2006 MST")
 		}
 		return r.emptyValue
+	case "{server_port}":
+		_, port, err := net.SplitHostPort(r.request.Host)
+		if err != nil {
+			if r.request.TLS != nil {
+				return "443"
+			} else {
+				return "80"
+			}
+		}
+		return port
 	default:
 		// {labelN}
 		if strings.HasPrefix(key, "{label") {


### PR DESCRIPTION
### 1. What does this change do, exactly?
Add placeholder server_port

### 2. Please link to the relevant issues.
[#2412](https://github.com/mholt/caddy/issues/2412)

### 3. Which documentation changes (if any) need to be made because of this PR?
https://caddyserver.com/docs/placeholders
Add placeholder "{server_port}" with value "The server port on the request" to request placeholders.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
