### PR TITLE
caddytls: Change clustering to be a plugin to the caddytls package

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -999,7 +999,6 @@ var (
 	DefaultConfigFile = "Caddyfile"
 )
 
-var clusterPluginSetup int32 // access atomically
 
 // CtxKey is a value type for use with context.WithValue.
 type CtxKey string

--- a/caddy.go
+++ b/caddy.go
@@ -999,6 +999,5 @@ var (
 	DefaultConfigFile = "Caddyfile"
 )
 
-
 // CtxKey is a value type for use with context.WithValue.
 type CtxKey string

--- a/caddyhttp/caddyhttp_test.go
+++ b/caddyhttp/caddyhttp_test.go
@@ -25,9 +25,9 @@ import (
 // ensure that the standard plugins are in fact plugged in
 // and registered properly; this is a quick/naive way to do it.
 func TestStandardPlugins(t *testing.T) {
-	numStandardPlugins := 31 // importing caddyhttp plugs in this many plugins
+	numStandardPlugins := 32 // importing caddyhttp plugs in this many plugins
 	s := caddy.DescribePlugins()
-	if got, want := strings.Count(s, "\n"), numStandardPlugins+7; got != want {
+	if got, want := strings.Count(s, "\n"), numStandardPlugins+4; got != want {
 		t.Errorf("Expected all standard plugins to be plugged in, got:\n%s", s)
 	}
 }

--- a/caddytls/tls.go
+++ b/caddytls/tls.go
@@ -108,3 +108,19 @@ func RegisterDNSProvider(name string, provider DNSProviderConstructor) {
 	dnsProviders[name] = provider
 	caddy.RegisterPlugin("tls.dns."+name, caddy.Plugin{})
 }
+
+// ClusterPluginConstructor is a function type that is used to
+// instantiate a new implementation of both certmagic.Storage
+// and certmagic.Locker, which are required for successful
+// use in cluster environments.
+type ClusterPluginConstructor func() (certmagic.Storage, error)
+
+// clusterProviders is the list of storage providers
+var clusterProviders = make(map[string]ClusterPluginConstructor)
+
+// RegisterClusterPlugin registers provider by name for facilitating
+// cluster-wide operations like storage and synchronization.
+func RegisterClusterPlugin(name string, provider ClusterPluginConstructor) {
+	clusterProviders[name] = provider
+	caddy.RegisterPlugin("tls.cluster."+name, caddy.Plugin{})
+}

--- a/plugins.go
+++ b/plugins.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/mholt/caddy/caddyfile"
-	"github.com/mholt/certmagic"
 )
 
 // These are all the registered plugins.
@@ -105,11 +104,6 @@ func ListPlugins() map[string][]string {
 	}
 	if defaultCaddyfileLoader.name != "" {
 		p["caddyfile_loaders"] = append(p["caddyfile_loaders"], defaultCaddyfileLoader.name)
-	}
-
-	// cluster plugins in registration order
-	for name := range clusterProviders {
-		p["clustering"] = append(p["clustering"], name)
 	}
 
 	// List the event hook plugins
@@ -454,21 +448,6 @@ func loadCaddyfileInput(serverType string) (Input, error) {
 		}
 	}
 	return caddyfileToUse, nil
-}
-
-// ClusterPluginConstructor is a function type that is used to
-// instantiate a new implementation of both certmagic.Storage
-// and certmagic.Locker, which are required for successful
-// use in cluster environments.
-type ClusterPluginConstructor func() (certmagic.Storage, error)
-
-// clusterProviders is the list of storage providers
-var clusterProviders = make(map[string]ClusterPluginConstructor)
-
-// RegisterClusterPlugin registers provider by name for facilitating
-// cluster-wide operations like storage and synchronization.
-func RegisterClusterPlugin(name string, provider ClusterPluginConstructor) {
-	clusterProviders[name] = provider
 }
 
 // OnProcessExit is a list of functions to run when the process


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?

Should resolve the failure in
https://github.com/coredns/coredns/pull/2541.

This change is breaking to clustering plugin developers (not Caddy
users), but logical, since only the caddytls package uses CertMagic
directly (the httpserver package also uses it, but only because it also
uses the caddytls plugin); and it is early enough that no clustering
plugins really exist yet.

This will also require a change of devportal
so that it looks for a different registration function, which has moved
to the caddytls package.

### 2. Please link to the relevant issues.

https://github.com/coredns/coredns/pull/2541

### 3. Which documentation changes (if any) need to be made because of this PR?

No user-facing changes, but update the wiki about how to write (and register) a clustering plugin. Devportal needs updating too, since the registration function moved.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I am willing to help maintain this change if there are issues with it later
