### PR TITLE
readme: Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Caddy binaries have no dependencies and are available for every platform. Get Ca
 
 To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.12 or newer). Follow these instruction for fast building:
 
+- Set the transitional environment variable `GO111MODULE` to `on`
 - Get the source with `go get github.com/mholt/caddy/caddy` and then run `go get github.com/caddyserver/builds`
 - Now `cd $GOPATH/src/github.com/mholt/caddy/caddy` and run `go run build.go`
 


### PR DESCRIPTION
## 1. What does this change do, exactly?

Update the build instructions to reflect the transition to Go modules. This will not be necessary in Go 1.13, according to https://blog.golang.org/modules2019



## 2. Please link to the relevant issues.

#2560 



## 3. Which documentation changes (if any) need to be made because of this PR?

n/a



## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later

@mholt The PR template does not show up :/