### PR TITLE
Simple rewrite regex captures

### DIFF
--- a/caddyhttp/rewrite/rewrite.go
+++ b/caddyhttp/rewrite/rewrite.go
@@ -95,9 +95,15 @@ func (s *SimpleRule) Match(r *http.Request) bool {
 
 // Rewrite rewrites the internal location of the current request.
 func (s *SimpleRule) Rewrite(fs http.FileSystem, r *http.Request) Result {
+	matches := regexpMatches(s.Regexp, "/", r.URL.Path)
+
+	replacer := newReplacer(r)
+	for i := 1; i < len(matches); i++ {
+		replacer.Set(fmt.Sprint(i), matches[i])
+	}
 
 	// attempt rewrite
-	return To(fs, r, s.To, newReplacer(r))
+	return To(fs, r, s.To, replacer)
 }
 
 // ComplexRule is a rewrite rule based on a regular expression

--- a/caddyhttp/rewrite/rewrite_test.go
+++ b/caddyhttp/rewrite/rewrite_test.go
@@ -129,7 +129,7 @@ func TestRewrite(t *testing.T) {
 		}
 
 		if got, want := rec.Body.String(), test.expectedTo; got != want {
-			t.Errorf("Test %d: Expected URL to be '%s' but was '%s'", i, want, got)
+			t.Errorf("Test %d: Expected URL '%s' to be rewritten to '%s' but was rewritten to '%s'", i, test.from, want, got)
 		}
 	}
 }

--- a/caddyhttp/rewrite/rewrite_test.go
+++ b/caddyhttp/rewrite/rewrite_test.go
@@ -33,6 +33,7 @@ func TestRewrite(t *testing.T) {
 			newSimpleRule(t, "^/from$", "/to"),
 			newSimpleRule(t, "^/a$", "/b"),
 			newSimpleRule(t, "^/b$", "/b{uri}"),
+			newSimpleRule(t, "^/simplereggrp/([0-9]+)([a-z]*)$", "/{1}/{2}/{query}"),
 		},
 		FileSys: http.Dir("."),
 	}
@@ -113,6 +114,7 @@ func TestRewrite(t *testing.T) {
 		{"/hashtest/a%20%23%20test", "/a%20%23%20test"},
 		{"/hashtest/a%20%3F%20test", "/a%20%3F%20test"},
 		{"/hashtest/a%20%3F%23test", "/a%20%3F%23test"},
+		{"/simplereggrp/123abc?q", "/123/abc/q?q"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## 1. What does this change do, exactly?

Enable substitution of numbered regex captures in the `to` part of a simple rewrite rule.

Example:
```Caddyfile
rewrite ^/foo/(bar)$ /{1}
```

This would previously rewrite to `/` while now it rewrites to `/bar`.

## 2. Please link to the relevant issues.

https://github.com/mholt/caddy/issues/2586

## 3. Which documentation changes (if any) need to be made because of this PR?

On https://caddyserver.com/docs/rewrite copy the description of "destinations..." after the second example code block to the description of "to" after the first example code block.

## 4. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [X] I am willing to help maintain this change if there are issues with it later