### PR TITLE
Ensure closing curly brace is on its own line

### DIFF
--- a/caddyfile/dispenser.go
+++ b/caddyfile/dispenser.go
@@ -258,3 +258,11 @@ func (d *Dispenser) isNewLine() bool {
 	return d.tokens[d.cursor-1].File != d.tokens[d.cursor].File ||
 		d.tokens[d.cursor-1].Line+d.numLineBreaks(d.cursor-1) < d.tokens[d.cursor].Line
 }
+
+// isQuoted returns true if the current token is derived from a quoted string.
+func (d *Dispenser) isQuoted() bool {
+	if d.cursor < 0 || d.cursor >= len(d.tokens) {
+		return false
+	}
+	return d.tokens[d.cursor].Quoted
+}

--- a/caddyfile/lexer.go
+++ b/caddyfile/lexer.go
@@ -33,9 +33,10 @@ type (
 
 	// Token represents a single parsable unit.
 	Token struct {
-		File string
-		Line int
-		Text string
+		File   string
+		Line   int
+		Quoted bool
+		Text   string
 	}
 )
 
@@ -78,6 +79,10 @@ func (l *lexer) next() bool {
 		l.token.Text = string(val)
 		return true
 	}
+	makeQuotedToken := func() bool {
+		l.token.Quoted = true
+		return makeToken()
+	}
 
 	for {
 		ch, _, err := l.reader.ReadRune()
@@ -98,7 +103,7 @@ func (l *lexer) next() bool {
 					continue
 				} else if ch == '"' {
 					quoted = false
-					return makeToken()
+					return makeQuotedToken()
 				}
 			}
 			if ch == '\n' {

--- a/caddyfile/lexer_test.go
+++ b/caddyfile/lexer_test.go
@@ -29,7 +29,7 @@ func TestLexer(t *testing.T) {
 		{
 			input: `host:123`,
 			expected: []Token{
-				{Line: 1, Text: "host:123"},
+				{Line: 1, Quoted: false, Text: "host:123"},
 			},
 		},
 		{
@@ -37,8 +37,8 @@ func TestLexer(t *testing.T) {
 
 					directive`,
 			expected: []Token{
-				{Line: 1, Text: "host:123"},
-				{Line: 3, Text: "directive"},
+				{Line: 1, Quoted: false, Text: "host:123"},
+				{Line: 3, Quoted: false, Text: "directive"},
 			},
 		},
 		{
@@ -46,19 +46,19 @@ func TestLexer(t *testing.T) {
 						directive
 					}`,
 			expected: []Token{
-				{Line: 1, Text: "host:123"},
-				{Line: 1, Text: "{"},
-				{Line: 2, Text: "directive"},
-				{Line: 3, Text: "}"},
+				{Line: 1, Quoted: false, Text: "host:123"},
+				{Line: 1, Quoted: false, Text: "{"},
+				{Line: 2, Quoted: false, Text: "directive"},
+				{Line: 3, Quoted: false, Text: "}"},
 			},
 		},
 		{
 			input: `host:123 { directive }`,
 			expected: []Token{
-				{Line: 1, Text: "host:123"},
-				{Line: 1, Text: "{"},
-				{Line: 1, Text: "directive"},
-				{Line: 1, Text: "}"},
+				{Line: 1, Quoted: false, Text: "host:123"},
+				{Line: 1, Quoted: false, Text: "{"},
+				{Line: 1, Quoted: false, Text: "directive"},
+				{Line: 1, Quoted: false, Text: "}"},
 			},
 		},
 		{
@@ -69,41 +69,41 @@ func TestLexer(t *testing.T) {
 						foobar # another comment
 					}`,
 			expected: []Token{
-				{Line: 1, Text: "host:123"},
-				{Line: 1, Text: "{"},
-				{Line: 3, Text: "directive"},
-				{Line: 5, Text: "foobar"},
-				{Line: 6, Text: "}"},
+				{Line: 1, Quoted: false, Text: "host:123"},
+				{Line: 1, Quoted: false, Text: "{"},
+				{Line: 3, Quoted: false, Text: "directive"},
+				{Line: 5, Quoted: false, Text: "foobar"},
+				{Line: 6, Quoted: false, Text: "}"},
 			},
 		},
 		{
 			input: `a "quoted value" b
 					foobar`,
 			expected: []Token{
-				{Line: 1, Text: "a"},
-				{Line: 1, Text: "quoted value"},
-				{Line: 1, Text: "b"},
-				{Line: 2, Text: "foobar"},
+				{Line: 1, Quoted: false, Text: "a"},
+				{Line: 1, Quoted: true, Text: "quoted value"},
+				{Line: 1, Quoted: false, Text: "b"},
+				{Line: 2, Quoted: false, Text: "foobar"},
 			},
 		},
 		{
 			input: `A "quoted \"value\" inside" B`,
 			expected: []Token{
-				{Line: 1, Text: "A"},
-				{Line: 1, Text: `quoted "value" inside`},
-				{Line: 1, Text: "B"},
+				{Line: 1, Quoted: false, Text: "A"},
+				{Line: 1, Quoted: true, Text: `quoted "value" inside`},
+				{Line: 1, Quoted: false, Text: "B"},
 			},
 		},
 		{
 			input: `"don't\escape"`,
 			expected: []Token{
-				{Line: 1, Text: `don't\escape`},
+				{Line: 1, Quoted: true, Text: `don't\escape`},
 			},
 		},
 		{
 			input: `"don't\\escape"`,
 			expected: []Token{
-				{Line: 1, Text: `don't\\escape`},
+				{Line: 1, Quoted: true, Text: `don't\\escape`},
 			},
 		},
 		{
@@ -112,40 +112,40 @@ func TestLexer(t *testing.T) {
 						foobar
 					}`,
 			expected: []Token{
-				{Line: 1, Text: "A"},
-				{Line: 1, Text: "quoted value with line\n\t\t\t\t\tbreak inside"},
-				{Line: 2, Text: "{"},
-				{Line: 3, Text: "foobar"},
-				{Line: 4, Text: "}"},
+				{Line: 1, Quoted: false, Text: "A"},
+				{Line: 1, Quoted: true, Text: "quoted value with line\n\t\t\t\t\tbreak inside"},
+				{Line: 2, Quoted: false, Text: "{"},
+				{Line: 3, Quoted: false, Text: "foobar"},
+				{Line: 4, Quoted: false, Text: "}"},
 			},
 		},
 		{
 			input: `"C:\php\php-cgi.exe"`,
 			expected: []Token{
-				{Line: 1, Text: `C:\php\php-cgi.exe`},
+				{Line: 1, Quoted: true, Text: `C:\php\php-cgi.exe`},
 			},
 		},
 		{
 			input: `empty "" string`,
 			expected: []Token{
-				{Line: 1, Text: `empty`},
-				{Line: 1, Text: ``},
-				{Line: 1, Text: `string`},
+				{Line: 1, Quoted: false, Text: `empty`},
+				{Line: 1, Quoted: true, Text: ``},
+				{Line: 1, Quoted: false, Text: `string`},
 			},
 		},
 		{
 			input: "skip those\r\nCR characters",
 			expected: []Token{
-				{Line: 1, Text: "skip"},
-				{Line: 1, Text: "those"},
-				{Line: 2, Text: "CR"},
-				{Line: 2, Text: "characters"},
+				{Line: 1, Quoted: false, Text: "skip"},
+				{Line: 1, Quoted: false, Text: "those"},
+				{Line: 2, Quoted: false, Text: "CR"},
+				{Line: 2, Quoted: false, Text: "characters"},
 			},
 		},
 		{
 			input: "\xEF\xBB\xBF:8080", // test with leading byte order mark
 			expected: []Token{
-				{Line: 1, Text: ":8080"},
+				{Line: 1, Quoted: false, Text: ":8080"},
 			},
 		},
 	}
@@ -174,6 +174,11 @@ func lexerCompare(t *testing.T, n int, expected, actual []Token) {
 		if actual[i].Line != expected[i].Line {
 			t.Errorf("Test case %d token %d ('%s'): expected line %d but was line %d",
 				n, i, expected[i].Text, expected[i].Line, actual[i].Line)
+			break
+		}
+		if actual[i].Quoted != expected[i].Quoted {
+			t.Errorf("Test case %d token %d ('%s'): expected quoted %t but was quoted %t",
+				n, i, expected[i].Text, expected[i].Quoted, actual[i].Quoted)
 			break
 		}
 		if actual[i].Text != expected[i].Text {

--- a/caddyfile/parse.go
+++ b/caddyfile/parse.go
@@ -371,6 +371,10 @@ func (p *parser) directive() error {
 			}
 			p.cursor-- // cursor is advanced when we continue, so roll back one more
 			continue
+		} else if !p.isQuoted() &&
+			!strings.HasPrefix(p.Val(), "{") &&
+			strings.HasSuffix(p.Val(), "}") {
+			return p.Errf("'}' must be on its own line")
 		}
 		p.tokens[p.cursor].Text = replaceEnvVars(p.tokens[p.cursor].Text)
 		p.block.Tokens[dir] = append(p.block.Tokens[dir], p.tokens[p.cursor])


### PR DESCRIPTION
<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.
-->

### 1. What does this change do, exactly?
This change enforces the documentation that, "the closing curly brace } must be the only token on its line" without breaking the requirement that an environment variable is, "enclosed in curly braces { } without extra whitespace."

### 2. Please link to the relevant issues.
#2366 

### 3. Which documentation changes (if any) need to be made because of this PR?
None.  This PR brings parsing functionality in line with the documentation.

### 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later
