### PR TITLE
Implement TLS 1.3 ciphers

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -487,9 +487,9 @@ func GetSupportedCipherName(cipher uint16) (string, error) {
 
 // List of all the ciphers we want to use by default
 var defaultCiphers = []uint16{
- 	tls.TLS_AES_256_GCM_SHA384,
- 	tls.TLS_AES_128_GCM_SHA256,
-  	tls.TLS_CHACHA20_POLY1305_SHA256,
+	tls.TLS_AES_256_GCM_SHA384,
+	tls.TLS_AES_128_GCM_SHA256,
+	tls.TLS_CHACHA20_POLY1305_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -500,9 +500,9 @@ var defaultCiphers = []uint16{
 
 // List of ciphers we should prefer if native AESNI support is missing
 var defaultCiphersNonAESNI = []uint16{
- 	tls.TLS_AES_256_GCM_SHA384,
- 	tls.TLS_AES_128_GCM_SHA256,
-  	tls.TLS_CHACHA20_POLY1305_SHA256,
+	tls.TLS_CHACHA20_POLY1305_SHA256,
+	tls.TLS_AES_256_GCM_SHA384,
+	tls.TLS_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,

--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -455,6 +455,9 @@ func GetSupportedProtocolName(protocol uint16) (string, error) {
 //
 // This map, like any map, is NOT ORDERED. Do not range over this map.
 var SupportedCiphersMap = map[string]uint16{
+ 	"TLS13-AES-256-GCM-SHA384":           tls.TLS_AES_256_GCM_SHA384,
+ 	"TLS13-AES-128-GCM-SHA256":           tls.TLS_AES_128_GCM_SHA256,
+ 	"TLS13-CHACHA20-POLY1305-SHA256":     tls.TLS_CHACHA20_POLY1305_SHA256,
 	"ECDHE-ECDSA-AES256-GCM-SHA384":      tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-RSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-ECDSA-AES128-GCM-SHA256":      tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -484,6 +487,9 @@ func GetSupportedCipherName(cipher uint16) (string, error) {
 
 // List of all the ciphers we want to use by default
 var defaultCiphers = []uint16{
+ 	tls.TLS_AES_256_GCM_SHA384,
+ 	tls.TLS_AES_128_GCM_SHA256,
+  	tls.TLS_CHACHA20_POLY1305_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -494,6 +500,9 @@ var defaultCiphers = []uint16{
 
 // List of ciphers we should prefer if native AESNI support is missing
 var defaultCiphersNonAESNI = []uint16{
+ 	tls.TLS_AES_256_GCM_SHA384,
+ 	tls.TLS_AES_128_GCM_SHA256,
+  	tls.TLS_CHACHA20_POLY1305_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,


### PR DESCRIPTION
This PR fixes the current issue of missing ciphers when Caddy is configured with TLS 1.3 enabled after compiling it against the latest commit:

```
● caddy.service - Caddy HTTP/2 web server
   Loaded: loaded (/etc/systemd/system/caddy.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Tue 2019-02-26 07:22:32 CET; 16min ago
     Docs: https://caddyserver.com/docs
  Process: 11181 ExecStart=/usr/local/bin/caddy -agree -email letsencrypt@jadja.eu -http2 -log /opt/caddy/log -root /opt/caddy/webroot -conf /opt/caddy/Caddyfile (code=exited, status=1/FAILURE)
 Main PID: 11181 (code=exited, status=1/FAILURE)
      CPU: 23ms

Feb 26 07:22:32 debian systemd[1]: Started Caddy HTTP/2 web server.
Feb 26 07:22:32 debian caddy[11181]: 2019/02/26 07:22:32 /opt/caddy/snippets/ecc-tls-wildcard:6 - Error during parsing: Wrong cipher name or cipher not supported: 'TLS13-AES-128-GCM-SHA256'
Feb 26 07:22:32 debian systemd[1]: caddy.service: Main process exited, code=exited, status=1/FAILURE
Feb 26 07:22:32 debian systemd[1]: caddy.service: Unit entered failed state.
Feb 26 07:22:32 debian systemd[1]: caddy.service: Failed with result 'exit-code'.
```