### PR TITLE
Add a function to SetCAAgreement for embedded Caddy.

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -16,7 +16,7 @@
 //
 // To use this package:
 //
-//   1. Set the AppName and AppVersion variables.
+//   1. Set the AppName and AppVersion variables, and SetCAAgreement(true)
 //   2. Call LoadCaddyfile() to get the Caddyfile.
 //      Pass in the name of the server type (like "http").
 //      Make sure the server type's package is imported
@@ -466,6 +466,11 @@ func CaddyfileFromPipe(f *os.File, serverType string) (Input, error) {
 // Caddyfile returns the Caddyfile used to create i.
 func (i *Instance) Caddyfile() Input {
 	return i.caddyfileInput
+}
+
+// Set CA subscriber agreement status
+func SetCAAgreement(agreed bool) {
+	certmagic.Agreed = agreed
 }
 
 // Start starts Caddy with the given Caddyfile.


### PR DESCRIPTION
Use case: Embedded Caddy server

Setting certmagic.Agreed = true from outside the caddy package does not
set the variable in the vendored instance, so we need a method to set
it safely from outside the package.

The vendored certmagic package gets a different memory address as we see in these logs:

 ```go
log.Printf("Mark4 certmagic.Agreed = %t @ %p", certmagic.Agreed, &certmagic.Agreed)
```


```text
2019/02/06 01:55:13 Mark10 certmagic.Agreed = false @ 0x24a6c2d
2019/02/06 01:55:13 [INFO] Reloading
2019/02/06 01:55:13 Mark4 certmagic.Agreed = true @ 0x24a6bf3
```

The first access is from my application code, and the second access is from inside the caddy package.

### Checklist

- [ x] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I am willing to help maintain this change if there are issues with it later
