### PR TITLE
Add permission plugin directive

### DIFF
--- a/caddyhttp/httpserver/plugin.go
+++ b/caddyhttp/httpserver/plugin.go
@@ -656,13 +656,14 @@ var directives = []string{
 	"s3browser", // github.com/techknowlogick/caddy-s3browser
 	"nobots",    // github.com/Xumeiquer/nobots
 	"mime",
-	"login",     // github.com/tarent/loginsrv/caddy
-	"reauth",    // github.com/freman/caddy-reauth
-	"extauth",   // github.com/BTBurke/caddy-extauth
-	"jwt",       // github.com/BTBurke/caddy-jwt
-	"jsonp",     // github.com/pschlump/caddy-jsonp
-	"upload",    // blitznote.com/src/caddy.upload
-	"multipass", // github.com/namsral/multipass/caddy
+        "login",      // github.com/tarent/loginsrv/caddy
+        "reauth",     // github.com/freman/caddy-reauth
+        "extauth",    // github.com/BTBurke/caddy-extauth
+        "jwt",        // github.com/BTBurke/caddy-jwt
+        "permission", // github.com/dhaavi/caddy-permission 
+        "jsonp",      // github.com/pschlump/caddy-jsonp
+        "upload",     // blitznote.com/src/caddy.upload
+        "multipass",  // github.com/namsral/multipass/caddy
 	"internal",
 	"pprof",
 	"expvar",


### PR DESCRIPTION
I'm finally looking to make my plugin for caddy officially available.

The code currently lives at https://github.com/dhaavi/caddy-authplugger, but will be moved to https://github.com/dhaavi/caddy-permission within the next days.

Like a couple other plugins, this plugin is about authentication, but, additionally also about authorization:
Instead of just relaying authenticating users to another piece of software, it aims to bring fine-grained permission management to otherwise unsupported web applications.

For example, I've been using this code for over a year now to enforce fine-grained permissions on the filebrowser plugin. It plays fairly nice for the basic feature set, I must say. (I have not yet bothered to integrate all features with the permission model)

Technically speaking, it fetches and authenticates users via (1) the config file (HTTP Basic Auth), (2) an easy json-based api and/or (3) TLS client certificates. It then enforces a HTTP Method + Request Path permission model on the user. It also handles websockets.

I changed the name in order for users to better differentiate this plugin from other auth plugins.

EDITED TO ADD: There will be minor improvements and some maintenance within the next days (go modules!).