### PR TITLE
Clarify docs about Go file to build Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There is no need to modify the Caddy code to build it with plugins. We will crea
 
 <!-- TODO: This env variable will not be required starting with Go 1.13 -->
 1. Set the transitional environment variable for Go modules: `export GO111MODULE=on`
-2. Create a new folder anywhere, and put this Go file into it, then import the plugins you want to include:
+2. Create a new folder anywhere and within create a Go file  (extension `.go`) with the contents below, adjusting to import the plugins you want to include:
 ```go
 package main
 


### PR DESCRIPTION
My first time using Go was in regards to building Caddy-- so I hit a bit of a dead-end when knowing what to call the file mentioned in **To build Caddy with plugins (and with version information)**.  As obvious as it is now-- it took me far too long to realize the file could be anything with the extension `.go`.  This small PR might save fellow newcomers a small headache.