### PR TITLE
Add header X-Forwarded-Port to preset transparent

### DIFF
--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -448,6 +448,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		u.upstreamHeaders.Add("Host", "{host}")
 		u.upstreamHeaders.Add("X-Real-IP", "{remote}")
 		u.upstreamHeaders.Add("X-Forwarded-Proto", "{scheme}")
+		u.upstreamHeaders.Add("X-Forwarded-Port", "{server_port}")
 	case "websocket":
 		u.upstreamHeaders.Add("Connection", "{>Connection}")
 		u.upstreamHeaders.Add("Upgrade", "{>Upgrade}")

--- a/caddyhttp/proxy/upstream_test.go
+++ b/caddyhttp/proxy/upstream_test.go
@@ -321,6 +321,10 @@ func TestParseBlockTransparent(t *testing.T) {
 			if _, ok := headers["X-Forwarded-For"]; ok {
 				t.Errorf("Test %d: Found unexpected X-Forwarded-For header", i+1)
 			}
+
+			if _, ok := headers["X-Forwarded-Port"]; !ok {
+				t.Errorf("Test %d: Could not find the X-Forwarded-Port header", i+1)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### 1. What does this change do, exactly?
My change adds the requested server port to the header X-Forwarded-Port for preset transparent.

### 2. Please link to the relevant issues.
[#2412](https://github.com/mholt/caddy/issues/2412) 

### 3. Which documentation changes (if any) need to be made because of this PR?
On page https://caddyserver.com/docs/proxy you have to add "header_upstream X-Forwarded-Port {server_port}" to preset transparent.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
