### PR TITLE
Implement own CA certificates of backends

### DIFF
--- a/caddyhttp/proxy/reverseproxy_test.go
+++ b/caddyhttp/proxy/reverseproxy_test.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/lucas-clemente/quic-go/h2quic"
 )
 
 const (
@@ -30,6 +32,20 @@ const (
 )
 
 var upstreamHost *httptest.Server
+var upstreamHostTLS *httptest.Server
+
+func setupTLSServer() {
+	upstreamHostTLS = httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/test-path" {
+				w.WriteHeader(expectedStatus)
+				w.Write([]byte(expectedResponse))
+			} else {
+				w.WriteHeader(404)
+				w.Write([]byte("Not found"))
+			}
+		}))
+}
 
 func setupTest() {
 	upstreamHost = httptest.NewServer(http.HandlerFunc(
@@ -44,10 +60,76 @@ func setupTest() {
 		}))
 }
 
+func tearDownTLSServer() {
+	upstreamHostTLS.Close()
+}
+
 func tearDownTest() {
 	upstreamHost.Close()
 }
 
+func TestReverseProxyWithOwnCACertificates(t *testing.T) {
+	setupTLSServer()
+	defer tearDownTLSServer()
+
+	// get http client from tls server
+	cl := upstreamHostTLS.Client()
+
+	// add certs from httptest tls server to reverse proxy
+	var transport *http.Transport
+	if tr, ok := cl.Transport.(*http.Transport); ok {
+		transport = tr
+	} else {
+		t.Error("could not parse transport from upstreamHostTLS")
+	}
+
+	pool := transport.TLSClientConfig.RootCAs
+
+	u := staticUpstream{}
+	u.CaCertPool = pool
+
+	upstreamURL, err := url.Parse(upstreamHostTLS.URL)
+	if err != nil {
+		t.Errorf("Failed to parse test server URL [%s]. %s", upstreamHost.URL, err.Error())
+	}
+
+	// setup host for reverse proxy
+	ups, err := u.NewHost(upstreamURL.String())
+	if err != nil {
+		t.Errorf("Creating new host failed. %v", err)
+	}
+
+	// UseOwnCACertificates called in NewHost sets the RootCAs based if the cert pool is set
+	if transport, ok := ups.ReverseProxy.Transport.(*http.Transport); ok {
+		if transport.TLSClientConfig.RootCAs == nil {
+			t.Errorf("RootCAs not set on TLSClientConfig.")
+		}
+	} else if transport, ok := ups.ReverseProxy.Transport.(*h2quic.RoundTripper); ok {
+		if transport.TLSClientConfig.RootCAs == nil {
+			t.Errorf("RootCAs not set on TLSClientConfig.")
+		}
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "https://test.host/test-path", nil)
+	if err != nil {
+		t.Errorf("Failed to create new request. %s", err.Error())
+	}
+
+	err = ups.ReverseProxy.ServeHTTP(resp, req, nil)
+	if err != nil {
+		t.Errorf("Failed to perform reverse proxy to upstream host. %s", err.Error())
+	}
+
+	rBody := resp.Body.String()
+	if rBody != expectedResponse {
+		t.Errorf("Unexpected proxy response received. Expected: '%s', Got: '%s'", expectedResponse, resp.Body.String())
+	}
+
+	if resp.Code != expectedStatus {
+		t.Errorf("Unexpected proxy status. Expected: '%d', Got: '%d'", expectedStatus, resp.Code)
+	}
+}
 func TestSingleSRVHostReverseProxy(t *testing.T) {
 	setupTest()
 	defer tearDownTest()

--- a/caddyhttp/proxy/upstream.go
+++ b/caddyhttp/proxy/upstream.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -69,6 +70,7 @@ type staticUpstream struct {
 	insecureSkipVerify bool
 	MaxFails           int32
 	resolver           srvResolver
+	CaCertPool         *x509.CertPool
 }
 
 type srvResolver interface {
@@ -231,6 +233,10 @@ func (u *staticUpstream) NewHost(host string) (*UpstreamHost, error) {
 	uh.ReverseProxy = NewSingleHostReverseProxy(baseURL, uh.WithoutPathPrefix, u.KeepAlive, u.Timeout, u.FallbackDelay)
 	if u.insecureSkipVerify {
 		uh.ReverseProxy.UseInsecureTransport()
+	}
+
+	if u.CaCertPool != nil {
+		uh.ReverseProxy.UseOwnCACertificates(u.CaCertPool)
 	}
 
 	return uh, nil
@@ -464,6 +470,34 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		u.IgnoredSubPaths = ignoredPaths
 	case "insecure_skip_verify":
 		u.insecureSkipVerify = true
+	case "ca_certificates":
+		caCertificates := c.RemainingArgs()
+		if len(caCertificates) == 0 {
+			return c.ArgErr()
+		}
+
+		pool := x509.NewCertPool()
+		caCertificatesAdded := make(map[string]struct{})
+		for _, caFile := range caCertificates {
+			// don't add cert to pool more than once
+			if _, ok := caCertificatesAdded[caFile]; ok {
+				continue
+			}
+			caCertificatesAdded[caFile] = struct{}{}
+
+			// any client with a certificate from this CA will be allowed to connect
+			caCrt, err := ioutil.ReadFile(caFile)
+			if err != nil {
+				return c.Err(err.Error())
+			}
+
+			// attempt to parse pem and append to cert pool
+			if ok := pool.AppendCertsFromPEM(caCrt); !ok {
+				return c.Errf("loading CA certificate '%s': no certificates were successfully parsed", caFile)
+			}
+		}
+
+		u.CaCertPool = pool
 	case "keepalive":
 		if !c.NextArg() {
 			return c.ArgErr()
@@ -488,6 +522,13 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}
+
+	// these settings are at odds with one another. insecure_skip_verify disables security features over HTTPS
+	// which is what we are trying to achieve with ca_certificates
+	if u.insecureSkipVerify && u.CaCertPool != nil {
+		return c.Errf("both insecure_skip_verify and ca_certificates cannot be set in the proxy directive")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
By using option ca_certificates in proxy block it is possible now to select a
CA for which backend certificates should be verified against.

Resolves #1550

Co-authored-by: Danny Navarro <navdgo@gmail.com>

### 1. What does this change do, exactly?

It adds a `ca_certificates` option to proxy, which allows one to use their own PEM with CA certificates to validate a proxy backend against.

### 2. Please link to the relevant issues.

https://github.com/mholt/caddy/issues/1550

### 3. Which documentation changes (if any) need to be made because of this PR?

https://caddyserver.com/docs/proxy would need documentation updated.

A section along the lines of:

```
ca_certificates are a list of CA Certificate file paths to validate the connection to the backend server being proxied to.

ex. ca_certificates foo.pem bar.pem
```

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
  - [X] test that option work
  - [X] (discussed with mholt, an error is returned if both are set) test that it conflicts with `insecure_skip_verify`
  - [x] Test proving that system pool (eg. provided locally with `SSL_CERT_FILES` environment variable) is overridden by the option

     This is a non issue. `SSL_CERT_FILES` and `SSL_CERT_DIR` are only taken into account when a NewCertPool is created through x509.SystemCertPool(). [go source page](https://golang.org/src/crypto/x509/cert_pool.go?s=1328:1368#L45)

- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
