### PR TITLE
Add pubsub plugin

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -671,6 +671,7 @@ var directives = []string{
 	"prometheus", // github.com/miekg/caddy-prometheus
 	"templates",
 	"proxy",
+	"pubsub", // github.com/jung-kurt/caddy-pubsub
 	"fastcgi",
 	"cgi", // github.com/jung-kurt/caddy-cgi
 	"websocket",


### PR DESCRIPTION
This PR adds publish/subscribe middleware to Caddy. The repository is https://github.com/jung-kurt/caddy-pubsub.