### PR TITLE
caddy: optimize the code order to make the logic more accurate

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -833,22 +833,21 @@ func startServers(serverList []Server, inst *Instance, restartFds map[string]res
 }
 
 func getServerType(serverType string) (ServerType, error) {
-	stype, ok := serverTypes[serverType]
-	if ok {
-		return stype, nil
-	}
 	if len(serverTypes) == 0 {
 		return ServerType{}, fmt.Errorf("no server types plugged in")
 	}
 	if serverType == "" {
 		if len(serverTypes) == 1 {
-			for _, stype := range serverTypes {
-				return stype, nil
-			}
+			return serverTypes[serverType], nil
 		}
 		return ServerType{}, fmt.Errorf("multiple server types available; must choose one")
 	}
-	return ServerType{}, fmt.Errorf("unknown server type '%s'", serverType)
+	stype, ok := serverTypes[serverType]
+	if ok {
+		return stype, nil
+	} else {
+		return ServerType{}, fmt.Errorf("unknown server type '%s'", serverType)
+	}
 }
 
 func loadServerBlocks(serverType, filename string, input io.Reader) ([]caddyfile.ServerBlock, error) {


### PR DESCRIPTION
The original logic is a little fuzzy. 

For example

if serverType is equal to  "",  it happens that there is such a key in the map, but it is not the only key. 

https://github.com/mholt/caddy/blob/4a3c9b428622f91744f2e74f791e2affdc186d73/caddy.go#L839-L843

This code is easy to skip.