### PR TITLE
Simplify User Replacement on basicauth authentication failure

### DIFF
--- a/caddyhttp/basicauth/basicauth.go
+++ b/caddyhttp/basicauth/basicauth.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"crypto/subtle"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -109,8 +108,7 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		repl := httpserver.NewReplacer(r, nil, "-")
 		repl.Set("user", username)
 		errstr := repl.Replace("BasicAuth: user \"{user}\" was not found or password was incorrect. {remote} {host} {uri} {proto}")
-
-		err := errors.New(errstr)
+		err := fmt.Errorf(errstr)
 		return http.StatusUnauthorized, err
 	}
 

--- a/caddyhttp/basicauth/basicauth.go
+++ b/caddyhttp/basicauth/basicauth.go
@@ -108,7 +108,7 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 		repl := httpserver.NewReplacer(r, nil, "-")
 		repl.Set("user", username)
 		errstr := repl.Replace("BasicAuth: user \"{user}\" was not found or password was incorrect. {remote} {host} {uri} {proto}")
-		err := fmt.Errorf(errstr)
+		err := fmt.Errorf("%s", errstr)
 		return http.StatusUnauthorized, err
 	}
 

--- a/caddyhttp/basicauth/basicauth.go
+++ b/caddyhttp/basicauth/basicauth.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,10 +107,10 @@ func (a BasicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 
 		// Get a replacer so we can provide basic info for the authentication error.
 		repl := httpserver.NewReplacer(r, nil, "-")
-		errstr := repl.Replace("BasicAuth: user \"%s\" was not found or password was incorrect. {remote} {host} {uri} {proto}")
+		repl.Set("user", username)
+		errstr := repl.Replace("BasicAuth: user \"{user}\" was not found or password was incorrect. {remote} {host} {uri} {proto}")
 
-		// Username will not exist in Replacer so provide here.
-		err := fmt.Errorf(errstr, username)
+		err := errors.New(errstr)
 		return http.StatusUnauthorized, err
 	}
 


### PR DESCRIPTION
This is an update to recent PR #2434 .

I realised I can set the user value before calling replace.

An additonal benefit of this change is that the access logs will show the username even when the user is not authenticated. eg.  

>127.0.0.1 - admin [16/Feb/2019:09:38:31 +0000] "GET /admin HTTP/1.1" 401 17

This seems to be how other webservers report authentication failures.