### PR TITLE
Removed redeclaration of config.Manager

### DIFF
--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -64,7 +64,7 @@ func setupTLS(c *caddy.Controller) error {
 		})
 		c.Set(CertCacheInstStorageKey, certCache)
 	}
-	config.Manager = certmagic.NewWithCache(certCache, certmagic.Config{})
+	config.Manager = certmagic.NewWithCache(certCache, *config.Manager)
 
 	// we use certmagic events to collect metrics for telemetry
 	config.Manager.OnEvent = func(event string, data interface{}) {


### PR DESCRIPTION
The config.Manager is redeclared causing it to lose the AltTLSALPNPort value which in turn causes CertMagic to not correctly issue certificates when the http-port command line option is set. It now passes through the existing configuration.

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
Fixes #2407

### 2. Please link to the relevant issues.
^

### 3. Which documentation changes (if any) need to be made because of this PR?
N/A

### 4. Checklist

- [-] I have written tests and verified that they fail without my change
- [-] I have squashed any insignificant commits
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [-] I am willing to help maintain this change if there are issues with it later
