### PR TITLE
Rollback changes creating an additional instance_startup event in #2161

### DIFF
--- a/onevent/hook/config.go
+++ b/onevent/hook/config.go
@@ -14,8 +14,7 @@ type Config struct {
 
 // SupportedEvents is a map of supported events.
 var SupportedEvents = map[string]caddy.EventName{
-	"startup":          caddy.StartupEvent,
-	"instance_startup": caddy.InstanceStartupEvent,
-	"shutdown":         caddy.ShutdownEvent,
-	"certrenew":        caddy.CertRenewEvent,
+	"startup":   caddy.InstanceStartupEvent,
+	"shutdown":  caddy.ShutdownEvent,
+	"certrenew": caddy.CertRenewEvent,
 }

--- a/onevent/on_test.go
+++ b/onevent/on_test.go
@@ -45,8 +45,7 @@ func TestCommandParse(t *testing.T) {
 	}{
 		{name: "noInput", input: `on`, shouldErr: true},
 		{name: "nonExistent", input: "on xyz cmd arg", shouldErr: true},
-		{name: "startup", input: `on startup cmd arg1 arg2`, shouldErr: false, config: hook.Config{Event: caddy.StartupEvent, Command: "cmd", Args: []string{"arg1", "arg2"}}},
-		{name: "instance_startup", input: `on instance_startup cmd arg1 arg2`, shouldErr: false, config: hook.Config{Event: caddy.InstanceStartupEvent, Command: "cmd", Args: []string{"arg1", "arg2"}}},
+		{name: "startup", input: `on startup cmd arg1 arg2`, shouldErr: false, config: hook.Config{Event: caddy.InstanceStartupEvent, Command: "cmd", Args: []string{"arg1", "arg2"}}},
 		{name: "shutdown", input: `on shutdown cmd arg1 arg2 &`, shouldErr: false, config: hook.Config{Event: caddy.ShutdownEvent, Command: "cmd", Args: []string{"arg1", "arg2", "&"}}},
 		{name: "certrenew", input: `on certrenew cmd arg1 arg2`, shouldErr: false, config: hook.Config{Event: caddy.CertRenewEvent, Command: "cmd", Args: []string{"arg1", "arg2"}}},
 	}


### PR DESCRIPTION
### 1. What does this change do, exactly?

When fixing #2161 by moving the emitEvent call to ensure on startup was called at the right point, a new event was created instance_startup.  After discussion it has been decided we dont need this new event and it was a breaking change so it has been reverted.

## Testing

- [ ] Can someone please test that this works on linux.  I have a windows only. 
- [ ] Can someone on linux please check that whatever is supposed to happen after SIGUSR1 still happens? 
- [x]  see if it fixes the issue with caddy not executing `on startup` if caddy.service was included.  __Tested and Works__

 - Anyone else who would like to test. 

### 2. Please link to the relevant issues.

#2161 

https://github.com/hacdias/caddy-service/issues/21

### 3. Which documentation changes (if any) need to be made because of this PR?

none

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
