### PR TITLE
Add TLSv1.3 to list of known ciphers.

### DIFF
--- a/caddytls/config.go
+++ b/caddytls/config.go
@@ -444,7 +444,8 @@ func GetSupportedProtocolName(protocol uint16) (string, error) {
 	return "", fmt.Errorf("name: unsupported protocol")
 }
 
-// SupportedCiphersMap has supported ciphers, used only for parsing config.
+// SupportedCiphersMap has supported ciphers, used only for parsing config
+// and logging.
 //
 // Note that, at time of writing, HTTP/2 blacklists 276 cipher suites,
 // including all but four of the suites below (the four GCM suites).
@@ -455,6 +456,9 @@ func GetSupportedProtocolName(protocol uint16) (string, error) {
 //
 // This map, like any map, is NOT ORDERED. Do not range over this map.
 var SupportedCiphersMap = map[string]uint16{
+	"AES-128-GCM-SHA256":                 tls.TLS_AES_128_GCM_SHA256,
+	"AES-256-GCM-SHA384":                 tls.TLS_AES_256_GCM_SHA384,
+	"CHACHA20-POLY1305-SHA256":           tls.TLS_CHACHA20_POLY1305_SHA256,
 	"ECDHE-ECDSA-AES256-GCM-SHA384":      tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-RSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	"ECDHE-ECDSA-AES128-GCM-SHA256":      tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -469,6 +473,14 @@ var SupportedCiphersMap = map[string]uint16{
 	"RSA-AES128-CBC-SHA":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 	"ECDHE-RSA-3DES-EDE-CBC-SHA":         tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
 	"RSA-3DES-EDE-CBC-SHA":               tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+}
+
+// NonConfigurableCiphersMap is a list of ciphers that are understood but
+// cannot be configured such as the case of TLSv1.3.
+var NonConfigurableCiphersMap = map[string]struct{}{
+	"AES-128-GCM-SHA256":       struct{}{},
+	"AES-256-GCM-SHA384":       struct{}{},
+	"CHACHA20-POLY1305-SHA256": struct{}{},
 }
 
 // GetSupportedCipherName returns the cipher name

--- a/caddytls/setup.go
+++ b/caddytls/setup.go
@@ -197,8 +197,10 @@ func setupTLS(c *caddy.Controller) error {
 				}
 			case "ciphers":
 				for c.NextArg() {
-					value, ok := SupportedCiphersMap[strings.ToUpper(c.Val())]
-					if !ok {
+					cipherName := strings.ToUpper(c.Val())
+					value, ok := SupportedCiphersMap[cipherName]
+					_, nonconfigurable := NonConfigurableCiphersMap[cipherName]
+					if !ok || nonconfigurable {
 						return c.Errf("Wrong cipher name or cipher not supported: '%s'", c.Val())
 					}
 					config.Ciphers = append(config.Ciphers, value)

--- a/caddytls/setup_test.go
+++ b/caddytls/setup_test.go
@@ -213,6 +213,18 @@ func TestSetupParseWithWrongOptionalParams(t *testing.T) {
 		t.Error("Expected errors, but no error returned")
 	}
 
+	// Test trying to configure TLSv1.3 ciphers
+	params = `tls ` + certFile + ` ` + keyFile + ` {
+			ciphers AES-128-GCM-SHA256
+		}`
+	cfg = &Config{Manager: &certmagic.Config{}}
+	RegisterConfigGetter("", func(c *caddy.Controller) *Config { return cfg })
+	c = caddy.NewTestController("", params)
+	err = setupTLS(c)
+	if err == nil {
+		t.Error("Expected errors, but no error returned")
+	}
+
 	// Test key_type wrong params
 	params = `tls {
 			key_type ab123


### PR DESCRIPTION
This adds the TLSv1.3 ciphers to the list of known ciphers which is required for logging. It also introduces a means of making a cipher disallowed from configuration but still getting it be used in the `SupportedCiphersMap` map.

The disallow list appears to be necessary. If the TLSv1.3 suite is in the `SupportedCiphersMap` and a user attempts to put it in their Caddyfile, Caddy will panic later during the configuration process. Simplest approach for now seemed to be to just disallow them.

Note I am not a Go developer. This is my second go PR ever. 😅

Fixes #2505 