### PR TITLE
add BTBurke/caddy-extauth plugin

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -654,6 +654,7 @@ var directives = []string{
 	"mime",
 	"login",     // github.com/tarent/loginsrv/caddy
 	"reauth",    // github.com/freman/caddy-reauth
+	"extauth",   // github.com/BTBurke/caddy-extauth
 	"jwt",       // github.com/BTBurke/caddy-jwt
 	"jsonp",     // github.com/pschlump/caddy-jsonp
 	"upload",    // blitznote.com/src/caddy.upload


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

This pull request adds support for the [caddy-extauth plugin](https://github.com/BTBurke/caddy-extauth) that creates a forward/external authentication capability to caddy.  I'm the author of the JWT plugin and have found that many people need/want a more flexible authentication solution where they have full control over authorizing each request.  Instead of adding more complexity to plugins like JWT, forward or external authentication allows someone to create their own authorization service in any language and have it plug in easily to Caddy's auth flow.

This is similar to forward authentication services in [Traefik](https://docs.traefik.io/configuration/entrypoints/#forward-authentication) and [Ambassador](https://www.getambassador.io/reference/services/auth-service/#the-external-authentication-service).  Each request is proxied to an external auth service that can authorize access by responding `200 OK`.  Any other status code will result in a `401 Unauthorized`.  Users have full access to the original request parameters to use whatever information they need, including the freedom to access their own database or session caching service, to determine whether authorization should be granted.

### 2. Please link to the relevant issues.

N/A

### 3. Which documentation changes (if any) need to be made because of this PR?

Only needs to be added to the list of plugins

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
