### PR TITLE
Raise parsing error if errors directive has more than one argument.

### DIFF
--- a/caddyhttp/errors/setup.go
+++ b/caddyhttp/errors/setup.go
@@ -123,6 +123,10 @@ func errorsParse(c *caddy.Controller) (*ErrorHandler, error) {
 			}
 		}
 
+		if len(args) > 1 {
+			return handler, c.Errf("Only 1 Argument expected for errors directive")
+		}
+
 		// Configuration may be in a block
 		err := optionalBlock()
 		if err != nil {

--- a/caddyhttp/errors/setup_test.go
+++ b/caddyhttp/errors/setup_test.go
@@ -179,6 +179,11 @@ func TestErrorsParse(t *testing.T) {
 			* generic_error.html
 			* generic_error.html
 		}`, true, ErrorHandler{ErrorPages: map[int]string{}, Log: &httpserver.Logger{}}},
+		{`errors /path error.txt {
+			404 
+		}`, true, ErrorHandler{ErrorPages: map[int]string{}, Log: &httpserver.Logger{}}},
+
+		{`errors /path error.txt`, true, ErrorHandler{ErrorPages: map[int]string{}, Log: &httpserver.Logger{}}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I found I had written the following  in several places in my caddyfile

````
example.com {
  root c:\web
   log / c:\logs\mylogfilt.txt
  errors /  c:\logs\myerrorlog.txt
}
````
However `error` does not require a path param so the `/` is unneeded

This silently fails and the only place the log is written to is stdout.

This PR raises a parsing error in this case.

I'm not sure how to write tests for this.